### PR TITLE
Datacheck config and registry improvements

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,6 +1,11 @@
 {
-  "registry_file"  : null,
-  "server_uri"     : null,
-  "old_server_uri" : null,
-  "data_file_path" : null,
+  "datacheck_params" : {
+    "registry_file"  : null,
+    "server_uri"     : null,
+    "old_server_uri" : null,
+    "data_file_path" : null
+  },
+  "history_file" : null,
+  "output_file"  : null,
+  "output_dir"   : null
 }

--- a/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
@@ -184,8 +184,16 @@ sub _registry_default {
     die "Registry requires a 'registry_file' or 'server_uri' attribute";
   }
 
-  if ($registry->alias_exists($species)) {
-	  $registry->remove_DBAdaptor($species, $self->dba->group);
+  if ($self->dba->is_multispecies) {
+    foreach my $collection_species (@{$self->dba->all_species}) {
+      if ($registry->alias_exists($collection_species)) {
+        $registry->remove_DBAdaptor($collection_species, $self->dba->group);
+      }
+    }
+  } else {
+    if ($registry->alias_exists($species)) {
+      $registry->remove_DBAdaptor($species, $self->dba->group);
+    }
   }
 
   $registry->load_registry_from_url($dba_url);

--- a/lib/Bio/EnsEMBL/DataCheck/Manager.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Manager.pm
@@ -169,9 +169,21 @@ sub load_config {
     my $json = path($self->config_file)->slurp;
     my %config = %{ JSON->new->decode($json) };
 
-    foreach my $key (keys %config) {
+    foreach my $key (keys %{$config{'datacheck_params'}}) {
       if (!exists $params{$key}) {
-        $params{$key} = $config{$key};
+        $params{$key} = $config{'datacheck_params'}{$key};
+      }
+    }
+
+    if (!defined $self->history_file) {
+      if (defined $config{'history_file'} && exists $config{'history_file'}) {
+        $self->history_file($config{'history_file'});
+      }
+    }
+
+    if (!defined $self->output_file) {
+      if (defined $config{'output_file'} && exists $config{'output_file'}) {
+        $self->history_file($config{'output_file'});
       }
     }
   }

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/DbDataChecks_conf.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/DbDataChecks_conf.pm
@@ -186,9 +186,6 @@ sub pipeline_analyses {
       -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::RunDataChecks',
       -analysis_capacity => 10,
       -max_retry_count   => 0,
-      -parameters        => {
-                              'output_filename' => '#dbname#',
-                            },
       -rc_name           => 'default',
       -flow_into         => {
                               '1' => ['StoreResults'],
@@ -200,9 +197,6 @@ sub pipeline_analyses {
       -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::DataCheckFactory',
       -analysis_capacity => 10,
       -max_retry_count   => 0,
-      -parameters        => {
-                              'output_filename' => '#dbname#',
-                            },
       -rc_name           => 'default',
       -flow_into         => {
                               '2->A' => ['DataCheckFan'],
@@ -215,9 +209,6 @@ sub pipeline_analyses {
       -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::DataCheckFan',
       -analysis_capacity => 100,
       -max_retry_count   => 0,
-      -parameters        => {
-                              'output_filename' => '#dbname#',
-                            },
       -rc_name           => 'default',
       -flow_into         => {
                               '1' => ['?accu_name=results&accu_address=[]'],
@@ -230,9 +221,6 @@ sub pipeline_analyses {
       -analysis_capacity => 10,
       -batch_size        => 100,
       -max_retry_count   => 0,
-      -parameters        => {
-                              'output_filename' => '#dbname#',
-                            },
       -rc_name           => 'default',
       -flow_into         => {
                               '1' => ['StoreResults'],

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/RunDataChecks.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/RunDataChecks.pm
@@ -83,7 +83,7 @@ sub fetch_input {
     my $filename =
       $self->param('dbname') . '.' .
       $self->param('submission_job_id') . '.txt';
-    $self->param('output_file', $self->param('output_dir') . "/$filename"));
+    $self->param('output_file', $self->param('output_dir') . "/$filename");
   }
 
   my %manager_params;

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/RunDataChecks.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/RunDataChecks.pm
@@ -79,9 +79,11 @@ sub fetch_input {
     $reg->load_all($self->param('registry_file'));
   }
 
-  my $output_file;
-  if ($self->param_is_defined('output_dir') && $self->param_is_defined('output_filename')) {
-    $self->param('output_file', $self->param('output_dir') . '/' . $self->param('output_filename') . '.txt');
+  if ($self->param_is_defined('output_dir')) {
+    my $filename =
+      $self->param('dbname') . '.' .
+      $self->param('submission_job_id') . '.txt';
+    $self->param('output_file', $self->param('output_dir') . "/$filename"));
   }
 
   my %manager_params;

--- a/scripts/run_pipeline.pl
+++ b/scripts/run_pipeline.pl
@@ -263,26 +263,32 @@ if (! defined $host || ! defined $port || ! defined $user || ! defined $pass) {
 }
 $dbname = $ENV{'USER'}.'_db_datachecks'unless defined $dbname;
 
-if (! defined $registry_file) {
-  if (! defined $config_file) {
-    $config_file = $FindBin::Bin;
-    $config_file =~ s!scripts$!config.json!;
-  }
+my %config;
+if (! defined $config_file) {
+  $config_file = $FindBin::Bin;
+  $config_file =~ s!scripts$!config.json!;
+}
+if (-e $config_file) {
+  my $json = path($config_file)->slurp;
+  %config = %{ JSON->new->decode($json) };
+}
 
-  if (-e $config_file) {
-    my $json = path($config_file)->slurp;
-    my %config = %{ JSON->new->decode($json) };
-    if (exists $config{registry_file} && defined $config{registry_file}) {
-      $registry_file = $config{registry_file};
-    } else {
-      die "registry_file is mandatory";
-    }
+if (! defined $registry_file) {
+  if (exists $config{registry_file} && defined $config{registry_file}) {
+    $registry_file = $config{registry_file};
   } else {
     die "registry_file is mandatory";
   }
 }
+
 if (! -e $registry_file) {
   die "registry_file '$registry_file' does not exist";
+}
+
+if (! defined $output_dir) {
+  if (exists $config{output_dir} && defined $config{output_dir}) {
+    $output_dir = $config{output_dir};
+  }
 }
 
 # It doesn't make sense to use the default index file if a datacheck_dir

--- a/t/Manager.t
+++ b/t/Manager.t
@@ -82,14 +82,19 @@ subtest 'Config file', sub {
     qr/Config file does not exist/, 'Check for existence of config file');
 
   my $config = {
-    registry_file  => 'registry_file_from_config',
-    data_file_path =>  'data_file_path_from_config',
+    datacheck_params => {
+      registry_file  => 'registry_file_from_config',
+      data_file_path => 'data_file_path_from_config'
+    },
+    history_file => 'history_file_from_config',
+    output_file  => 'output_file_from_config',
   };
   my $json = JSON->new->pretty->encode($config);
   my $config_file = Path::Tiny->tempfile();
   $config_file->spew($json);
 
   $manager->config_file($config_file->stringify);
+  $manager->output_file('output_file_from_param');
 
   my %params = (
     registry_file  => 'registry_file_from_param',
@@ -101,6 +106,8 @@ subtest 'Config file', sub {
   is($loaded{data_file_path}, 'data_file_path_from_config', 'Parameter loaded from config file');
   is($loaded{old_server_uri}, 'old_server_uri_from_param', 'Explicit parameter loaded');
   is($loaded{registry_file},  'registry_file_from_param', 'Explicit parameters overwrite config file');
+  is($manager->history_file,  'history_file_from_config', 'File parameter loaded from config file');
+  is($manager->output_file,   'output_file_from_param', 'Explicit file parameter loaded');
 };
 
 subtest 'TestChecks directory', sub {

--- a/t/RunDataChecks.t
+++ b/t/RunDataChecks.t
@@ -57,13 +57,13 @@ subtest 'Parameter instantiation: Manager', sub {
   $obj->param('index_file', '/path/to/index/file');
   $obj->param('history_file', '/path/to/history/file');
   $obj->param('output_dir', '/output/dir');
-  $obj->param('output_filename', 'tap_output');
   $obj->param('config_file', '/path/to/config/file');
   $obj->param('overwrite_files', 0);
   $obj->param('datacheck_names', ['DbCheck_1', 'DbCheck_4']);
   $obj->param('datacheck_patterns', ['BaseCheck']);
   $obj->param('datacheck_groups', ['base']);
   $obj->param('datacheck_types', ['advisory']);
+  $obj->param('submission_job_id', '1612');
 
   $obj->fetch_input();
   my $manager = $obj->param('manager');
@@ -72,7 +72,7 @@ subtest 'Parameter instantiation: Manager', sub {
   is($manager->datacheck_dir, '/datacheck/dir', 'Datacheck directory is set correctly');
   is($manager->index_file, '/path/to/index/file', 'Index file is set correctly');
   is($manager->history_file, '/path/to/history/file', 'History file is set correctly');
-  is($manager->output_file, '/output/dir/tap_output.txt', 'Output file is set correctly');
+  is($manager->output_file, '/output/dir/.1612.txt', 'Output file is set correctly');
   is($manager->config_file, '/path/to/config/file', 'Config file is set correctly');
   is($manager->overwrite_files, 0, 'Overwrite flag is set correctly');
   is_deeply($manager->names, ['DbCheck_1', 'DbCheck_4'], 'Datacheck names are set correctly');


### PR DESCRIPTION
Extending config file to work with more parameters. This means that we'll be able to create a per-division config file which can be selected when running datachecks through a service, which will simplify that process for the user, and hopefully avoid things going in the wrong place.

Fix to make an explicitly provided registry work properly with collection dbs.

Tidy up output_file specification; append job id to the filename to prevent unintended overwriting and make it easier to find relevant result sets.