### PR TITLE
Make funcgen bounds check more efficient

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CoreTables.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CoreTables.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2018] EMBL-European Bioinformatics Institute
+Copyright [2018-2019] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the 'License');
 you may not use this file except in compliance with the License.

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/FeaturePosition.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/FeaturePosition.pm
@@ -129,7 +129,7 @@ sub end_bound_check {
   }
 
   is(scalar(@out_of_bounds), 0, $desc) ||
-    diag explain {'seq__region_ids' => \@out_of_bounds};
+    diag explain {'seq_region_ids' => \@out_of_bounds};
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/FeaturePosition.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/FeaturePosition.pm
@@ -23,67 +23,113 @@ use strict;
 
 use Moose;
 use Test::More;
-use Bio::EnsEMBL::DataCheck::Utils qw/sql_count/;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
 
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
     NAME        => 'FeaturePosition',
-    DESCRIPTION => 'Checks if features lie within bounds of seq_region i.e. start >=0 and end <= seq_region length.',
-    GROUPS      => [ 'funcgen_handover' ],
-    DB_TYPES    => [ 'funcgen' ],
-    TABLES      => [ "peak", "regulatory_feature", "motif_feature", "external_feature", "mirna_target_feature" ]
+    DESCRIPTION => 'Ensure that features are within the bounds of their seq_region',
+    GROUPS      => ['funcgen_handover'],
+    DB_TYPES    => ['funcgen'],
+    TABLES      => ['external_feature', 'mirna_target_feature', 'motif_feature', 'peak', 'regulatory_feature']
 };
 
 sub tests {
   my ($self) = @_;
 
-  my $dna_dba = $self->get_dna_dba();
+  my $seq_regions = $self->seq_region_lengths();
 
-  # process with db is not master
-  my $sql_regions = q/
-    SELECT  seq_region_id,
-            `length`
-    FROM    seq_region
-    JOIN    seq_region_attrib USING (seq_region_id)
-    JOIN    attrib_type USING (attrib_type_id)
-    WHERE   code = "toplevel"
-  /;
-
-  my $helper = $dna_dba->dbc->sql_helper;
-  my %regions = %{$helper->execute_into_hash(-SQL => $sql_regions)};
-  my @feature_tables = ("peak", "regulatory_feature", "motif_feature", "external_feature", "mirna_target_feature");
-  my $feature_pos_sql;
-  my $region_length;
-
-  foreach my $feature_table (@feature_tables) {
-    my $desc_feature_ok = "No " . $feature_table . "s exceeding seq_region bounds";
-    my $feature_count = 0;
-    foreach my $region_id (keys %regions) {
-      $region_length = $regions{$region_id};
-      if ($feature_table eq "regulatory_feature") {
-        $feature_pos_sql = qq/
-          SELECT COUNT(${feature_table}_id)
-          FROM    $feature_table
-          WHERE   seq_region_id = $region_id
-          AND     ((seq_region_start - bound_start_length) <= 0
-          OR      (seq_region_end + bound_end_length) > $region_length)
-          /;
-
-      }
-      else {
-        $feature_pos_sql = qq/
-          SELECT COUNT(${feature_table}_id)
-          FROM    $feature_table
-          WHERE   seq_region_id= $region_id
-          AND     (seq_region_start <= 0 OR seq_region_end > $region_length)
-          /;
-      }
-      $feature_count += sql_count($self->dba, $feature_pos_sql);
-    }
-    is($feature_count, 0, $desc_feature_ok);
+  foreach my $table (@{$self->tables}) {
+    $self->start_bound_check($table);
+    $self->end_bound_check($table, $seq_regions);
   }
 }
 
-1;
+sub seq_region_lengths {
+  my ($self) = @_;
 
+  my $species_id = $self->dba->species_id;
+
+  my $dna_dba = $self->get_dna_dba();
+
+  my $sql = qq/
+    SELECT seq_region_id, length FROM
+	  seq_region INNER JOIN
+	  seq_region_attrib USING (seq_region_id) INNER JOIN
+	  attrib_type USING (attrib_type_id) INNER JOIN
+	  coord_system USING (coord_system_id)
+    WHERE
+      attrib_type.code = "toplevel" AND
+      coord_system.species_id = $species_id;
+  /;
+
+  my $seq_regions = $dna_dba->dbc->sql_helper->execute_into_hash( -SQL => $sql );
+
+  return $seq_regions;
+}
+
+sub start_bound_check {
+  my ($self, $table) = @_;
+
+  my $desc = "No ${table}s beyond start of seq_region";
+
+  my $sql;
+  if ($table eq "regulatory_feature") {
+    $sql = qq/
+      SELECT COUNT(*)
+      FROM $table
+      WHERE seq_region_start - bound_start_length <= 0
+    /;
+  } else {
+    $sql = qq/
+      SELECT COUNT(*)
+      FROM $table
+      WHERE seq_region_start <= 0
+    /;
+  }
+
+  is_rows_zero($self->dba, $sql, $desc);
+}
+
+sub end_bound_check {
+  my ($self, $table, $seq_regions) = @_;
+
+  my $desc = "No ${table}s beyond end of seq_region";
+
+  my $sql;
+  if ($table eq "regulatory_feature") {
+    $sql = qq/
+      SELECT
+        seq_region_id,
+        MAX(seq_region_end + bound_end_length) AS max_length
+      FROM $table
+      GROUP BY seq_region_id
+    /;
+  } else {
+    $sql = qq/
+      SELECT
+        seq_region_id,
+        MAX(seq_region_end) AS max_length
+      FROM $table
+      GROUP BY seq_region_id
+    /;
+  }
+
+  my $max_ends = $self->dba->dbc->sql_helper->execute_into_hash( -SQL => $sql );
+
+  my @out_of_bounds;
+
+  foreach my $sr_id (keys %$max_ends) {
+	if (exists $$seq_regions{$sr_id}) {
+	  if ($$max_ends{$sr_id} > $$seq_regions{$sr_id}) {
+	    push @out_of_bounds, $sr_id;
+	  }
+	}
+  }
+
+  is(scalar(@out_of_bounds), 0, $desc) ||
+    diag explain {'seq__region_ids' => \@out_of_bounds};
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/FeaturePosition.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/FeaturePosition.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
     NAME        => 'FeaturePosition',
     DESCRIPTION => 'Ensure that features are within the bounds of their seq_region',
-    GROUPS      => ['funcgen_handover'],
+    GROUPS      => ['funcgen', 'ersa'],
     DB_TYPES    => ['funcgen'],
     TABLES      => ['external_feature', 'mirna_target_feature', 'motif_feature', 'peak', 'regulatory_feature']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -240,7 +240,7 @@
    },
    "FeaturePosition" : {
       "datacheck_type" : "critical",
-      "description" : "Checks if features lie within bounds of seq_region i.e. start >=0 and end <= seq_region length.",
+      "description" : "Ensure that features are within the bounds of their seq_region",
       "groups" : [
          "funcgen_handover"
       ],

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -242,7 +242,8 @@
       "datacheck_type" : "critical",
       "description" : "Ensure that features are within the bounds of their seq_region",
       "groups" : [
-         "funcgen_handover"
+         "funcgen",
+         "ersa"
       ],
       "name" : "FeaturePosition",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::FeaturePosition"


### PR DESCRIPTION
Rewrote the logic of the tests, to minimise and simplify the queries hitting the db, based on the approaches used in the FeatureBounds and MetaCoord datachecks. Reduces run time by 2 orders of magnitude, down to <10 mins for human.