### PR TITLE
Remove the condition that a repeat must start above zero

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
@@ -81,18 +81,6 @@ sub tests {
       coord_system.species_id = $species_id
   /;
   is_rows_zero($self->dba, $sql_3, $desc_3);
-
-  my $desc_4 = 'Repeat start > 0';
-  my $sql_4  = qq/
-    SELECT COUNT(*) FROM
-      repeat_feature INNER JOIN
-      seq_region USING (seq_region_id) INNER JOIN
-      coord_system USING (coord_system_id)
-    WHERE
-      repeat_start < 1 AND
-      coord_system.species_id = $species_id
-  /;
-  is_rows_zero($self->dba, $sql_4, $desc_4);
 }
 
 1;


### PR DESCRIPTION
We have some genomes (ancylostoma_ceylanicum_prjna72583, caenorhabditis_angaria_prjna51225, caenorhabditis_japonica_prjna12591, caenorhabditis_sinica_prjna194557, ditylenchus_dipsaci_prjna498219, schistosoma_bovis_prjna451066 ) that fail this check.

I am not sure why this would be incorrect that a scaffold starts with a repetitive region - in fact I believe that if the repeat is unresolved, and the assembler couldn't go through the junction, the assembly is gonna look like that: it will start with a repeat.

WormBase ParaSite data would like to have this datacheck for making sure analyses got done - and we know some of our assemblies are bad :)

Could this check be moved or removed?