### PR TITLE
Bug correction. Test of proportion of fragment with distance to paren…

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignTreeTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignTreeTable.pm
@@ -98,7 +98,7 @@ sub tests {
     
     my $desc_3 = "Less than 1% of entries have a distance_to_parent > 1 for $mlss_id ($mlss_name)";
     
-    row_totals($dbc, undef, $sql_3, $sql_2, 0.99, $desc_3);
+    row_totals($dbc, undef, $sql_2, $sql_3, 0.99, $desc_3);
   }
 
 }


### PR DESCRIPTION
the datacheck is checking that the number of entries with a distance to parent >1 is less than 1% of the total fragment. 
The calculation of the ratio was done the way around so to corect the two requests have been inverted to calculate the right ratio. 
