### PR TITLE
New test/regulatory feature is active

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CurrentRegulatoryBuildHasEpigenomes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CurrentRegulatoryBuildHasEpigenomes.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'CurrentRegulatoryBuildHasEpigenomes',
   DESCRIPTION => 'Check if the current regulatory build has epigenomes data',
-  GROUPS      => ['funcgen_integrity', 'funcgen_Post_regulatory_build.'],
+  GROUPS      => ['funcgen_integrity', 'funcgen_Post_regulatory_build'],
   DB_TYPES    => ['funcgen'],
   TABLES      => ['regulatory_build','regulatory_build_epigenome','epigenome'],
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/RegulatoryFeatureIsActive.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/RegulatoryFeatureIsActive.pm
@@ -1,0 +1,65 @@
+=head1 LICENSE
+
+Copyright [2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::RegulatoryFeatureIsActive;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+use Bio::EnsEMBL::DataCheck::Utils qw/sql_count/;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'RegulatoryFeatureIsActive',
+  DESCRIPTION => 'Check that every regulatory_feature of the current Regulatory Build have a valid activity value in at least one epigenome.',
+  GROUPS      => ['funcgen_integrity', 'funcgen_Post_regulatory_build.'],
+  DB_TYPES    => ['funcgen'],
+  TABLES      => ['regulatory_build','regulatory_feature','regulatory_activity'],
+};
+
+sub skip_tests {
+  my ($self) = @_;
+
+  my $sql = q/
+    SELECT COUNT(name) FROM regulatory_build 
+    WHERE is_current=1
+  /;
+
+  if (! sql_count($self->dba, $sql) ) {
+    return (1, 'The database has no regulatory build');
+  }
+}
+
+sub tests {
+  my ($self) = @_;
+  my $desc = "All epigenomes of regulatory_feature for current regulatory build have a valid activity";
+  my $sql  = qq/
+    SELECT regulatory_feature.regulatory_feature_id FROM 
+      regulatory_build JOIN 
+      regulatory_feature USING (regulatory_build_id) LEFT JOIN 
+      regulatory_activity ON (regulatory_feature.regulatory_feature_id=regulatory_activity.regulatory_feature_id AND activity!='NA')
+    WHERE regulatory_activity.regulatory_activity_id IS NULL AND regulatory_build.is_current=1
+  /;
+  is_rows_zero($self->dba, $sql, $desc);
+}
+1;
+

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/RegulatoryFeatureIsActive.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/RegulatoryFeatureIsActive.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'RegulatoryFeatureIsActive',
   DESCRIPTION => 'Check that every regulatory_feature of the current Regulatory Build have a valid activity value in at least one epigenome.',
-  GROUPS      => ['funcgen_integrity', 'funcgen_Post_regulatory_build.'],
+  GROUPS      => ['funcgen_integrity', 'funcgen_Post_regulatory_build'],
   DB_TYPES    => ['funcgen'],
   TABLES      => ['regulatory_build','regulatory_feature','regulatory_activity'],
 };

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -102,7 +102,7 @@
       "description" : "Check if the current regulatory build has epigenomes data",
       "groups" : [
          "funcgen_integrity",
-         "funcgen_Post_regulatory_build."
+         "funcgen_Post_regulatory_build"
       ],
       "name" : "CurrentRegulatoryBuildHasEpigenomes",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CurrentRegulatoryBuildHasEpigenomes"
@@ -193,8 +193,11 @@
    },
    "RegulatoryFeatureIsActive" : {
       "datacheck_type" : "critical",
-      "description" : "Check that every regulatory_feature of the current Regulatory Build has a valid activity value in at least one epigenome.",
-      "groups" : [],
+      "description" : "Check that every regulatory_feature of the current Regulatory Build have a valid activity value in at least one epigenome.",
+      "groups" : [
+         "funcgen_integrity",
+         "funcgen_Post_regulatory_build"
+      ],
       "name" : "RegulatoryFeatureIsActive",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::RegulatoryFeatureIsActive"
    },

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -191,6 +191,13 @@
       "name" : "PhenotypeDescription",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::PhenotypeDescription"
    },
+   "RegulatoryFeatureIsActive" : {
+      "datacheck_type" : "critical",
+      "description" : "Check that every regulatory_feature of the current Regulatory Build has a valid activity value in at least one epigenome.",
+      "groups" : [],
+      "name" : "RegulatoryFeatureIsActive",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::RegulatoryFeatureIsActive"
+   },
    "SchemaVersion" : {
       "datacheck_type" : "critical",
       "description" : "Check that the schema version meta_key matches the DB name",


### PR DESCRIPTION
Port of the following healthcheck: https://github.com/Ensembl/ensj-healthcheck/blob/release/94/src/org/ensembl/healthcheck/testcase/funcgen/RegulatoryFeatureIsActive.java
I used the final SQL instead of looping through the different objects. The hc mention that the SQL is slow but it only takes 3s for human. Ilias is having a look why he didn't used the final SQL in the hc, if he comes back to me, I will update the test.