### PR TITLE
Fixing typo in SQL condition

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/InterProFeatures.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/InterProFeatures.pm
@@ -59,7 +59,7 @@ sub tests {
       interpro INNER JOIN
       xref ON interpro_ac = dbprimary_acc
     WHERE
-      dbprimary_acc = display_label IS NULL OR
+      display_label IS NULL OR
       description = '' OR
       description IS NULL
   /;


### PR DESCRIPTION
So that we actually check the display_label field, and not the result of a equality comparison...