### PR TITLE
Add config file functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 MultiTestDB.conf
+config*.json
 .idea
 /_Deparsed_XSubs.pm
-E

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,6 @@
+{
+  "registry_file"  : null,
+  "server_uri"     : null,
+  "old_server_uri" : null,
+  "data_file_path" : null,
+}

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DataFilesExist.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DataFilesExist.pm
@@ -99,9 +99,11 @@ sub segmentation_file_has_bigbed {
 sub data_files_exist {
   my ($self) = @_;
 
-  # This path needs to be un-hardcoded from here and put into a config file...
-  my $data_file_path = '/nfs/panda/ensembl/production/ensemblftp/data_files/';
-  my $path = $self->species_assembly_path($data_file_path);
+  if ( ! (defined $self->data_file_path && -e $self->data_file_path) ) {
+    die "Data file directory must be set as 'data_file_path' attribute";
+  }
+
+  my $path = $self->species_assembly_path($self->data_file_path);
 
   my $data_file_sql = q/
     SELECT table_name, path FROM data_file

--- a/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
@@ -206,6 +206,15 @@ has 'old_server_uri' => (
   isa => 'Str | Undef',
 );
 
+=head2 data_file_path
+  Description: Path to directory containing data files that need to be
+               tested as part of some datachecks.
+=cut
+has 'data_file_path' => (
+  is  => 'ro',
+  isa => 'Str | Undef',
+);
+
 =head2 dba_list
   Description: List of DBAdaptor objects that get created by the datacheck.
                (They're tracked so that we can close the connections nicely.)

--- a/lib/Bio/EnsEMBL/DataCheck/Manager.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Manager.pm
@@ -76,6 +76,26 @@ sub _index_file_default {
   return $file;
 }
 
+=head2 config_file
+  Description: Path to a file with parameters needed by datachecks
+=cut
+has 'config_file' => (
+  is       => 'rw',
+  isa      => 'Str | Undef',
+  lazy     => 1,
+  required => 0,
+  builder  => '_config_file_default',
+);
+
+sub _config_file_default {
+  (my $module_name = __PACKAGE__) =~ s!::!/!g;
+  my $file = $INC{"$module_name.pm"};
+
+  $file =~ s!lib/Bio/EnsEMBL/DataCheck/[\w\.]+$!config.json!;
+
+  return $file if -e $file;
+}
+
 =head2 names
   Description: List of datacheck names
 =cut
@@ -139,9 +159,29 @@ has 'overwrite_files' => (
 
 __PACKAGE__->meta->make_immutable;
 
+sub load_config {
+  my $self = shift;
+  my %params = @_;
+
+  if (defined $self->config_file) {
+    die unless -e $self->config_file;
+
+    my $json = path($self->config_file)->slurp;
+    my %config = %{ JSON->new->decode($json) };
+
+    foreach my $key (keys %config) {
+      if (!exists $params{$key}) {
+        $params{$key} = $config{$key};
+      }
+    }
+  }
+
+  return %params;
+}
+
 sub load_checks {
   my $self = shift;
-  my @params = @_;
+  my @params = $self->load_config(@_);
 
   my %index = %{ $self->read_index() };
 

--- a/lib/Bio/EnsEMBL/DataCheck/Manager.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Manager.pm
@@ -164,7 +164,7 @@ sub load_config {
   my %params = @_;
 
   if (defined $self->config_file) {
-    die unless -e $self->config_file;
+    die "Config file does not exist" unless -e $self->config_file;
 
     my $json = path($self->config_file)->slurp;
     my %config = %{ JSON->new->decode($json) };

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/DataCheckSubmission.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/DataCheckSubmission.pm
@@ -58,6 +58,7 @@ sub write_output {
     index_file         => $self->param('index_file'),
     history_file       => $self->param('history_file'),
     output_dir         => $self->param('output_dir'),
+    config_file        => $self->param('config_file'),
     overwrite_files    => $self->param('overwrite_files'),
     datacheck_names    => $self->param('datacheck_names'),
     datacheck_patterns => $self->param('datacheck_patterns'),
@@ -65,6 +66,7 @@ sub write_output {
     datacheck_types    => $self->param('datacheck_types'),
     registry_file      => $self->param('registry_file'),
     old_server_uri     => $self->param('old_server_uri'),
+    data_file_path     => $self->param('data_file_path'),
 
     failures_fatal => $self->param('failures_fatal'),
 

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/DbDataChecks_conf.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/DbDataChecks_conf.pm
@@ -51,6 +51,7 @@ sub default_options {
     index_file         => undef,
     history_file       => undef,
     output_dir         => undef,
+    config_file        => undef,
     overwrite_files    => 1,
     datacheck_names    => [],
     datacheck_patterns => [],
@@ -58,6 +59,7 @@ sub default_options {
     datacheck_types    => [],
     registry_file      => undef,
     old_server_uri     => undef,
+    data_file_path     => undef,
 
     failures_fatal => 0,
 
@@ -136,6 +138,7 @@ sub pipeline_analyses {
                               index_file         => $self->o('index_file'),
                               history_file       => $self->o('history_file'),
                               output_dir         => $self->o('output_dir'),
+                              config_file        => $self->o('config_file'),
                               overwrite_files    => $self->o('overwrite_files'),
                               datacheck_names    => $self->o('datacheck_names'),
                               datacheck_patterns => $self->o('datacheck_patterns'),
@@ -143,6 +146,7 @@ sub pipeline_analyses {
                               datacheck_types    => $self->o('datacheck_types'),
                               registry_file      => $self->o('registry_file'),
                               old_server_uri     => $self->o('old_server_uri'),
+                              data_file_path     => $self->o('data_file_path'),
 
                               failures_fatal     => $self->o('failures_fatal'),
 

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/RunDataChecks.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/RunDataChecks.pm
@@ -42,6 +42,7 @@ sub param_defaults {
     history_file       => undef,
     output_dir         => undef,
     output_filename    => undef,
+    config_file        => undef,
     overwrite_files    => 1,
     datacheck_names    => [],
     datacheck_patterns => [],
@@ -57,6 +58,7 @@ sub param_defaults {
     registry_file  => undef,
     server_uri     => undef,
     old_server_uri => undef,
+    data_file_path => undef,
   );
 
   return {
@@ -87,6 +89,7 @@ sub fetch_input {
   $manager_params{index_file}    = $self->param('index_file')    if $self->param_is_defined('index_file');
   $manager_params{history_file}  = $self->param('history_file')  if $self->param_is_defined('history_file');
   $manager_params{output_file}   = $self->param('output_file')   if $self->param_is_defined('output_file');
+  $manager_params{config_file}   = $self->param('config_file')   if $self->param_is_defined('config_file');
 
   $manager_params{overwrite_files} = $self->param('overwrite_files');
 
@@ -170,7 +173,7 @@ sub datacheck_params {
 
   $self->set_dba_param($datacheck_params);
 
-  $self->set_registry_param($datacheck_params);
+  $self->set_datacheck_params($datacheck_params);
 
   return $datacheck_params;
 }
@@ -234,17 +237,19 @@ sub set_dba_param {
   # parameter for datachecks, because databases aren't necessarily needed.
 }
 
-sub set_registry_param {
+sub set_datacheck_params {
   my $self = shift;
   my ($params) = @_;
 
   my $registry_file  = $self->param('registry_file');
   my $server_uri     = $self->param('server_uri');
   my $old_server_uri = $self->param('old_server_uri');
+  my $data_file_path = $self->param('data_file_path');
 
   $$params{registry_file}  = $registry_file  if defined $registry_file;
   $$params{server_uri}     = $server_uri     if defined $server_uri;
   $$params{old_server_uri} = $old_server_uri if defined $old_server_uri;
+  $$params{data_file_path} = $data_file_path if defined $data_file_path;
 }
 
 1;

--- a/scripts/run_datachecks.pl
+++ b/scripts/run_datachecks.pl
@@ -57,6 +57,19 @@ not possible to load them via the registry_file.
 A URI must be specified with the location of the previous release's databases,
 e.g. mysql://a_user@some_host:port_number/[old_db_name|old_release_number]
 
+=item B<-data_f[ile_path]> <data_file_path>
+
+Path to a directory containing data files that need to be tested
+as part of some datachecks (currently only applies to funcgen).
+
+=item B<-c[onfig_file]> <config_file>
+
+Path to a config file that contains default values for parameters
+needed by datachecks. If not explicitly specified, then the config.json
+file in the repository's root directory will be used, if it exists.
+The values in this file are overridden by any specific parameters
+that are given to this script.
+
 =item B<-n[ames]> <names>
 
 The name of the datacheck to execute.
@@ -131,7 +144,7 @@ use Pod::Usage;
 my (
     $help,
     $host, $port, $user, $pass, $dbname, $dbtype,
-    $registry_file, $server_uri, $old_server_uri,
+    $registry_file, $server_uri, $old_server_uri, $data_file_path, $config_file,
     @names, @patterns, @groups, @datacheck_types,
     $datacheck_dir, $index_file, $history_file, $output_file,
 );
@@ -147,6 +160,8 @@ GetOptions(
   "registry_file=s",   \$registry_file,
   "server_uri=s",      \$server_uri,
   "old_server_uri=s",  \$old_server_uri,
+  "data_file_path=s",  \$data_file_path,
+  "config_file=s",     \$config_file,
   "names|n:s",         \@names,
   "patterns:s",        \@patterns,
   "groups:s",          \@groups,
@@ -229,12 +244,14 @@ $manager_params{datacheck_dir}   = $datacheck_dir    if defined $datacheck_dir;
 $manager_params{index_file}      = $index_file       if defined $index_file;
 $manager_params{history_file}    = $history_file     if defined $history_file;
 $manager_params{output_file}     = $output_file      if defined $output_file;
+$manager_params{config_file}     = $config_file      if defined $config_file;
 
 my %datacheck_params;
 $datacheck_params{dba}            = $dba            if defined $dba;
 $datacheck_params{registry_file}  = $registry_file  if defined $registry_file;
 $datacheck_params{server_uri}     = $server_uri     if defined $server_uri;
 $datacheck_params{old_server_uri} = $old_server_uri if defined $old_server_uri;
+$datacheck_params{data_file_path} = $data_file_path if defined $data_file_path;
 
 my $manager = Bio::EnsEMBL::DataCheck::Manager->new(%manager_params);
 

--- a/t/DbCheck.t
+++ b/t/DbCheck.t
@@ -48,10 +48,10 @@ my $dba     = $testdb->get_DBAdaptor($db_type);
 my $module = 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 diag('Fixed attributes');
-can_ok($module, qw(db_types tables per_db));
+can_ok($module, qw(db_types tables per_db force));
 
 diag('Runtime attributes');
-can_ok($module, qw(dba dba_species_only registry_file server_uri registry old_server_uri dba_list));
+can_ok($module, qw(dba dba_species_only registry_file server_uri registry old_server_uri data_file_path dba_list));
 
 diag('Methods');
 can_ok($module, qw(
@@ -425,6 +425,16 @@ subtest 'Fetch DBA from registry', sub {
   isa_ok($dba2, $dba_type, 'Return value of "get_dba"');
   is($dba2->species, $dba->species, 'Species name matches');
   is($dba2->group,   $dba->group,   'Group matches');
+};
+
+subtest 'Set directory for data files', sub {
+  my $check = TestChecks::DbCheck_1->new(
+    data_file_path => '/data_files',
+  );
+
+  my $data_file_path = $check->data_file_path;
+
+  is($data_file_path, '/data_files', 'Set data_file_path');
 };
 
 $species = 'collection';

--- a/t/Manager.t
+++ b/t/Manager.t
@@ -72,6 +72,37 @@ subtest 'Default attributes', sub {
   is_deeply($manager->datacheck_types, [], 'Default datacheck_types correct (empty list)');
 };
 
+subtest 'Config file', sub {
+  my $manager = $module->new(
+    config_file => '/oops/file/does/not/exist',
+  );
+
+  throws_ok(
+    sub { $manager->load_config() },
+    qr/Config file does not exist/, 'Check for existence of config file');
+
+  my $config = {
+    registry_file  => 'registry_file_from_config',
+    data_file_path =>  'data_file_path_from_config',
+  };
+  my $json = JSON->new->pretty->encode($config);
+  my $config_file = Path::Tiny->tempfile();
+  $config_file->spew($json);
+
+  $manager->config_file($config_file->stringify);
+
+  my %params = (
+    registry_file  => 'registry_file_from_param',
+    old_server_uri => 'old_server_uri_from_param',
+  );
+
+  my %loaded = $manager->load_config(%params);
+
+  is($loaded{data_file_path}, 'data_file_path_from_config', 'Parameter loaded from config file');
+  is($loaded{old_server_uri}, 'old_server_uri_from_param', 'Explicit parameter loaded');
+  is($loaded{registry_file},  'registry_file_from_param', 'Explicit parameters overwrite config file');
+};
+
 subtest 'TestChecks directory', sub {
   my $manager = $module->new(
     datacheck_dir => $datacheck_dir,

--- a/t/RunDataChecks.t
+++ b/t/RunDataChecks.t
@@ -38,7 +38,7 @@ my $module = 'Bio::EnsEMBL::DataCheck::Pipeline::RunDataChecks';
 
 diag('Methods');
 my @hive_methods   = qw(param_defaults fetch_input run write_output);
-my @module_methods = qw(datacheck_params set_dba_param set_registry_param);
+my @module_methods = qw(datacheck_params set_dba_param set_datacheck_params);
 can_ok($module, @hive_methods);
 can_ok($module, @module_methods);
 
@@ -58,6 +58,7 @@ subtest 'Parameter instantiation: Manager', sub {
   $obj->param('history_file', '/path/to/history/file');
   $obj->param('output_dir', '/output/dir');
   $obj->param('output_filename', 'tap_output');
+  $obj->param('config_file', '/path/to/config/file');
   $obj->param('overwrite_files', 0);
   $obj->param('datacheck_names', ['DbCheck_1', 'DbCheck_4']);
   $obj->param('datacheck_patterns', ['BaseCheck']);
@@ -72,6 +73,7 @@ subtest 'Parameter instantiation: Manager', sub {
   is($manager->index_file, '/path/to/index/file', 'Index file is set correctly');
   is($manager->history_file, '/path/to/history/file', 'History file is set correctly');
   is($manager->output_file, '/output/dir/tap_output.txt', 'Output file is set correctly');
+  is($manager->config_file, '/path/to/config/file', 'Config file is set correctly');
   is($manager->overwrite_files, 0, 'Overwrite flag is set correctly');
   is_deeply($manager->names, ['DbCheck_1', 'DbCheck_4'], 'Datacheck names are set correctly');
   is_deeply($manager->patterns, ['BaseCheck'], 'Datacheck patterns are set correctly');
@@ -159,10 +161,11 @@ foreach my $species (@species) {
     $obj->param('group', 'core');
   };
 
-  subtest 'Parameter instantiation: DbCheck registry parameters', sub {
+  subtest 'Parameter instantiation: DbCheck non-DBA parameters', sub {
     $obj->param('registry_file', '/path/to/registry');
     $obj->param('server_uri', 'mysql_uri_1');
     $obj->param('old_server_uri', 'mysql_uri_2');
+    $obj->param('data_file_path', '/path/to/data_files');
 
     $obj->fetch_input();
     my $datacheck_params = $obj->param('datacheck_params');
@@ -170,10 +173,12 @@ foreach my $species (@species) {
     is($$datacheck_params{registry_file}, '/path/to/registry', 'Registry file is set correctly');
     is($$datacheck_params{server_uri}, 'mysql_uri_1', 'Server URI is set correctly');
     is($$datacheck_params{old_server_uri}, 'mysql_uri_2', 'Old server URI is set correctly');
+    is($$datacheck_params{data_file_path}, '/path/to/data_files', 'Data file path is set correctly');
 
     $obj->param('registry_file', undef);
     $obj->param('server_uri', undef);
     $obj->param('old_server_uri', undef);
+    $obj->param('data_file_path', undef);
   };
 
   # Point at the test datachecks. Output file is needed to prevent the


### PR DESCRIPTION
It's useful to be able to define a config file with all the parameters needed to run a set of datachecks; there are some rarely used parameters which are essentially constant, so it's a pain to have to specify on the command line.
These changes allow for a config file to be created once with the default parameters. Anything passed on the command line overwrites these defaults.