### PR TITLE
Release/99

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CigarCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CigarCheck.pm
@@ -29,10 +29,10 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CigarCheck',
   DESCRIPTION    => 'The cigar_line must not have negative numbers or zeros in it',
-  DATACHECK_TYPE => 'advisory',
+  GROUPS        => ['compara', 'compara_pairwise_alignments'],
+  DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['family_member', 'gene_align_member', 'genomic_align', 'homology_member', 'peptide_align_feature'],
-  PER_DB         => 0
 };
 
 sub tests {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CigarCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CigarCheck.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CigarCheck',
   DESCRIPTION    => 'The cigar_line must not have negative numbers or zeros in it',
-  GROUPS        => ['compara', 'compara_pairwise_alignments'],
+  GROUPS         => ['compara', 'compara_pairwise_alignments'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['family_member', 'gene_align_member', 'genomic_align', 'homology_member', 'peptide_align_feature'],

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CigarCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CigarCheck.pm
@@ -1,0 +1,82 @@
+=head1 LICENSE
+
+Copyright [2018-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::CigarCheck;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'CigarCheck',
+  DESCRIPTION    => 'The cigar_line must not have negative numbers or zeros in it',
+  DATACHECK_TYPE => 'advisory',
+  DB_TYPES       => ['compara'],
+  TABLES         => ['family_member', 'gene_align_member', 'genomic_align', 'homology_member', 'peptide_align_feature'],
+  PER_DB         => 0
+};
+
+sub tests {
+  my ($self) = @_;
+
+  my @cigar_tables = ('family_member', 'gene_align_member', 'genomic_align', 'homology_member', 'peptide_align_feature');
+  foreach my $table (@cigar_tables) {
+
+    my $desc = "Column $table.cigar_line has no negative values";
+    my $sql_2 = qq/
+      SELECT COUNT(*) FROM
+        $table
+      WHERE
+        cigar_line LIKE '%-%'
+    /;
+    if ($table eq "gene_align_member") {
+      $sql_2 = qq/
+      SELECT COUNT(*) FROM
+        gene_align_member g INNER JOIN
+        gene_align a ON a.gene_align_id=g.gene_align_id
+      WHERE NOT aln_method="mcoffee_score" AND
+        cigar_line LIKE '%-%'
+      /;
+    }
+    is_rows_zero($self->dba, $sql_2, $desc);
+
+    my $desc_2 = "Column $table.cigar_line does not contain a zero";
+    my $sql_3 = qq/
+      SELECT COUNT(*) FROM
+        $table
+      WHERE
+        (cigar_line REGEXP '^[0]' OR cigar_line REGEXP '[A-Z][0]')
+    /;
+    if ($table eq "gene_align_member") {
+      $sql_2 = qq/
+      SELECT COUNT(*) FROM
+        gene_align_member g INNER JOIN
+        gene_align a ON a.gene_align_id=g.gene_align_id
+      WHERE NOT aln_method="mcoffee_score" AND
+        (cigar_line REGEXP '^[0]' OR cigar_line REGEXP '[A-Z][0]')
+      /;
+    }
+    is_rows_zero($self->dba, $sql_3, $desc_2);
+
+  }
+}
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/TagCoverageStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/TagCoverageStats.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'TagCoverageStats',
   DESCRIPTION    => 'The coverage must not exceed the genome lengths',
-  GROUPS        => ['compara', 'compara_pairwise_alignments'],
+  GROUPS         => ['compara', 'compara_pairwise_alignments'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['method_link_species_set_tag', 'species_tree_node_tag'],

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/TagCoverageStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/TagCoverageStats.pm
@@ -1,0 +1,146 @@
+=head1 LICENSE
+
+Copyright [2018-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::TagCoverageStats;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'TagCoverageStats',
+  DESCRIPTION    => 'The coverage must not exceed the genome lengths',
+  DATACHECK_TYPE => 'advisory',
+  DB_TYPES       => ['compara'],
+  TABLES         => ['method_link_species_set_tag', 'species_tree_node_tag'],
+  PER_DB         => 0
+};
+
+sub tests {
+  my ($self) = @_;
+
+  my $desc_1 = "Table method_link_species_set_tag: ref_genome_coverage <= ref_genome_length";
+  my $sql_1 = q/
+  SELECT COUNT(*) FROM method_link_species_set_tag coverage
+    INNER JOIN method_link_species_set_tag length
+      ON coverage.method_link_species_set_id=length.method_link_species_set_id
+  WHERE coverage.tag="ref_genome_coverage"
+    AND length.tag="ref_genome_length" AND
+    CAST(coverage.value AS SIGNED) > CAST(length.value AS SIGNED);
+  /;
+  is_rows_zero($self->dba, $sql_1, $desc_1);
+  my $desc_2 = "Table method_link_species_set_tag: (ref_matches+ref_mis_matches+ref_insertions) <= (ref_coding_exon_length - ref_uncovered)";
+  my $sql_2 = q/
+  SELECT COUNT(*) FROM method_link_species_set_tag matches
+    INNER JOIN method_link_species_set_tag mis
+      ON matches.method_link_species_set_id=mis.method_link_species_set_id
+    INNER JOIN method_link_species_set_tag ins
+      ON mis.method_link_species_set_id=ins.method_link_species_set_id
+    INNER JOIN method_link_species_set_tag exon
+      ON ins.method_link_species_set_id=exon.method_link_species_set_id
+    INNER JOIN method_link_species_set_tag unc
+      ON exon.method_link_species_set_id=unc.method_link_species_set_id
+  WHERE matches.tag="ref_matches"
+    AND mis.tag="ref_mis_matches"
+    AND ins.tag="ref_insertions"
+    AND exon.tag="ref_coding_exon_length"
+    AND unc.tag="ref_uncovered"
+    AND ((CAST(matches.value AS SIGNED) + CAST(mis.value AS SIGNED) + CAST(ins.value AS SIGNED)) > (CAST(exon.value AS SIGNED) - CAST(unc.value AS SIGNED)));
+  /;
+  is_rows_zero($self->dba, $sql_2, $desc_2);
+  my $desc_3 = "Table method_link_species_set_tag: ref_covered <= (ref_coding_length - ref_uncovered)";
+  my $sql_3 = q/
+  SELECT COUNT(*) FROM method_link_species_set_tag cov
+    INNER JOIN method_link_species_set_tag exon
+      ON cov.method_link_species_set_id=exon.method_link_species_set_id
+    INNER JOIN method_link_species_set_tag unc
+      ON exon.method_link_species_set_id=unc.method_link_species_set_id
+  WHERE cov.tag="ref_covered"
+    AND exon.tag="ref_coding_exon_length"
+    AND unc.tag="ref_uncovered"
+    AND CAST(cov.value AS SIGNED) > (CAST(exon.value AS SIGNED) - CAST(unc.value AS SIGNED));
+  /;
+  is_rows_zero($self->dba, $sql_3, $desc_3);
+  my $desc_4 = "Table method_link_species_set_tag: non_ref_genome_coverage <= non_ref_genome_length";
+  my $sql_4 = q/
+  SELECT COUNT(*) FROM method_link_species_set_tag coverage
+    INNER JOIN method_link_species_set_tag length
+      ON coverage.method_link_species_set_id=length.method_link_species_set_id
+  WHERE coverage.tag="non_ref_genome_coverage"
+    AND length.tag="non_ref_genome_length" AND
+    CAST(coverage.value AS SIGNED) > CAST(length.value AS SIGNED);
+  /;
+  is_rows_zero($self->dba, $sql_4, $desc_4);
+  my $desc_5 = "Table method_link_species_set_tag: (non_ref_matches+non_ref_mis_matches+non_ref_insertions) <= (non_ref_coding_exon_length - non_ref_uncovered)";
+  my $sql_5 = q/
+  SELECT COUNT(*) FROM method_link_species_set_tag matches
+    INNER JOIN method_link_species_set_tag mis
+      ON matches.method_link_species_set_id=mis.method_link_species_set_id
+    INNER JOIN method_link_species_set_tag ins
+      ON mis.method_link_species_set_id=ins.method_link_species_set_id
+    INNER JOIN method_link_species_set_tag exon
+      ON ins.method_link_species_set_id=exon.method_link_species_set_id
+    INNER JOIN method_link_species_set_tag unc
+      ON exon.method_link_species_set_id=unc.method_link_species_set_id
+  WHERE matches.tag="non_ref_matches"
+    AND mis.tag="non_ref_mis_matches"
+    AND ins.tag="non_ref_insertions"
+    AND exon.tag="non_ref_coding_exon_length"
+    AND unc.tag="non_ref_uncovered"
+    AND ((CAST(matches.value AS SIGNED) + CAST(mis.value AS SIGNED) + CAST(ins.value AS SIGNED)) > (CAST(exon.value AS SIGNED) - CAST(unc.value AS SIGNED)));
+  /;
+  is_rows_zero($self->dba, $sql_5, $desc_5);
+  my $desc_6 = "Table method_link_species_set_tag: non_ref_covered <= (non_ref_coding_length - non_ref_uncovered)";
+  my $sql_6 = q/
+  SELECT COUNT(*) FROM method_link_species_set_tag cov
+    INNER JOIN method_link_species_set_tag exon
+      ON cov.method_link_species_set_id=exon.method_link_species_set_id
+    INNER JOIN method_link_species_set_tag unc
+      ON exon.method_link_species_set_id=unc.method_link_species_set_id
+  WHERE cov.tag="non_ref_covered"
+    AND exon.tag="non_ref_coding_exon_length"
+    AND unc.tag="non_ref_uncovered"
+    AND CAST(cov.value AS SIGNED) > (CAST(exon.value AS SIGNED) - CAST(unc.value AS SIGNED));
+  /;
+  is_rows_zero($self->dba, $sql_6, $desc_6);
+  my $desc_7 = "Table species_tree_node_tag: genome_coverage <= genome_length";
+  my $sql_7 = q/
+  SELECT COUNT(*) FROM species_tree_node_tag coverage
+    INNER JOIN species_tree_node_tag length
+      ON coverage.node_id=length.node_id
+  WHERE coverage.tag="genome_coverage"
+    AND length.tag="genome_length"
+    AND (CAST(coverage.value AS SIGNED) > CAST(length.value AS SIGNED));
+  /;
+  is_rows_zero($self->dba, $sql_7, $desc_7);
+  my $desc_8 = "Table species_tree_node_tag: coding_exon_coverage <= coding_exon_length";
+  my $sql_8 = q/
+  SELECT COUNT(*) FROM species_tree_node_tag coverage
+    INNER JOIN species_tree_node_tag length
+      ON coverage.node_id=length.node_id
+  WHERE coverage.tag="coding_exon_coverage"
+    AND length.tag="coding_exon_length"
+    AND (CAST(coverage.value AS SIGNED) > CAST(length.value AS SIGNED))
+  /;
+  is_rows_zero($self->dba, $sql_8, $desc_8);
+}
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/TagCoverageStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/TagCoverageStats.pm
@@ -29,10 +29,10 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'TagCoverageStats',
   DESCRIPTION    => 'The coverage must not exceed the genome lengths',
-  DATACHECK_TYPE => 'advisory',
+  GROUPS        => ['compara', 'compara_pairwise_alignments'],
+  DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['method_link_species_set_tag', 'species_tree_node_tag'],
-  PER_DB         => 0
 };
 
 sub tests {

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -158,6 +158,16 @@
       "name" : "ChromosomesAnnotated",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ChromosomesAnnotated"
    },
+   "CigarCheck" : {
+      "datacheck_type" : "critical",
+      "description" : "The cigar_line must not have negative numbers or zeros in it",
+      "groups" : [
+         "compara",
+         "compara_pairwise_alignments"
+      ],
+      "name" : "CigarCheck",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CigarCheck"
+   },
    "CompareAllele" : {
       "datacheck_type" : "advisory",
       "description" : "Compare allele counts between two databases",
@@ -1326,6 +1336,16 @@
       ],
       "name" : "StructuralVariationFeature",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::StructuralVariationFeature"
+   },
+   "TagCoverageStats" : {
+      "datacheck_type" : "critical",
+      "description" : "The coverage must not exceed the genome lengths",
+      "groups" : [
+         "compara",
+         "compara_pairwise_alignments"
+      ],
+      "name" : "TagCoverageStats",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::TagCoverageStats"
    },
    "TranscriptBounds" : {
       "datacheck_type" : "critical",


### PR DESCRIPTION
Inclusion of two new compara-specific datacheck modules:

1. CigarCheck.pm:
- The cigar_line must not have negative numbers in it 
- The cigar_line must not have zeros in it

2. TagCoverageStats.pm
- For each method_link_species_set_id from method_link_species_set_tag:
```
ref_genome_coverage <= ref_genome_length
(ref_matches+ref_mis_matches+ref_insertions) <= (ref_coding_exon_length - ref_uncovered)
ref_covered <= (ref_coding_length - ref_uncovered)
```
- The same for the non_ref_genomes also.
- For each node_id from species_tree_node_tag:
```
genome_coverage <= genome_length
coding_exon_coverage <= coding_exon_length
```
3. Inclusion of these new modules in the index.json file