### PR TITLE
funcgen updates

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeys.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeys.pm
@@ -132,7 +132,6 @@ sub funcgen_fk {
   fk($self->dba, 'object_xref', 'ensembl_id', 'regulatory_feature',   'regulatory_feature_id',   'ensembl_object_type = "RegulatoryFeature"');
   fk($self->dba, 'object_xref', 'ensembl_id', 'external_feature',     'external_feature_id',     'ensembl_object_type = "ExternalFeature"');
   fk($self->dba, 'object_xref', 'ensembl_id', 'feature_type',         'feature_type_id',         'ensembl_object_type = "FeatureType"');
-  fk($self->dba, 'object_xref', 'ensembl_id', 'mirna_target_feature', 'mirna_target_feature_id', 'ensembl_object_type = "MirnaTargetFeature"');
   fk($self->dba, 'object_xref', 'ensembl_id', 'probe_set',            'probe_set_id',            'ensembl_object_type = "ProbeSet"');
   fk($self->dba, 'object_xref', 'ensembl_id', 'probe',                'probe_id',                'ensembl_object_type = "Probe"');
   fk($self->dba, 'object_xref', 'ensembl_id', 'probe_feature',        'probe_feature_id',        'ensembl_object_type = "ProbeFeature"');

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysMultiDB.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysMultiDB.pm
@@ -145,6 +145,17 @@ sub funcgen_core_fk {
     is(scalar(@diffs), 0, $desc) || diag explain \@diffs;
   }
 
+  my ($gene_stable_ids) = $self->col_array($dna_dba, 'gene', 'stable_id');
+  my @gene_stable_id_tables = ('mirna_target_feature');
+
+  for my $table (@gene_stable_id_tables){
+    my $desc = "All gene stable IDs in $table exist in core database";
+    my ($ids, $label) = $self->col_array($self->dba, $table, 'gene_stable_id');
+    my $diff = array_diff($ids, $gene_stable_ids, $label);
+    my @diffs = @{$$diff{"In $label only"}};
+    is(scalar(@diffs), 0, $desc) || diag explain \@diffs;
+  }
+
   my ($seq_region_ids) = $self->col_array($dna_dba, 'seq_region', 'seq_region_id');
   my @seq_region_id_tables = qw/
     external_feature


### PR DESCRIPTION
The funcgen 'mirna_target_feature' table has been modified for release 97 (see https://github.com/Ensembl/ensembl-funcgen/blob/master/sql/patch_96_97_e.sql).
Up until now, mirna_target_features were linked to genes via the 'object_xref' table. From now on, they will be linked via the new 'gene_stable_id' column.
This PR updates the relevant foreign key checks.