### PR TITLE
Fix test skipping for collection dbs

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/BaseCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/BaseCheck.pm
@@ -128,10 +128,14 @@ sub skip_datacheck {
   # Method to be overridden by a subclass, if required.
 }
 
-sub run_tests {
+sub run_datacheck {
   # Method can be overridden by a subclass, if required.
   my $self = shift;
   $self->tests(@_);
+}
+
+sub skip_tests {
+  # Method to be overridden by a subclass, if required.
 }
 
 sub tests {
@@ -155,7 +159,7 @@ sub run {
 
       plan skip_all => $skip_reason if $skip;
 
-      $self->run_tests(@_);
+      $self->run_datacheck(@_);
 
       $self->_finished(time);
     }

--- a/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
@@ -386,7 +386,7 @@ sub get_old_dba {
   return $old_dba;
 }
 
-sub run_tests {
+sub run_datacheck {
   my $self = shift;
 
   if (!$self->per_db && !$self->dba_species_only && $self->dba->is_multispecies) {
@@ -414,7 +414,13 @@ sub run_tests {
       $self->dba($dba);
 
       subtest $species => sub {
-        $self->tests(@_);
+        SKIP: {
+          my ($skip, $skip_reason) = $self->skip_tests(@_);
+
+          plan skip_all => $skip_reason if $skip;
+
+          $self->tests(@_);
+        }
       };
     }
 
@@ -423,7 +429,13 @@ sub run_tests {
     $self->dba($original_dba);
 
   } else {
-    $self->tests(@_);
+    SKIP: {
+      my ($skip, $skip_reason) = $self->skip_tests(@_);
+
+      plan skip_all => $skip_reason if $skip;
+
+      $self->tests(@_);
+    }
   }
 }
 
@@ -433,9 +445,6 @@ sub skip_datacheck {
   my ($skip, $skip_reason) = $self->verify_db_type();
   if (!$skip) {
     ($skip, $skip_reason) = $self->check_history();
-    if (!$skip) {
-      ($skip, $skip_reason) = $self->skip_tests(@_);
-    }
   }
 
   return ($skip, $skip_reason);

--- a/t/BaseCheck.t
+++ b/t/BaseCheck.t
@@ -42,7 +42,7 @@ diag('Internal attributes');
 can_ok($module, qw(_started _finished _passed));
 
 diag('Methods');
-can_ok($module, qw(skip_datacheck run tests run_tests));
+can_ok($module, qw(skip_datacheck run_datacheck skip_tests tests run));
 
 # As well as being a nice way to encapsulate sets of tests, the use of
 # subtests here is necessary, because the behaviour we are testing

--- a/t/DbCheck.t
+++ b/t/DbCheck.t
@@ -53,7 +53,10 @@ diag('Runtime attributes');
 can_ok($module, qw(dba dba_species_only registry_file server_uri registry old_server_uri dba_list));
 
 diag('Methods');
-can_ok($module, qw(species get_dba get_dna_dba get_prod_dba get_old_dba run_tests skip_datacheck verify_db_type check_history table_dates skip_tests));
+can_ok($module, qw(
+  species get_dba get_dna_dba get_prod_dba get_old_dba 
+  skip_datacheck run_datacheck skip_tests tests run
+  verify_db_type check_history table_dates));
 
 # As well as being a nice way to encapsulate sets of tests, the use of
 # subtests here is necessary, because the behaviour we are testing
@@ -275,10 +278,6 @@ subtest 'DbCheck with skip_tests method defined', sub {
   is($skip_reason, undef, 'No skip reason');
 
   ($skip, $skip_reason) = $dbcheck->skip_tests('please');
-  is($skip, 1, 'Skip if condition is not met');
-  is($skip_reason, 'All good here, thank you', 'Correct skip reason');
-
-  ($skip, $skip_reason) = $dbcheck->skip_datacheck('please');
   is($skip, 1, 'Skip if condition is not met');
   is($skip_reason, 'All good here, thank you', 'Correct skip reason');
 };


### PR DESCRIPTION
The code was not properly handling the skipping of tests for collection databases. The skipping was done at the database level, with species_id=1 deciding whether tests were skipped for all species. Have now separated the logic of skipping a datacheck (which happens at the db-level, e.g. because tables haven't been updated) and the skipping of tests (which happens at the species-level). Seemed to make sense to rename the 'run_tests' method to 'run_datacheck', to match the structure/logic of the code.