### PR TITLE
Restructure datacheck pipeline

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/DataCheckFactory.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/DataCheckFactory.pm
@@ -47,9 +47,17 @@ sub write_output {
 
   my $datachecks = $self->param('datachecks');
 
+  # Because we have pipeline-wide parameter propagation, any pattern,
+  # group or type parameters would be picked up by the subsequent 'fan'
+  # module, which is not what we want, so we need to explicitly overwrite
+  # them with empty arrays.
+
   foreach my $datacheck (@$datachecks) {
     my %output = (
-      datacheck_names => [$datacheck->name],
+      datacheck_names    => [$datacheck->name],
+      datacheck_patterns => [],
+      datacheck_groups   => [],
+      datacheck_types    => [],
     );
 
     $self->dataflow_output_id(\%output, 2);

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/DataCheckSubmission.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/DataCheckSubmission.pm
@@ -1,0 +1,101 @@
+=head1 LICENSE
+Copyright [2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+Bio::EnsEMBL::DataCheck::Pipeline::DataCheckSubmission
+
+=head1 DESCRIPTION
+Perform housekeeping tasks that make it easier to seed jobs.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Pipeline::DataCheckSubmission;
+
+use strict;
+use warnings;
+use feature 'say';
+
+use Time::Piece;
+
+use base ('Bio::EnsEMBL::Hive::Process');
+
+sub write_output {
+  my $self = shift;
+
+  # This module is a single point of entry into the pipeline, to enable
+  # an eternal beekeeper to be seeded with multiple datacheck runs.
+  # Pipeline-wide parameter propagation is switched on, so we just need
+  # to pass on all the input parameters in order for subsequent modules
+  # to have the data they need. There's no way in hive to get all the
+  # parameters in a data structure, so need to do it the long-winded way,
+  # which does at least make it explicit what we're doing...
+  # We also add the job_id for this analysis, in order to be able to
+  # associate results summaries with the relvant submission.
+
+  my $params = {
+    species      => $self->param('species'),
+    antispecies  => $self->param('antispecies'),
+    taxons       => $self->param('taxons'),
+    antitaxons   => $self->param('antitaxons'),
+    division     => $self->param('division'),
+    run_all      => $self->param('run_all'),
+    meta_filters => $self->param('meta_filters'),
+    db_type      => $self->param('db_type'),
+
+    datacheck_dir      => $self->param('datacheck_dir'),
+    index_file         => $self->param('index_file'),
+    history_file       => $self->param('history_file'),
+    output_dir         => $self->param('output_dir'),
+    overwrite_files    => $self->param('overwrite_files'),
+    datacheck_names    => $self->param('datacheck_names'),
+    datacheck_patterns => $self->param('datacheck_patterns'),
+    datacheck_groups   => $self->param('datacheck_groups'),
+    datacheck_types    => $self->param('datacheck_types'),
+    registry_file      => $self->param('registry_file'),
+    old_server_uri     => $self->param('old_server_uri'),
+
+    failures_fatal => $self->param('failures_fatal'),
+
+    parallelize_datachecks => $self->param('parallelize_datachecks'),
+
+    tag          => $self->param('tag'),
+    email        => $self->param('email'),
+    email_report => $self->param('email_report'),
+    report_all   => $self->param('report_all'),
+
+    submission_job_id => $self->input_job->dbID,
+
+    reg_conf => $self->param('registry_file'),
+  };
+  $self->dataflow_output_id($params, 1);
+
+  my $timestamp = $self->param('timestamp');
+  $timestamp = localtime->cdate unless defined $timestamp;
+
+  # A subset of the input parameters are stored in the 'datacheck_submission'
+  # table, for easier subsequent retrieval than querying the native hive tables.
+  my $datacheck_submission = {
+    submission_job_id => $self->input_job->dbID,
+    history_file      => $self->param('history_file'),
+    output_dir        => $self->param('output_dir'),
+    tag               => $self->param('tag'),
+    email             => $self->param('email'),
+    submitted         => $timestamp,
+  };
+  $self->dataflow_output_id($datacheck_submission, 3);
+
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/EmailSummary.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/EmailSummary.pm
@@ -1,0 +1,100 @@
+=head1 LICENSE
+Copyright [2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+Bio::EnsEMBL::DataCheck::Pipeline::EmailSummary
+
+=head1 DESCRIPTION
+Send an email with the overall summary for all datachecks.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Pipeline::EmailSummary;
+
+use strict;
+use warnings;
+use feature 'say';
+
+use base ('Bio::EnsEMBL::Hive::RunnableDB::NotifyByEmail');
+
+sub fetch_input {
+  my $self = shift;
+
+  my $submission_job_id = $self->param('submission_job_id');
+
+  my $tag          = $self->param('tag');
+  my $history_file = $self->param('history_file');
+  my $output_dir   = $self->param('output_dir');
+
+  my ($passed_total, $failed_total) = (0, 0);
+  my $db_text = '';
+
+  my $sql = q/
+    SELECT dbname, passed, failed, skipped FROM datacheck_results
+    WHERE submission_job_id = ?
+  /;
+  my $sth = $self->dbc->prepare($sql);
+  $sth->execute($submission_job_id);
+
+  my $results = $sth->fetchall_arrayref();
+  foreach my $result (@$results) {
+    my ($dbname, $passed, $failed, $skipped) = @$result;
+
+    $failed ? $failed_total++ : $passed_total++;
+
+    $db_text .= "\tpassed: $passed";
+    $db_text .= "\tfailed: $failed";
+    $db_text .= "\tskipped: $skipped";
+    $db_text .= "\t$dbname\n";
+  }
+
+  my $subject;
+  if ($failed_total) {
+    $subject = "FAIL: Datacheck Summary";
+  } else {
+    $subject = "PASS: Datacheck Summary";
+  }
+
+  my $passed_db = $passed_total == 1 ? 'database' : 'databases';
+  my $failed_db = $failed_total == 1 ? 'database' : 'databases';
+
+  my $text = "All datachecks have completed.\n".
+    "$passed_total $passed_db passed all datachecks, ".
+    "$failed_total $failed_db failed one or more datachecks.\n";
+
+  if (defined $tag) {
+    $subject .= " ($tag)";
+    $text    .= "Submission tag: $tag\n";
+  }
+  $self->param('subject', $subject);
+
+  $text .= "Details:\n$db_text";
+
+  if (defined $history_file) {
+    $text .= "The datacheck results were stored in a history file: $history_file.\n";
+  } else {
+    $text .= "The datacheck results were not stored in a history file.\n";
+  }
+
+  if (defined $output_dir) {
+    $text .= "The full output of the datachecks were stored in: $output_dir.\n";
+  } else {
+    $text .= "The full output of the datachecks were not stored.\n";
+  }
+
+  $self->param('text', $text);
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/RunDataChecks.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/RunDataChecks.pm
@@ -28,6 +28,7 @@ use warnings;
 use feature 'say';
 
 use Bio::EnsEMBL::DataCheck::Manager;
+use Bio::EnsEMBL::Registry;
 use Path::Tiny;
 
 use base ('Bio::EnsEMBL::Hive::Process');
@@ -70,6 +71,11 @@ sub param_defaults {
 
 sub fetch_input {
   my $self = shift;
+
+  my $reg = 'Bio::EnsEMBL::Registry';
+  if ($self->param_is_defined('registry_file')) {
+    $reg->load_all($self->param('registry_file'));
+  }
 
   my $output_file;
   if ($self->param_is_defined('output_dir') && $self->param_is_defined('output_filename')) {

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/StoreResults.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/StoreResults.pm
@@ -1,0 +1,55 @@
+=head1 LICENSE
+Copyright [2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+Bio::EnsEMBL::DataCheck::Pipeline::StoreResults
+
+=head1 DESCRIPTION
+Store summary stats in a hive database table.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Pipeline::StoreResults;
+
+use strict;
+use warnings;
+use feature 'say';
+
+use base ('Bio::EnsEMBL::Hive::Process');
+
+sub write_output {
+  my $self = shift;
+
+  my $output = {
+    submission_job_id  => $self->param('submission_job_id'),
+    dbname             => $self->param('dbname'),
+    passed             => $self->param('datachecks_passed'),
+    failed             => $self->param('datachecks_failed'),
+    skipped            => $self->param('datachecks_skipped'),
+  };
+
+  $self->dataflow_output_id($output, 3);
+
+  if (
+    defined $self->param('email') &&
+    $self->param('email_report') &&
+    ($self->param('datachecks_failed') || $self->param('report_all'))
+  ) {
+    
+    $self->dataflow_output_id({}, 4);
+  }
+}
+
+1;


### PR DESCRIPTION
New module that deals with datacheck submissions. This allows the pipeline to be used with an eternal beekeeper, isolating submissions from each other. Submission metadata is stored in a table in the hive, for easier lookup. The default is now to receive a single summary email per submission.

init_pipeline.pl can be used to create an empty database, and then each submission is a call to seed_pipeline.pl. The formatting of variables required by seed_pipeline.pl is a little unfriendly; a further task will be to create a simple script, analogous to scripts/run_datachecks.pl, to mask the complexity and enable people to more easily create/manage their own pipelines. Documentation needs to be updated accordingly.