### PR TITLE
Datacheck for biotype groups

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeys.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeys.pm
@@ -33,7 +33,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'ForeignKeys',
   DESCRIPTION => 'Check for incorrect foreign key relationships',
-  DB_TYPES    => ['compara', 'core', 'funcgen', 'otherfeatures', 'variation'],
+  DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1,
 };
 
@@ -59,7 +59,7 @@ sub tests {
     }
   }
 
-  if ($self->dba->group =~ /(core|otherfeatures)/) {
+  if ($self->dba->group =~ /(cdna|core|otherfeatures|rnaseq)/) {
     $self->core_fk();
   } elsif ($self->dba->group eq 'funcgen') {
     $self->funcgen_fk();

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBiotypes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBiotypes.pm
@@ -38,15 +38,23 @@ use constant {
 sub tests {
   my ($self) = @_;
 
+  # Check that biotypes in gene and transcript tables are valid.
   $self->biotypes('gene');
   $self->biotypes('transcript');
+
+  # Check that biotypes are consistent between genes and transcripts.
+  $self->biotype_groups();
 }
 
 sub biotypes {
   my ($self, $feature) = @_;
+  # Use SQL rather than the API, because the latter does not have
+  # an easy way to check for db_type; even if it did, it might not
+  # work if it's not correct in the db anyway, so SQL is the way to go.
+
   my $species_id = $self->dba->species_id;
   my $db_type = $self->dba->group;
-  
+
   my $desc = ucfirst($feature)."s have valid biotypes";
   my $diag = "Invalid biotype for $db_type $feature";
   my $sql = qq/
@@ -67,5 +75,70 @@ sub biotypes {
   is_rows_zero($self->dba, $sql, $desc, $diag);
 }
 
-1;
+sub biotype_groups {
+  my ($self, $feature) = @_;
+  # Use API rather than SQL, because the queries would be fiendish: joins
+  # across 6+ tables, 5+ constraints. The API is easily an order of
+  # magnitude slower, maybe two. But we're talking a few minutes here,
+  # compared to a few seconds, and I think it's worth taking the hit on
+  # runtime for the sake of readability and maintainability.
 
+  my $ba = $self->dba->get_adaptor('Biotype');
+  my $biotype_objs = $ba->fetch_all();
+  my %groups = map { $_->name => $_->biotype_group } @$biotype_objs;
+
+  # It's too verbose to report all the OKs, we'd be spewing out
+  # millions of lines of text. So accumulate errors in arrays
+  # and then test whether they are empty at the end.
+  my @polymorphic_mismatch;
+  my @group_mismatch;
+  my @pseudogene_mismatch;
+
+  my $ga = $self->dba->get_adaptor("Gene");
+  foreach my $gene ( @{ $ga->fetch_all } ) {
+    my $gene_group = $groups{$gene->biotype};
+
+    # Can't do anything sensible if a group isn't defined
+    next if $gene_group eq 'undefined';
+
+    my @transcripts         = @{ $gene->get_all_Transcripts };
+    my %transcript_biotypes = map { $_->biotype => 1 } @transcripts;
+    my %transcript_groups   = map { $groups{$_->biotype} => 1 } @transcripts;
+    # We don't need any further transcript-related information,
+    # so flush to prevent excessive memory use.
+    $gene->flush_Transcripts();
+
+    # Test 1: genes have at least one transcript with a matching biotype group
+    if (!exists $transcript_groups{$gene_group}) {
+      push @group_mismatch, $gene->stable_id;
+    }
+
+    # Test 2: "pseudogene" genes do not have coding transcripts
+    if ($gene_group eq 'pseudogene') {
+      foreach (keys %transcript_groups) {
+        if ($_ eq 'coding') {
+          push @pseudogene_mismatch, $gene->stable_id;
+          last;
+        }
+      }
+    }
+
+    # Test 3: "polymorphic_pseudogene" genes have at least one polymorphic_pseudogene transcript
+    if ($gene->biotype eq 'polymorphic_pseudogene') {
+      if (!exists $transcript_biotypes{'polymorphic_pseudogene'}) {
+        push @polymorphic_mismatch, $gene->stable_id;
+      }
+    }
+  }
+
+  my $desc_1 = 'genes have at least one transcript with a matching biotype group';
+  is(scalar(@group_mismatch), 0, $desc_1);
+
+  my $desc_2 = '"pseudogene" genes do not have coding transcripts';
+  is(scalar(@pseudogene_mismatch), 0, $desc_2);
+
+  my $desc_3 = '"polymorphic_pseudogene" genes have at least one polymorphic_pseudogene transcript';
+  is(scalar(@polymorphic_mismatch), 0, $desc_3);
+}
+
+1;


### PR DESCRIPTION
There's actually a lot of flexibility in how biotypes can be specified, so there's not loads to check. But the old BiotypeGroups healtcheck was really complicated, which masked the fact that it was doing unnecessary tests.

The BiotypeGroups healthcheck consistently failed (requiring annotation as "OK") when trying to deal with 'TEC' biotypes (TEC => To be Experimentally Confirmed), which have the group "undefined". The datacheck just doesn't bother trying to test anything about biotype groups that are undefined.

The HC also sometimes failed for non-vertebrate species, which had valid biotypes but weren't exactly like the HC was expecting; these were single-transcript genes where the biotype was not exactly the same between gene and transcript. That's been the norm in the past, but it's not required (the HC allowed genes to have multiple transcripts, none of which needed to match the gene biotype). There are a couple of special cases for pseudogenes, which are retained in the datacheck.

Finally, the datacheck uses the API to check the groups; this is slow(ish), but is favoured over quicker (and rather complicated) SQL queries, for the sake of readability and maintainability, particularly as the datacheck may need to be developed in the short/medium-term because Ensembl is reviewing how biotypes are used.