### PR TITLE
Fix for embedded datacheck output

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/Example_conf.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/Example_conf.pm
@@ -141,6 +141,26 @@ sub pipeline_analyses {
                               failures_fatal     => $self->o('failures_fatal'),
                             },
       -rc_name           => 'default',
+      -flow_into         => {
+                              '1' => ['AllJobs'],
+                              '3' => ['PassedJobs'],
+                              '4' => ['FailedJobs'],
+                            },
+    },
+
+    {
+      -logic_name        => 'AllJobs',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+    },
+
+    {
+      -logic_name        => 'PassedJobs',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+    },
+
+    {
+      -logic_name        => 'FailedJobs',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
     },
 
     {

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/RunDataChecks.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/RunDataChecks.pm
@@ -158,10 +158,17 @@ sub write_output {
 
   $self->dataflow_output_id($summary, 1);
 
-  foreach my $datacheck ( @{$self->param('datachecks')} ) { 
+  foreach my $datacheck ( @{$self->param('datachecks')} ) {
+    # It's not possible to pass the dba parameter to another module;
+    # we have to delete it otherwise it causes errors. But it's
+    # very useful for diagnostics to have some db information.
+    my $output_params = $self->param('datacheck_params');
+    $$output_params{'dba_params'} = $$output_params{'dba'}->to_hash;
+    delete $$output_params{'dba'};
+
     my $output = {
       datacheck_name   => $datacheck->name,
-      datacheck_params => $self->param('datacheck_params'),
+      datacheck_params => $output_params,
       datacheck_output => $datacheck->output,
     };
 


### PR DESCRIPTION
Cannot pass DBA object from one hive module to another, but the database parameters are still useful for diagnostics, so pass them as a hash instead.