### PR TITLE
Set Ensembl release version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,13 @@ addons:
     - graphviz
 
 before_install:
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
+    - export ENSEMBL_BRANCH=release/99
+    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl.git
+    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
     - git clone --branch version/2.5 --depth 1 https://github.com/Ensembl/ensembl-hive.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-metadata.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-test.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-variation.git
+    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-metadata.git
+    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-test.git
+    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-variation.git
     - wget https://github.com/bioperl/bioperl-live/archive/release-1-6-924.zip
     - unzip release-1-6-924.zip
 

--- a/t/test-genome-DBs/homo_sapiens/variation/meta.txt
+++ b/t/test-genome-DBs/homo_sapiens/variation/meta.txt
@@ -13,3 +13,5 @@
 30	\N	patch	patch_96_97_c.sql|add an unique index on the name column
 31	\N	patch	patch_97_98_a.sql|schema version
 32	\N	patch	patch_98_99_a.sql|schema version
+33	\N	patch	patch_98_99_b.sql|Add the column data_source_attrib in the table variation_citation
+34	\N	patch	patch_98_99_c.sql|Increase the size of the title and doi columns in the publication table

--- a/t/test-genome-DBs/homo_sapiens/variation/table.sql
+++ b/t/test-genome-DBs/homo_sapiens/variation/table.sql
@@ -186,7 +186,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=33 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=35 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,
@@ -324,12 +324,12 @@ CREATE TABLE `protein_function_predictions_attrib` (
 
 CREATE TABLE `publication` (
   `publication_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `title` varchar(255) DEFAULT NULL,
+  `title` varchar(300) DEFAULT NULL,
   `authors` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
   `pmid` int(10) DEFAULT NULL,
   `pmcid` varchar(255) DEFAULT NULL,
   `year` int(10) unsigned DEFAULT NULL,
-  `doi` varchar(50) DEFAULT NULL,
+  `doi` varchar(80) DEFAULT NULL,
   `ucsc_id` varchar(50) DEFAULT NULL,
   PRIMARY KEY (`publication_id`),
   KEY `pmid_idx` (`pmid`),
@@ -601,6 +601,7 @@ CREATE TABLE `variation_attrib` (
 CREATE TABLE `variation_citation` (
   `variation_id` int(10) unsigned NOT NULL,
   `publication_id` int(10) unsigned NOT NULL,
+  `data_source_attrib` set('610','611','612') DEFAULT NULL,
   PRIMARY KEY (`variation_id`,`publication_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 


### PR DESCRIPTION
So that appropriate versions of the Ensembl repos are checked out.
The tests are failing because travis is currently checking out `master`, which has a variation schema change that introduces a discrepancy between the database (release 99) and code (release 100).
Something like the code in the ensembl-production `.travis.yml`, to pick up the `TRAVIS_BRANCH` and use that, doesn't work in this case, because candidate branches in PRs do not have the release number, and so still end up using `master`. It probably easier just to include an update to this variable in the SOP for branching at the start of a release.