### PR TITLE
Multi-database datachecks

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesNameUnique.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesNameUnique.pm
@@ -23,7 +23,8 @@ use strict;
 
 use Moose;
 use Test::More;
- use Time::HiRes qw( usleep );
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
@@ -32,35 +33,62 @@ use constant {
   GROUPS      => ['core', 'meta'],
   DB_TYPES    => ['core'],
   TABLES      => ['meta'],
+  PER_DB      => 1,
 };
 
 sub tests {
   my ($self) = @_;
 
-  my %names;
+  # The test currently allows for a species.alias that is the same as
+  # species.production_name. This is redundant, but doesn't hurt.
+  # If we want to fail in such cases, remove the 'DISTINCT' below.
   my $sql = qq/
-    SELECT DISTINCT meta_value FROM meta
+    SELECT DISTINCT meta_value, species_id FROM meta
     WHERE
       (meta_key = 'species.production_name' OR
-       meta_key = 'species.alias') AND
-      species_id = ?
+       meta_key = 'species.alias')
   /;
 
+  # First, test if species is unique within the database.
+  my $helper = $self->dba->dbc->sql_helper;
+  my $names = $helper->execute(-SQL => $sql);
+  $self->dba->dbc && $self->dba->dbc->disconnect_if_idle();
+
+  my %names;
+  foreach (@$names) {
+    my ($name, undef) = @{$_};
+    $names{$name}++;
+  }
+  foreach my $name (sort keys %names) {
+    my $desc = "Species name $name is unique within database";
+    is($names{$name}, 1, $desc);
+  }
+
+  # Second, check if species appears in any database in the given registry.
+  # For this check to be meaningful, that registry needs to have between
+  # defined with all of the appropriate species.
+  my %all_names;
+  my %dbs;
   my $all_dbas = $self->registry->get_all_DBAdaptors(-GROUP => 'core');
   foreach my $dba (@$all_dbas) {
-    my $helper = $dba->dbc->sql_helper;
     my $dbname = $dba->dbc->dbname;
+    next if exists $dbs{$dbname};
+    $dbs{$dbname}++;
 
-    my $names = $helper->execute_simple(-SQL => $sql, -PARAMS => [$dba->species_id]);
-    map { push @{ $names{$_} }, $dbname } @$names;
-
+    $helper = $dba->dbc->sql_helper;
+    my $all_names = $helper->execute(-SQL => $sql);
     $dba->dbc && $dba->dbc->disconnect_if_idle();
+
+    foreach (@$all_names) {
+      my ($name, undef) = @{$_};
+      push @{ $all_names{$name} }, $dbname;
+    }
   }
 
   foreach my $name (sort keys %names) {
-    my $desc = "Species name $name is unique";
-    is(scalar @{ $names{$name} }, 1, $desc) or
-      diag("In multiple databases: " . join(", ", @{ $names{$name} }));
+    my $desc = "Species name $name is unique across databases";
+    is(scalar @{ $all_names{$name} }, 1, $desc) or
+      diag("In multiple databases: " . join(", ", @{ $all_names{$name} }));
   }
 }
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/StableIDUnique.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/StableIDUnique.pm
@@ -1,0 +1,86 @@
+=head1 LICENSE
+
+Copyright [2018-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::StableIDUnique;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'StableIDUnique',
+  DESCRIPTION => 'Check for uniqueness of stable IDs, both within a database, and across all databases in the registry',
+  GROUPS      => ['annotation', 'core'],
+  DB_TYPES    => ['core', 'otherfeatures'],
+  TABLES      => ['gene', 'transcript', 'translation'],
+  PER_DB      => 1
+};
+
+sub tests {
+  my ($self) = @_;
+
+  foreach my $table (@{$self->tables}) {
+    my $desc = "Unique stable IDs in $table table";
+    my $diag = "Stable ID";
+    my $sql  = qq/
+      SELECT stable_id FROM $table
+      GROUP BY stable_id HAVING COUNT(*) > 1
+    /;
+    is_rows_zero($self->dba, $sql, $desc, $diag);
+  }
+
+  my $group = $self->dba->group;
+
+  foreach my $table (@{$self->tables}) {
+    my $sql    = "SELECT stable_id FROM $table";
+    my $helper = $self->dba->dbc->sql_helper;
+    my $ids    = $helper->execute_simple(-SQL => $sql);
+    $self->dba->dbc && $self->dba->dbc->disconnect_if_idle();
+
+    my %all_ids;
+    my %dbs;
+    my $all_dbas = $self->registry->get_all_DBAdaptors(-GROUP => $group);
+    foreach my $dba (@$all_dbas) {
+      my $dbname = $dba->dbc->dbname;
+      next if exists $dbs{$dbname};
+      $dbs{$dbname}++;
+
+      $helper = $dba->dbc->sql_helper;
+      my $all_ids = $helper->execute_simple(-SQL => $sql);
+      $dba->dbc && $dba->dbc->disconnect_if_idle();
+
+      map { push @{ $all_ids{$_} }, $dbname } @$all_ids;
+    }
+
+    my @duplicated;
+    foreach my $id (sort @$ids) {
+      if (scalar @{ $all_ids{$id} } > 1) {
+        push @duplicated, ("$id in multiple databases: " . join(", ", @{ $all_ids{$id} }));
+      }
+    }
+    my $desc = "Unique stable IDs across all $table tables";
+    is(scalar @duplicated, 0, $desc) or diag(\@duplicated);
+  }
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -718,6 +718,16 @@
       "name" : "SpeciesNameUnique",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SpeciesNameUnique"
    },
+   "StableIDUnique" : {
+      "datacheck_type" : "critical",
+      "description" : "Check for uniqueness of stable IDs, both within a database, and across all databases in the registry",
+      "groups" : [
+         "annotation",
+         "core"
+      ],
+      "name" : "StableIDUnique",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::StableIDUnique"
+   },
    "TranscriptBounds" : {
       "datacheck_type" : "critical",
       "description" : "Check that gene and transcript bounds are consistent",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -727,6 +727,7 @@
       ],
       "name" : "StableIDUnique",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::StableIDUnique"
+   },
    "SpeciesTaxonomy" : {
       "datacheck_type" : "critical",
       "description" : "Check that taxonomy meta key is consistent with taxonomy database",


### PR DESCRIPTION
Adding datacheck for testing stable ID uniqueness across many databases/servers.
Tweaking datacheck for species name uniqueness, make it db-level rather than species-level for collection dbs.