### PR TITLE
Converted HC to check if species inside a collection have protein cod…

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SharedDisplayXref.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SharedDisplayXref.pm
@@ -32,7 +32,7 @@ use constant {
   DESCRIPTION    => 'Protein coding Gene/Transcript display_xref are not shared between species inside a collection. This can lead to species-specific synonyms being applied to the wrong species',
   GROUPS         => ['xref'],
   DB_TYPES       => ['core'],
-  TABLES         => ['gene', 'transcript', 'seq_region', 'coord_system'],
+  TABLES         => ['gene', 'transcript', 'seq_region', 'coord_system','xref'],
   PER_DB         => 1,
 };
 
@@ -53,13 +53,15 @@ sub shared_display_xref {
   my ($self, $dba, $table) = @_;
 
   my $desc = "No Protein coding $table display_xref shared between species inside a collection database";
-  my $diag = "Protein coding $table display_xref shared between species inside a collection database";
+  my $diag = "Xref accession";
   my $sql  = qq/
     SELECT x.dbprimary_acc FROM
       xref x JOIN 
-      $table tb on (tb.display_xref_id=x.xref_id AND tb.biotype='protein_coding') JOIN
+      $table tb ON tb.display_xref_id=x.xref_id JOIN
       seq_region sr USING (seq_region_id) JOIN
-      coord_system cs USING (coord_system_id) 
+      coord_system cs USING (coord_system_id)
+    WHERE
+      tb.biotype='protein_coding'
     GROUP BY x.dbprimary_acc
     HAVING COUNT(DISTINCT (cs.species_id)) > 1
   /;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SharedDisplayXref.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SharedDisplayXref.pm
@@ -1,0 +1,70 @@
+=head1 LICENSE
+
+Copyright [2018-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::SharedDisplayXref;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'SharedDisplayXref',
+  DESCRIPTION    => 'Protein coding Gene/Transcript display_xref are not shared between species inside a collection. This can lead to species-specific synonyms being applied to the wrong species',
+  GROUPS         => ['xref'],
+  DB_TYPES       => ['core'],
+  TABLES         => ['gene', 'transcript', 'seq_region', 'coord_system'],
+  PER_DB         => 1,
+};
+
+sub tests {
+  my ($self) = @_;
+
+    SKIP: {
+    my $dba = $self->dba();
+
+    skip 'This test only applies to collection databases', 1 unless $dba->is_multispecies;
+
+    $self->shared_display_xref($dba,'gene');
+    $self->shared_display_xref($dba,'transcript');
+  }
+}
+
+sub shared_display_xref {
+  my ($self, $dba, $table) = @_;
+
+  my $desc = "No Protein coding $table display_xref shared between species inside a collection database";
+  my $diag = "Protein coding $table display_xref shared between species inside a collection database";
+  my $sql  = qq/
+    SELECT x.dbprimary_acc FROM
+      xref x JOIN 
+      $table tb on (tb.display_xref_id=x.xref_id AND tb.biotype='protein_coding') JOIN
+      seq_region sr USING (seq_region_id) JOIN
+      coord_system cs USING (coord_system_id) 
+    GROUP BY x.dbprimary_acc
+    HAVING COUNT(DISTINCT (cs.species_id)) > 1
+  /;
+
+  is_rows_zero($dba, $sql, $desc, $diag);
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SharedDisplayXref.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SharedDisplayXref.pm
@@ -29,30 +29,32 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
   NAME           => 'SharedDisplayXref',
-  DESCRIPTION    => 'Protein coding Gene/Transcript display_xref are not shared between species inside a collection. This can lead to species-specific synonyms being applied to the wrong species',
+  DESCRIPTION    => 'Protein coding gene/transcript display xrefs are not shared between species inside a collection. This can lead to species-specific synonyms being applied to the wrong species',
   GROUPS         => ['xref'],
   DB_TYPES       => ['core'],
   TABLES         => ['gene', 'transcript', 'seq_region', 'coord_system','xref'],
   PER_DB         => 1,
 };
 
+sub skip_tests {
+  my ($self) = @_;
+
+  if (! $self->dba->is_multispecies) {
+    return (1, 'Only applies to collection databases.');
+  }
+}
+
 sub tests {
   my ($self) = @_;
 
-    SKIP: {
-    my $dba = $self->dba();
-
-    skip 'This test only applies to collection databases', 1 unless $dba->is_multispecies;
-
-    $self->shared_display_xref($dba,'gene');
-    $self->shared_display_xref($dba,'transcript');
-  }
+  $self->shared_display_xref($self->dba,'gene');
+  $self->shared_display_xref($self->dba,'transcript');
 }
 
 sub shared_display_xref {
   my ($self, $dba, $table) = @_;
 
-  my $desc = "No Protein coding $table display_xref shared between species inside a collection database";
+  my $desc = "No protein-coding $table display xrefs shared between species";
   my $diag = "Xref accession";
   my $sql  = qq/
     SELECT x.dbprimary_acc FROM

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1245,6 +1245,15 @@
       "name" : "TranscriptBounds",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::TranscriptBounds"
    },
+   "TranscriptDisplayXrefSuffix" : {
+      "datacheck_type" : "critical",
+      "description" : "Transcript do not have a display xref with a -20* suffix. These are created by the non-vert Xref pipeline unless a flag is enabled: http://www.ebi.ac.uk/seqdb/confluence/display/EnsGen/Xref+mapping#Xrefmapping-CustomisingXrefMapping(DisplayXrefs)",
+      "groups" : [
+         "xref"
+      ],
+      "name" : "TranscriptDisplayXrefSuffix",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::TranscriptDisplayXrefSuffix"
+   },
    "TranscriptVariation" : {
       "datacheck_type" : "critical",
       "description" : "TranscriptVariation data is present and correct",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1158,6 +1158,15 @@
       "name" : "SequenceLevel",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SequenceLevel"
    },
+   "SharedDisplayXref" : {
+      "datacheck_type" : "critical",
+      "description" : "Protein coding Gene/Transcript display_xref are not shared between species inside a collection. This can lead to species-specific synonyms being applied to the wrong species",
+      "groups" : [
+         "xref"
+      ],
+      "name" : "SharedDisplayXref",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SharedDisplayXref"
+   },
    "SignalControlMismatches" : {
       "datacheck_type" : "critical",
       "description" : "Checks that signals are not matched to the wrong controls.",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1160,7 +1160,7 @@
    },
    "SharedDisplayXref" : {
       "datacheck_type" : "critical",
-      "description" : "Protein coding Gene/Transcript display_xref are not shared between species inside a collection. This can lead to species-specific synonyms being applied to the wrong species",
+      "description" : "Protein coding gene/transcript display xrefs are not shared between species inside a collection. This can lead to species-specific synonyms being applied to the wrong species",
       "groups" : [
          "xref"
       ],

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1245,15 +1245,6 @@
       "name" : "TranscriptBounds",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::TranscriptBounds"
    },
-   "TranscriptDisplayXrefSuffix" : {
-      "datacheck_type" : "critical",
-      "description" : "Transcript do not have a display xref with a -20* suffix. These are created by the non-vert Xref pipeline unless a flag is enabled: http://www.ebi.ac.uk/seqdb/confluence/display/EnsGen/Xref+mapping#Xrefmapping-CustomisingXrefMapping(DisplayXrefs)",
-      "groups" : [
-         "xref"
-      ],
-      "name" : "TranscriptDisplayXrefSuffix",
-      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::TranscriptDisplayXrefSuffix"
-   },
    "TranscriptVariation" : {
       "datacheck_type" : "critical",
       "description" : "TranscriptVariation data is present and correct",


### PR DESCRIPTION
…ing genes which are sharing the same display_xref_id. I extended the test to protein coding transcript too as I think it's relevant. It looks like this test only apply to protein coding gene/transcript, when extending to all genes/transcripts I do get back objects with shared display_xref_id but I don't know the reason behind it.