### PR TITLE
added critical datacheck DisplayableSampleGene

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayableSampleGene.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayableSampleGene.pm
@@ -1,0 +1,75 @@
+=head1 LICENSE
+
+Copyright [2018-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::DisplayableSampleGene;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'DisplayableSampleGene',
+  DESCRIPTION => 'Sample genes is displayable and has web_data attached to its analysis',
+  GROUPS      => ['core_handover'],
+  DB_TYPES    => ['core'],
+  TABLES      => ['analysis', 'analysis_description', 'gene', 'meta']
+};
+
+sub tests {
+  my ($self) = @_;
+
+  my $species_id = $self->dba->species_id;
+
+  my $desc_1 = 'Sample gene has displayable analysis';
+  my $diag_1 = 'Undisplayed analysis';
+  my $sql_1  = qq/
+      SELECT gene_id 
+        FROM gene g
+  INNER JOIN meta m 
+          ON g.stable_id = m.meta_value 
+         AND m.meta_key = 'sample.gene_param'
+  INNER JOIN analysis a ON g.analysis_id = a.analysis_id
+  INNER JOIN analysis_description ad 
+          ON g.analysis_id = ad.analysis_id AND ad.displayable = 1
+    /;
+
+  is_rows_zero($self->dba, $sql_1, $desc_1, $diag_1);
+
+  my $desc_2 = 'Sample gene has associated web_data';
+  my $diag_2 = 'web_data is not set';
+  my $sql_2  = qq/
+      SELECT gene_id 
+        FROM gene g
+  INNER JOIN meta m 
+          ON g.stable_id = m.meta_value 
+         AND m.meta_key = 'sample.gene_param'
+  INNER JOIN analysis a ON g.analysis_id = a.analysis_id
+  INNER JOIN analysis_description ad 
+          ON g.analysis_id = ad.analysis_id AND ad.web_data IS NOT NULL
+    /;
+
+  is_rows_zero($self->dba, $sql_2, $desc_2, $diag_2); 
+
+}
+
+1;
+

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayableSampleGene.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayableSampleGene.pm
@@ -64,7 +64,7 @@ sub tests {
          AND m.meta_key = 'sample.gene_param'
   INNER JOIN analysis a ON g.analysis_id = a.analysis_id
   INNER JOIN analysis_description ad 
-          ON g.analysis_id = ad.analysis_id AND ad.web_data IS NOT NULL
+          ON g.analysis_id = ad.analysis_id AND ad.web_data IS NULL
     /;
 
   is_rows_zero($self->dba, $sql_2, $desc_2, $diag_2); 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayableSampleGene.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayableSampleGene.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'DisplayableSampleGene',
   DESCRIPTION => 'Sample gene is displayable and has web_data attached to its analysis',
-  GROUPS      => ['core_handover'],
+  GROUPS      => ['core', 'geneset'],
   DB_TYPES    => ['core'],
   TABLES      => ['analysis', 'analysis_description', 'gene', 'meta']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayableSampleGene.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayableSampleGene.pm
@@ -49,7 +49,7 @@ sub tests {
          AND m.meta_key = 'sample.gene_param'
   INNER JOIN analysis a ON g.analysis_id = a.analysis_id
   INNER JOIN analysis_description ad 
-          ON g.analysis_id = ad.analysis_id AND ad.displayable = 1
+          ON g.analysis_id = ad.analysis_id AND ad.displayable = 0
     /;
 
   is_rows_zero($self->dba, $sql_1, $desc_1, $diag_1);

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayableSampleGene.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayableSampleGene.pm
@@ -28,7 +28,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
   NAME        => 'DisplayableSampleGene',
-  DESCRIPTION => 'Sample genes is displayable and has web_data attached to its analysis',
+  DESCRIPTION => 'Sample gene is displayable and has web_data attached to its analysis',
   GROUPS      => ['core_handover'],
   DB_TYPES    => ['core'],
   TABLES      => ['analysis', 'analysis_description', 'gene', 'meta']

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -377,6 +377,15 @@
       "name" : "DisplayableGenes",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DisplayableGenes"
    },
+   "DisplayableSampleGene" : {
+      "datacheck_type" : "critical",
+      "description" : "Sample gene is displayable and has web_data attached to its analysis",
+      "groups" : [
+         "core_handover"
+      ],
+      "name" : "DisplayableSampleGene",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DisplayableSampleGene"
+   },
    "DuplicateReadNames" : {
       "datacheck_type" : "critical",
       "description" : "Duplicate read names",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -381,7 +381,8 @@
       "datacheck_type" : "critical",
       "description" : "Sample gene is displayable and has web_data attached to its analysis",
       "groups" : [
-         "core_handover"
+         "core",
+         "geneset"
       ],
       "name" : "DisplayableSampleGene",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DisplayableSampleGene"


### PR DESCRIPTION
added critical datacheck DisplayableSampleGene to avoid issues such as https://github.com/Ensembl/staging-patches/pull/251

Created with:

$ perl -I lib scripts/create_datacheck.pl -n DisplayableSampleGene -d 'Sample gene is displayable and has web_data attached to its analysis' -g core_handover -db core -t meta,gene,analysis,analysis_description
