### PR TITLE
New datacheck to check if the current regulatory build has epigenome …

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CurrentRegulatoryBuildHasEpigenomes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CurrentRegulatoryBuildHasEpigenomes.pm
@@ -1,0 +1,66 @@
+=head1 LICENSE
+
+Copyright [2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::CurrentRegulatoryBuildHasEpigenomes;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+use Bio::EnsEMBL::DataCheck::Utils qw/sql_count/;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'CurrentRegulatoryBuildHasEpigenomes',
+  DESCRIPTION => 'Check if the current regulatory build has epigenomes data',
+  GROUPS      => ['funcgen_integrity', 'funcgen_Post_regulatory_build.'],
+  DB_TYPES    => ['funcgen'],
+  TABLES      => ['regulatory_build','regulatory_build_epigenome','epigenome'],
+};
+
+sub skip_tests {
+  my ($self) = @_;
+
+  my $sql = q/
+    SELECT COUNT(name) FROM regulatory_build 
+    WHERE is_current=true
+  /;
+
+  if (! sql_count($self->dba, $sql) ) {
+    return (1, 'The database has no regulatory build');
+  }
+}
+
+sub tests {
+  my ($self) = @_;
+    
+    my $desc = "Current Regulatory build has Epigenomes";
+    my $sql  = qq/
+    SELECT DISTINCT epigenome.name FROM
+      regulatory_build JOIN
+      regulatory_build_epigenome USING (regulatory_build_id) JOIN
+      epigenome USING (epigenome_id)
+    WHERE is_current=true
+  /;
+  is_rows_nonzero($self->dba, $sql, $desc);
+}
+1;
+

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CurrentRegulatoryBuildHasEpigenomes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CurrentRegulatoryBuildHasEpigenomes.pm
@@ -52,8 +52,8 @@ sub skip_tests {
 sub tests {
   my ($self) = @_;
     
-    my $desc = "Current Regulatory build has Epigenomes";
-    my $sql  = qq/
+  my $desc = "Current regulatory build has epigenomes";
+  my $sql  = qq/
     SELECT DISTINCT epigenome.name FROM
       regulatory_build JOIN
       regulatory_build_epigenome USING (regulatory_build_id) JOIN

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -97,6 +97,13 @@
       "name" : "CoreForeignKeys",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CoreForeignKeys"
    },
+   "CurrentRegulatoryBuildHasEpigenomes" : {
+      "datacheck_type" : "critical",
+      "description" : "Check if the current regulatory build has epigenomes data",
+      "groups" : [],
+      "name" : "CurrentRegulatoryBuildHasEpigenomes",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CurrentRegulatoryBuildHasEpigenomes"
+   },
    "ForeignKeys" : {
       "datacheck_type" : "critical",
       "description" : "Check for incorrect foreign key relationships, as defined by a \"foreign_keys.sql\" file.",


### PR DESCRIPTION
…data. If a regulation database don't have any regulatory build, the test will be skipped.
Port of the following JAVA healthcheck: https://github.com/Ensembl/ensj-healthcheck/blob/release/94/src/org/ensembl/healthcheck/testcase/funcgen/CurrentRegulatoryBuildHasEpigenomes.java
