### PR TITLE
New module to send an email for a failed Datcheck with datacheck name…

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/EmailNotify.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/EmailNotify.pm
@@ -31,14 +31,18 @@ use base ('Bio::EnsEMBL::Hive::RunnableDB::NotifyByEmail');
 
 sub fetch_input {
   my $self = shift;
-  my $datacheck_name       = $self->param('datacheck_name');
-  my $datacheck_output       = $self->param('datacheck_output');
-  my $datacheck_params       = $self->param('datacheck_params');
+  my $datacheck_name   = $self->param('datacheck_name');
+  my $datacheck_output = $self->param('datacheck_output');
+  my $datacheck_params = $self->param('datacheck_params');
+  my $pipeline_name    = $self->param('pipeline_name');
+
   my $dbname = $datacheck_params->{dba_params}->{-DBNAME};
+
   my $subject = "FAILED: Datacheck $datacheck_name for $dbname";
   $self->param('subject', $subject);
   my $text =
-    "Datacheck $datacheck_name failed for $dbname. See full output below: \n $datacheck_output";
+    "Datacheck $datacheck_name failed for $dbname in $pipeline_name pipeline.".
+    "See full output below: \n $datacheck_output";
   $self->param('text', $text);
 }
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/EmailNotify.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/EmailNotify.pm
@@ -1,0 +1,44 @@
+=head1 LICENSE
+Copyright [2018-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+Bio::EnsEMBL::DataCheck::Pipeline::EmailNotify
+
+=head1 DESCRIPTION
+Send an email with the failed datacheck name, database name and the full output
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Pipeline::EmailNotify;
+
+use strict;
+use warnings;
+use feature 'say';
+
+use base ('Bio::EnsEMBL::Hive::RunnableDB::NotifyByEmail');
+
+sub fetch_input {
+  my $self = shift;
+  my $datacheck_name       = $self->param('datacheck_name');
+  my $datacheck_output       = $self->param('datacheck_output');
+  my $datacheck_params       = $self->param('datacheck_params');
+  my $dbname = $datacheck_params->{dba_params}->{-DBNAME};
+  my $subject = "FAILED: Datacheck $datacheck_name for $dbname";
+  $self->param('subject', $subject);
+  my $text =
+    "Datacheck $datacheck_name failed for $dbname. See full output below: \n $datacheck_output";
+  $self->param('text', $text);
+}
+1;


### PR DESCRIPTION
…, database name and full output

See email example below:

```
From: maurel@ebi.ac.uk
Subject: FAILED: Datacheck MetaKeyAssembly for zea_mays_core_45_98_7
Date: 23 September 2019 at 15:02:48 BST
To: maurel@ebi.ac.uk

Datacheck MetaKeyAssembly failed for zea_mays_core_45_98_7. See full output below: 
# Subtest: MetaKeyAssembly
   # Subtest: zea_mays
       ok 1 - Assembly name matches in coord_system and meta tables
       ok 2 - Assembly mapping(s) exists
       ok 3 - Assembly mapping has correct format ('chromosome:B73_RefGen_v4' part of 'chromosome:B73_RefGen_v4|contig:B73_RefGen_v4')
       ok 4 - Assembly mapping has valid coordinate system (chromosome)
       ok 5 - Assembly mapping has correct format ('contig:B73_RefGen_v4' part of 'chromosome:B73_RefGen_v4|contig:B73_RefGen_v4')
       ok 6 - Assembly mapping has valid coordinate system (contig)
       ok 7 - Assembly mapping has correct format ('contig:B73_RefGen_v4' part of 'contig:B73_RefGen_v4\#chromosome:AGPv3')
       ok 8 - Assembly mapping has valid coordinate system (contig)
       ok 9 - Assembly mapping has correct format ('chromosome:AGPv3' part of 'contig:B73_RefGen_v4\#chromosome:AGPv3')
       ok 10 - Assembly mapping has valid coordinate system (chromosome)
       ok 11 - Assembly mapping has correct format ('chromosome:B73_RefGen_v4' part of 'chromosome:B73_RefGen_v4\#chromosome:AGPv3')
       ok 12 - Assembly mapping has valid coordinate system (chromosome)
       ok 13 - Assembly mapping has correct format ('chromosome:AGPv3' part of 'chromosome:B73_RefGen_v4\#chromosome:AGPv3')
       ok 14 - Assembly mapping has valid coordinate system (chromosome)
       ok 15 - Assembly mapping has correct format ('contig:B73_RefGen_v4' part of 'contig:B73_RefGen_v4\#scaffold:AGPv3')
       ok 16 - Assembly mapping has valid coordinate system (contig)
       ok 17 - Assembly mapping has correct format ('scaffold:AGPv3' part of 'contig:B73_RefGen_v4\#scaffold:AGPv3')
       ok 18 - Assembly mapping has valid coordinate system (scaffold)
       ok 19 - Assembly mapping has correct format ('chromosome:B73_RefGen_v4' part of 'chromosome:B73_RefGen_v4\#scaffold:AGPv3')
       ok 20 - Assembly mapping has valid coordinate system (chromosome)
       ok 21 - Assembly mapping has correct format ('scaffold:AGPv3' part of 'chromosome:B73_RefGen_v4\#scaffold:AGPv3')
       ok 22 - Assembly mapping has valid coordinate system (scaffold)
       ok 23 - Assembly mapping has correct format ('contig:B73_RefGen_v4' part of 'contig:B73_RefGen_v4\#chromosome:AGPv2')
       ok 24 - Assembly mapping has valid coordinate system (contig)
       ok 25 - Assembly mapping has correct format ('chromosome:AGPv2' part of 'contig:B73_RefGen_v4\#chromosome:AGPv2')
       ok 26 - Assembly mapping has valid coordinate system (chromosome)
       ok 27 - Assembly mapping has correct format ('chromosome:B73_RefGen_v4' part of 'chromosome:B73_RefGen_v4\#chromosome:AGPv2')
       ok 28 - Assembly mapping has valid coordinate system (chromosome)
       ok 29 - Assembly mapping has correct format ('chromosome:AGPv2' part of 'chromosome:B73_RefGen_v4\#chromosome:AGPv2')
       ok 30 - Assembly mapping has valid coordinate system (chromosome)
       ok 31 - Assembly mapping has correct format ('chromosome:AGPv3' part of 'chromosome:AGPv3\#chromosome:AGPv2')
       ok 32 - Assembly mapping has valid coordinate system (chromosome)
       ok 33 - Assembly mapping has correct format ('chromosome:AGPv2' part of 'chromosome:AGPv3\#chromosome:AGPv2')
       ok 34 - Assembly mapping has valid coordinate system (chromosome)
       ok 35 - Assembly mapping has correct format ('scaffold:AGPv3' part of 'scaffold:AGPv3\#chromosome:AGPv2')
       ok 36 - Assembly mapping has valid coordinate system (scaffold)
       ok 37 - Assembly mapping has correct format ('chromosome:AGPv2' part of 'scaffold:AGPv3\#chromosome:AGPv2')
       ok 38 - Assembly mapping has valid coordinate system (chromosome)
       ok 39 - Assembly mapping has corresponding meta key (chromosome:B73_RefGen_v4\#contig:B73_RefGen_v4)
       ok 40 - Liftover mapping(s) exists
       ok 41 - Liftover mapping has correct format ('contig:B73_RefGen_v4' part of 'contig:B73_RefGen_v4\#chromosome:AGPv3')
       ok 42 - Liftover mapping has valid coordinate system (contig)
       ok 43 - Liftover mapping has correct format ('chromosome:AGPv3' part of 'contig:B73_RefGen_v4\#chromosome:AGPv3')
       ok 44 - Liftover mapping has valid coordinate system (chromosome)
       ok 45 - Liftover mapping has correct format ('chromosome:B73_RefGen_v4' part of 'chromosome:B73_RefGen_v4\#chromosome:AGPv3')
       ok 46 - Liftover mapping has valid coordinate system (chromosome)
       ok 47 - Liftover mapping has correct format ('chromosome:AGPv3' part of 'chromosome:B73_RefGen_v4\#chromosome:AGPv3')
       ok 48 - Liftover mapping has valid coordinate system (chromosome)
       ok 49 - Liftover mapping has correct format ('contig:AGPv4' part of 'contig:AGPv4\#scaffold:AGPv3')
       not ok 50 - Liftover mapping has valid coordinate system (contig)

       #   Failed test 'Liftover mapping has valid coordinate system (contig)'
       #   at /homes/maurel/work/ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyAssembly.pm line 122.
       ok 51 - Liftover mapping has correct format ('scaffold:AGPv3' part of 'contig:AGPv4\#scaffold:AGPv3')
       ok 52 - Liftover mapping has valid coordinate system (scaffold)
       ok 53 - Liftover mapping has correct format ('chromosome:B73_RefGen_v4' part of 'chromosome:B73_RefGen_v4\#scaffold:AGPv3')
       ok 54 - Liftover mapping has valid coordinate system (chromosome)
       ok 55 - Liftover mapping has correct format ('scaffold:AGPv3' part of 'chromosome:B73_RefGen_v4\#scaffold:AGPv3')
       ok 56 - Liftover mapping has valid coordinate system (scaffold)
       ok 57 - Liftover mapping has correct format ('contig:AGPv4' part of 'contig:AGPv4\#chromosome:AGPv2')
       not ok 58 - Liftover mapping has valid coordinate system (contig)

       #   Failed test 'Liftover mapping has valid coordinate system (contig)'
       #   at /homes/maurel/work/ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyAssembly.pm line 122.
       ok 59 - Liftover mapping has correct format ('chromosome:AGPv2' part of 'contig:AGPv4\#chromosome:AGPv2')
       ok 60 - Liftover mapping has valid coordinate system (chromosome)
       ok 61 - Liftover mapping has correct format ('chromosome:B73_RefGen_v4' part of 'chromosome:B73_RefGen_v4\#chromosome:AGPv2')
       ok 62 - Liftover mapping has valid coordinate system (chromosome)
       ok 63 - Liftover mapping has correct format ('chromosome:AGPv2' part of 'chromosome:B73_RefGen_v4\#chromosome:AGPv2')
       ok 64 - Liftover mapping has valid coordinate system (chromosome)
       ok 65 - Liftover mapping has correct format ('chromosome:AGPv3' part of 'chromosome:AGPv3\#chromosome:AGPv2')
       ok 66 - Liftover mapping has valid coordinate system (chromosome)
       ok 67 - Liftover mapping has correct format ('chromosome:AGPv2' part of 'chromosome:AGPv3\#chromosome:AGPv2')
       ok 68 - Liftover mapping has valid coordinate system (chromosome)
       ok 69 - Liftover mapping has correct format ('scaffold:AGPv3' part of 'scaffold:AGPv3\#chromosome:AGPv2')
       ok 70 - Liftover mapping has valid coordinate system (scaffold)
       ok 71 - Liftover mapping has correct format ('chromosome:AGPv2' part of 'scaffold:AGPv3\#chromosome:AGPv2')
       ok 72 - Liftover mapping has valid coordinate system (chromosome)
       ok 73 - Liftover mapping has corresponding meta key (chromosome:AGPv3\#chromosome:AGPv2)
       ok 74 - Liftover mapping has corresponding meta key (chromosome:B73_RefGen_v4\#chromosome:AGPv2)
       ok 75 - Liftover mapping has corresponding meta key (chromosome:B73_RefGen_v4\#chromosome:AGPv3)
       ok 76 - Liftover mapping has corresponding meta key (chromosome:B73_RefGen_v4\#scaffold:AGPv3)
       not ok 77 - Liftover mapping has corresponding meta key (contig:B73_RefGen_v4\#chromosome:AGPv2)

       #   Failed test 'Liftover mapping has corresponding meta key (contig:B73_RefGen_v4#chromosome:AGPv2)'
       #   at /homes/maurel/work/ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyAssembly.pm line 166.
       ok 78 - Liftover mapping has corresponding meta key (contig:B73_RefGen_v4\#chromosome:AGPv3)
       not ok 79 - Liftover mapping has corresponding meta key (contig:B73_RefGen_v4\#scaffold:AGPv3)

       #   Failed test 'Liftover mapping has corresponding meta key (contig:B73_RefGen_v4#scaffold:AGPv3)'
       #   at /homes/maurel/work/ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyAssembly.pm line 166.
       ok 80 - Liftover mapping has corresponding meta key (scaffold:AGPv3\#chromosome:AGPv2)
       1..80
       # Looks like you failed 4 tests of 80.
   not ok 1 - zea_mays

   #   Failed test 'zea_mays'
   #   at /homes/maurel/work/ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm line 500.
   1..1
   # Looks like you failed 1 test of 1.
not ok 1 - MetaKeyAssembly

#   Failed test 'MetaKeyAssembly'
#   at /homes/maurel/work/ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/BaseCheck.pm line 166.
1..1
```