### PR TITLE
Update to multiple region update

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MultipleSeqRegions.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MultipleSeqRegions.pm
@@ -32,7 +32,7 @@ use constant {
   DESCRIPTION => 'Tables have multiple seq regions',
   GROUPS      => ['variation'],
   DB_TYPES    => ['variation'],
-  TABLES      => ['phenotype_feature', 'structural_variation_feature', 'variation_feature']
+  TABLES      => ['structural_variation_feature', 'variation_feature']
 };
 
 sub tests {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/PhenotypeMultipleSeqRegions.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/PhenotypeMultipleSeqRegions.pm
@@ -1,0 +1,62 @@
+=head1 LICENSE
+
+Copyright [2018-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::PhenotypeMultipleSeqRegions;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'PhenotypeMultipleSeqRegions',
+  DESCRIPTION => 'Phenotypes on multiple seq regions',
+  GROUPS      => ['variation'],
+  DB_TYPES    => ['variation'],
+  TABLES      => ['phenotype_feature']
+};
+
+sub skip_tests {
+  my ($self) = @_;
+
+  my $dna_dba = $self->get_dna_dba();
+  my $mca = $dna_dba->get_adaptor("MetaContainer");
+  my $division = $mca->get_division;
+
+  if ($division ne 'EnsemblVertebrates') {
+    return (1, "$division can have phenotypes on single seq region");
+  }
+}
+
+sub tests {
+  my ($self) = @_;
+  
+  my $table = 'phenotype_feature';
+  my $desc = "Table $table does not have 1 distinct seq region id";
+  my $sql  = qq/
+    SELECT COUNT(DISTINCT seq_region_id)
+    FROM $table
+  /;
+  cmp_rows($self->dba, $sql, '!=', 1, $desc);
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -213,16 +213,6 @@
       "name" : "ComparePhenotypeFeatures",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ComparePhenotypeFeatures"
    },
-   "CompareProjectedGeneNames" : {
-      "datacheck_type" : "advisory",
-      "description" : "Compare Projected Gene Name counts between two databases",
-      "groups" : [
-         "compare_core",
-         "xref"
-      ],
-      "name" : "CompareProjectedGeneNames",
-      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareProjectedGeneNames"
-   },
    "CompareProjectedGOXrefs" : {
       "datacheck_type" : "advisory",
       "description" : "Compare GO xref counts between two databases, categorised by source coming from the info_type",
@@ -232,6 +222,16 @@
       ],
       "name" : "CompareProjectedGOXrefs",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareProjectedGOXrefs"
+   },
+   "CompareProjectedGeneNames" : {
+      "datacheck_type" : "advisory",
+      "description" : "Compare Projected Gene Name counts between two databases",
+      "groups" : [
+         "compare_core",
+         "xref"
+      ],
+      "name" : "CompareProjectedGeneNames",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareProjectedGeneNames"
    },
    "CompareProjectedSynonyms" : {
       "datacheck_type" : "advisory",
@@ -983,6 +983,15 @@
       ],
       "name" : "PhenotypeFeatureAttrib",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::PhenotypeFeatureAttrib"
+   },
+   "PhenotypeMultipleSeqRegions" : {
+      "datacheck_type" : "critical",
+      "description" : "Phenotypes on multiple seq regions",
+      "groups" : [
+         "variation"
+      ],
+      "name" : "PhenotypeMultipleSeqRegions",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::PhenotypeMultipleSeqRegions"
    },
    "PolyploidAttribs" : {
       "datacheck_type" : "critical",


### PR DESCRIPTION
The check that phenotype_feature does not have a single seq region was failing for some metazoa databases. The has been made a separate check and only for vertebrate database