### PR TITLE
Statistics pipeline-related datachecks

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DensityFeatures.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DensityFeatures.pm
@@ -1,0 +1,159 @@
+=head1 LICENSE
+
+Copyright [2018-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::DensityFeatures;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'DensityFeatures',
+  DESCRIPTION => 'Density statistics are present and correct for chromosomal species',
+  GROUPS      => ['core_statistics', 'statistics'],
+  DB_TYPES    => ['core'],
+  TABLES      => ['analysis', 'attrib_type', 'coord_system', 'density_feature', 'density_type', 'seq_region', 'seq_region_attrib']
+};
+
+sub skip_tests {
+  my ($self) = @_;
+
+  my $gca = $self->dba->get_adaptor('GenomeContainer');
+
+  if ( ! $gca->has_karyotype ) {
+    return (1, 'No chromosomal seq_regions.');
+  }
+}
+
+sub tests {
+  my ($self) = @_;
+
+  $self->density_types();
+  $self->density_features();
+}
+
+sub density_types {
+  my ($self) = @_;
+
+  my $desc = 'Density analysis exists';
+
+  my @logic_names = qw/
+    codingdensity
+    pseudogenedensity
+    shortnoncodingdensity
+    longnoncodingdensity
+    percentgc
+    percentagerepeat
+  /;
+
+  my $dta = $self->dba->get_adaptor('DensityType');
+
+  my $density_types = $dta->fetch_all();
+  my %analyses = map { $_->analysis->logic_name => 1 } @$density_types;
+
+  foreach my $logic_name (@logic_names) {
+    ok(exists $analyses{$logic_name}, "$desc ($logic_name)");
+  }
+}
+
+sub density_features {
+  my ($self) = @_;
+
+  # Some seq_regions might not have genes of a particular
+  # category, so we need to compare the values of count
+  # attributes in order to know what to expect.
+  # (The GeneCounts datacheck ensures that the attribute values are correct.)
+  my %attrib_mapping = (
+    codingdensity         => 'coding_cnt',
+    pseudogenedensity     => 'pseudogene_cnt',
+    shortnoncodingdensity => 'noncoding_cnt_s',
+    longnoncodingdensity  => 'noncoding_cnt_l',
+  );
+
+  my $dfa = $self->dba->get_adaptor('DensityFeature');
+  my $sa  = $self->dba->get_adaptor('Slice');
+
+  my $slices = $sa->fetch_all_karyotype();
+
+  foreach my $slice (@$slices) {
+    my $sr_name = $slice->coord_system_name . ' ' . $slice->seq_region_name;
+
+    $self->gc_density($dfa, $slice,
+      "Density feature counts for $sr_name (percentgc)");
+
+    $self->repeat_density($dfa, $sa, $slice,
+      "Density feature counts for $sr_name (percentagerepeat)");
+
+    foreach my $logic_name (keys %attrib_mapping) {
+      my $attrib_name = $attrib_mapping{$logic_name};
+
+      $self->attrib_density($dfa, $slice, $logic_name, $attrib_name,
+        "Density feature counts for $sr_name ($logic_name)");
+    }
+  }
+}
+
+sub gc_density {
+  my ($self, $dfa, $slice, $desc) = @_;
+
+  # We should always have GC calcs.
+  my $dfs = $dfa->fetch_all_by_Slice($slice, 'percentgc');
+  ok(defined($dfs) && scalar(@$dfs), $desc);
+}
+
+sub repeat_density {
+  my ($self, $dfa, $sa, $slice, $desc) = @_;
+
+  # We should have repeat calcs if we have repeat features.
+  # Retrieving this information via the API takes a colossal amount
+  # of memory and time; we can only fetch all repeat features, not
+  # just check for their presence. So resort to SQL.
+  my $repeat_sql = 'SELECT COUNT(*) FROM repeat_feature WHERE seq_region_id = ?';
+  my $sth = $sa->dbc->prepare($repeat_sql);
+  $sth->execute($slice->get_seq_region_id);
+  my ($count) = $sth->fetchrow_array();
+  if ($count) {
+    my $dfs = $dfa->fetch_all_by_Slice($slice, 'percentagerepeat');
+    ok(defined($dfs) && scalar(@$dfs), $desc);
+  }
+}
+
+sub attrib_density {
+  my ($self, $dfa, $slice, $logic_name, $attrib_name, $desc) = @_;
+
+  # In addition to checking that appropriate density features exist,
+  # we can check that the sum of the attrib values is consistent.
+  my ($attrib) = @{$slice->get_all_Attributes($attrib_name)};
+  if (defined $attrib) {
+    my $dfs = $dfa->fetch_all_by_Slice($slice, $logic_name);
+    my $density_total;
+    foreach my $df (@$dfs) {
+      $density_total += $df->density_value();
+    }
+
+    # Use cmp because density features may overlap,
+    # in which case there will be double-counting.
+    cmp_ok($density_total, '>=', $attrib->value, $desc);
+  }
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DensitySNPs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DensitySNPs.pm
@@ -1,0 +1,85 @@
+=head1 LICENSE
+
+Copyright [2018-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::DensitySNPs;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'DensitySNPs',
+  DESCRIPTION => 'Density statistics are present and correct for SNPs',
+  GROUPS      => ['statistics', 'variation_statistics'],
+  DB_TYPES    => ['core'],
+  TABLES      => ['analysis', 'attrib_type', 'coord_system', 'density_feature', 'density_type', 'seq_region', 'seq_region_attrib']
+};
+
+sub skip_tests {
+  my ($self) = @_;
+
+  my $gca = $self->dba->get_adaptor('GenomeContainer');
+
+  if ( ! $gca->has_karyotype ) {
+    return (1, 'No chromosomal seq_regions.');
+  }
+}
+
+sub tests {
+  my ($self) = @_;
+
+  my $dfa = $self->dba->get_adaptor('DensityFeature');
+  my $sa  = $self->dba->get_adaptor('Slice');
+
+  my $slices = $sa->fetch_all_karyotype();
+
+  foreach my $slice (@$slices) {
+    my $sr_name = $slice->coord_system_name . ' ' . $slice->seq_region_name;
+
+    $self->attrib_density($dfa, $slice, 'snpdensity', 'SNPCount',
+      "Density feature counts for $sr_name (snpdensity)");
+  }
+}
+
+sub attrib_density {
+  my ($self, $dfa, $slice, $logic_name, $attrib_name, $desc) = @_;
+
+  SKIP: {
+    # In addition to checking that appropriate density features exist,
+    # we can check that the sum of the attrib values is consistent.
+    my ($attrib) = @{$slice->get_all_Attributes($attrib_name)};
+
+    skip 'No SNPs on seq_region', 1 unless defined $attrib;
+
+    my $dfs = $dfa->fetch_all_by_Slice($slice, $logic_name);
+    my $density_total;
+    foreach my $df (@$dfs) {
+      $density_total += $df->density_value();
+    }
+
+    # Use cmp because density features may overlap,
+    # in which case there will be double-counting.
+    cmp_ok($density_total, '>=', $attrib->value, $desc);
+  }
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneCounts.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneCounts.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'GeneCounts',
   DESCRIPTION => 'Gene counts are correct',
-  GROUPS      => ['statistics'],
+  GROUPS      => ['core_statistics', 'statistics'],
   DB_TYPES    => ['core'],
   TABLES      => ['attrib_type', 'gene', 'seq_region', 'seq_region_attrib']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneGC.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneGC.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'GeneGC',
   DESCRIPTION => 'All genes have a GC statistic',
-  GROUPS      => ['statistics'],
+  GROUPS      => ['core_statistics', 'statistics'],
   DB_TYPES    => ['core'],
   TABLES      => ['attrib_type', 'gene', 'gene_attrib']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GenomeStatistics.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GenomeStatistics.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'GenomeStatistics',
   DESCRIPTION => 'Genome statistics are present and correct',
-  GROUPS      => ['statistics'],
+  GROUPS      => ['core_statistics', 'statistics', 'variation_statistics'],
   DB_TYPES    => ['core'],
   TABLES      => ['attrib_type', 'genome_statistics']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/PepstatsAttributes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/PepstatsAttributes.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'PepstatsAttributes',
   DESCRIPTION => 'All translations have peptide statistics',
-  GROUPS      => ['statistics'],
+  GROUPS      => ['core_statistics', 'statistics'],
   DB_TYPES    => ['core'],
   TABLES      => ['attrib_type', 'translation', 'translation_attrib']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SNPCounts.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SNPCounts.pm
@@ -1,0 +1,66 @@
+=head1 LICENSE
+
+Copyright [2018-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::SNPCounts;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'SNPCounts',
+  DESCRIPTION => 'SNP counts are correct',
+  GROUPS      => ['statistics', 'variation_statistics'],
+  DB_TYPES    => ['core'],
+  FORCE       => 1
+};
+
+sub tests {
+  my ($self) = @_;
+
+  SKIP: {
+    my $var_dba = $self->get_dba(undef, 'variation');
+    skip 'No variation database', 1 unless defined $var_dba;
+
+    my $sa = $self->dba->get_adaptor('Slice');
+
+    my $slices = $sa->fetch_all_karyotype();
+
+    foreach my $slice (@$slices) {
+      my $sr_name = $slice->coord_system_name . ' ' . $slice->seq_region_name;
+      my $desc = "SNP counts match for $sr_name in core and variation databases";
+
+      my ($attrib) = @{$slice->get_all_Attributes('SNPCount')};
+      my $sum = defined $attrib ? $attrib->value() : 0;
+
+      my $var_sql = 'SELECT COUNT(*) FROM variation_feature WHERE seq_region_id = ?';
+      my $sth = $var_dba->dbc->prepare($var_sql);
+      $sth->execute($slice->get_seq_region_id);
+      my ($count) = $sth->fetchrow_array();
+
+      is($sum, $count, $desc);
+    }
+  }
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -324,6 +324,26 @@
       "name" : "Denormalized",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::Denormalized"
    },
+   "DensityFeatures" : {
+      "datacheck_type" : "critical",
+      "description" : "Density statistics are present and correct for chromosomal species",
+      "groups" : [
+         "core_statistics",
+         "statistics"
+      ],
+      "name" : "DensityFeatures",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DensityFeatures"
+   },
+   "DensitySNPs" : {
+      "datacheck_type" : "critical",
+      "description" : "Density statistics are present and correct for SNPs",
+      "groups" : [
+         "statistics",
+         "variation_statistics"
+      ],
+      "name" : "DensitySNPs",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DensitySNPs"
+   },
    "DisplayableGenes" : {
       "datacheck_type" : "advisory",
       "description" : "Genes are displayable and have web_data attached to their analysis",
@@ -458,6 +478,7 @@
       "datacheck_type" : "critical",
       "description" : "Gene counts are correct",
       "groups" : [
+         "core_statistics",
          "statistics"
       ],
       "name" : "GeneCounts",
@@ -467,6 +488,7 @@
       "datacheck_type" : "critical",
       "description" : "All genes have a GC statistic",
       "groups" : [
+         "core_statistics",
          "statistics"
       ],
       "name" : "GeneGC",
@@ -497,7 +519,9 @@
       "datacheck_type" : "critical",
       "description" : "Genome statistics are present and correct",
       "groups" : [
-         "statistics"
+         "core_statistics",
+         "statistics",
+         "variation_statistics"
       ],
       "name" : "GenomeStatistics",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::GenomeStatistics"
@@ -639,6 +663,7 @@
       "datacheck_type" : "critical",
       "description" : "All translations have peptide statistics",
       "groups" : [
+         "core_statistics",
          "statistics"
       ],
       "name" : "PepstatsAttributes",
@@ -731,6 +756,16 @@
       ],
       "name" : "RepeatFeatures",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::RepeatFeatures"
+   },
+   "SNPCounts" : {
+      "datacheck_type" : "critical",
+      "description" : "SNP counts are correct",
+      "groups" : [
+         "statistics",
+         "variation_statistics"
+      ],
+      "name" : "SNPCounts",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SNPCounts"
    },
    "SampleRegulatoryFeatureExists" : {
       "datacheck_type" : "critical",


### PR DESCRIPTION
Three new datachecks, for SNP counts and density calculations for features and SNPs. Categorised datachecks into core and variation specific groups, as well as a more general 'statistics' one.