### PR TITLE
Stable ID checking per database doesn't work

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/StableIDUnique.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/StableIDUnique.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'StableIDUnique',
   DESCRIPTION => 'Stable IDs are unique, both within a database, and across all databases in the registry',
-  GROUPS      => ['core', 'corelike', 'geneset'],
+  GROUPS      => ['multi_db'],
   DB_TYPES    => ['core', 'otherfeatures'],
   TABLES      => ['gene', 'transcript', 'translation'],
   PER_DB      => 1

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1211,9 +1211,7 @@
       "datacheck_type" : "critical",
       "description" : "Stable IDs are unique, both within a database, and across all databases in the registry",
       "groups" : [
-         "core",
-         "corelike",
-         "geneset"
+         "multi_db"
       ],
       "name" : "StableIDUnique",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::StableIDUnique"


### PR DESCRIPTION
It takes too long, and uses too much memory. Needs to be run as a one-off, not on a per database basis.