### PR TITLE
New translation/protein feature checks

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ProteinFeatureLength.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ProteinFeatureLength.pm
@@ -1,0 +1,60 @@
+=head1 LICENSE
+
+Copyright [2018-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::ProteinFeatureLength;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'ProteinFeatureLength',
+  DESCRIPTION => 'Protein features do not extend beyond the bounds of the translated sequence',
+  GROUPS      => ['protein_features'],
+  DB_TYPES    => ['core'],
+  TABLES      => ['analysis', 'coord_system', 'interpro', 'protein_feature', 'seq_region', 'transcript', 'translation'],
+  PER_DB      => 1
+};
+
+sub tests {
+  my ($self) = @_;
+
+  # We can assume every translation has a NumResidues attribute,
+  # because that is tested by the PepstatsAttributes datacheck.
+  my $desc = 'Protein features do not extend beyond the translation';
+  my $diag = 'Hit name, translation_id';
+  my $sql  = qq/
+    SELECT
+      hit_name, translation_id
+    FROM
+      protein_feature INNER JOIN
+      translation_attrib USING (translation_id) INNER JOIN
+      attrib_type USING (attrib_type_id)
+    WHERE
+      code = 'NumResidues' AND
+      value < seq_end
+  /;
+  is_rows_zero($self->dba, $sql, $desc, $diag);
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ProteinFeatures.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ProteinFeatures.pm
@@ -56,7 +56,8 @@ sub tests {
 
   my $sql = qq/
     SELECT COUNT(*) FROM
-      protein_feature INNER JOIN
+      analysis INNER JOIN
+      protein_feature USING (analysis_id) INNER JOIN
       translation USING (translation_id) INNER JOIN
       transcript USING (transcript_id) INNER JOIN
       seq_region USING (seq_region_id) INNER JOIN
@@ -76,6 +77,28 @@ sub tests {
   my $desc_4 = 'Protein feature seq start > 0';
   my $sql_4  = $sql.' AND protein_feature.seq_start < 1';
   is_rows_zero($self->dba, $sql_4, $desc_4);
+
+  my $desc_5 = 'protein feature accessions have correct format';
+  my %format = (
+    cdd =>         '^cd[[:digit:]]{5}',
+    gene3d =>      '^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+',
+    hamap =>       '^MF\_[[:digit:]]{5}',
+    hmmpanther =>  '^PTHR[[:digit:]]{5}',
+    pfam =>        '^PF[[:digit:]]{5}',
+    pfscan =>      '^PS[[:digit:]]{5}',
+    pirsf =>       '^PIRSF[[:digit:]]{6}',
+    prints =>      '^PR[[:digit:]]{5}',
+    scanprosite => '^PS[[:digit:]]{5}',
+    sfld =>        '^SFLD[FGS][[:digit:]]{5}',
+    smart =>       '^SM[[:digit:]]{5}',
+    superfamily => '^SSF[[:digit:]]{5}',
+    tigrfam =>     '^TIGR[[:digit:]]{5}',
+  );
+  foreach my $source (sort keys %format) {
+    my $regexp = $format{$source};
+    my $sql_5 = $sql." AND logic_name = '$source' AND hit_name NOT REGEXP '$regexp'";
+    is_rows_zero($self->dba, $sql_5, "$source $desc_5");
+  }
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ValidTranslations.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ValidTranslations.pm
@@ -127,6 +127,25 @@ sub tests {
       cs.species_id = $species_id
   /;
   is_rows_zero($self->dba, $sql_6, $desc_6, $diag_6);
+
+  # The non_translating_CDS biotype is a bit odd; it is classed as
+  # protein-coding, because the originating annotator says it is.
+  # But for whatever reason it does not have a valid translation,
+  # and we don't want to give the impression it does, or have it
+  # processed by, for example, compara.
+  my $desc_7 = 'Non-translating CDS transcripts do not have translations';
+  my $diag_7 = "Transcript";
+  my $sql_7  = qq/
+    SELECT t.stable_id FROM
+  	  transcript t INNER JOIN
+      translation tn USING (transcript_id) INNER JOIN
+      seq_region sr ON t.seq_region_id = sr.seq_region_id INNER JOIN
+      coord_system cs USING (coord_system_id)
+  WHERE
+      t.biotype = 'nontranslating_CDS' AND
+      cs.species_id = $species_id
+  /;
+  is_rows_zero($self->dba, $sql_7, $desc_7, $diag_7);
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -994,6 +994,15 @@
       "name" : "ProteinCodingGenes",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ProteinCodingGenes"
    },
+   "ProteinFeatureLength" : {
+      "datacheck_type" : "critical",
+      "description" : "Protein features do not extend beyond the bounds of the translated sequence",
+      "groups" : [
+         "protein_features"
+      ],
+      "name" : "ProteinFeatureLength",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ProteinFeatureLength"
+   },
    "ProteinFeatures" : {
       "datacheck_type" : "critical",
       "description" : "Protein features are present and correct",


### PR DESCRIPTION
New checks for:
- proteins labelled as non-translating that nonetheless have a translation.
- protein feature accession formats (replicates and extends functionality of HC generic.Accession)
- protein features are not longer than the associated translation (replicates functionality of ProteinFeatureTranslation and EgProteinFeatureTranslation)

