### PR TITLE
Feature/compara dc

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGOCScoreStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGOCScoreStats.pm
@@ -16,20 +16,19 @@ limitations under the License.
 
 =cut
 
-package Bio::EnsEMBL::DataCheck::Checks::CheckWGACoverageStats;
+package Bio::EnsEMBL::DataCheck::Checks::CheckGOCScoreStats;
 
 use warnings;
 use strict;
 
 use Moose;
 use Test::More;
-use Bio::EnsEMBL::Utils::SqlHelper;
 
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
-  NAME           => 'CheckWGACoverageStats',
-  DESCRIPTION    => 'The number of rows for WGA coverage have not dropped from previous release',
+  NAME           => 'CheckGOCScoreStats',
+  DESCRIPTION    => 'The number of rows for GOC have not dropped from previous release',
   GROUPS         => ['compara', 'compara_protein_trees'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
@@ -46,7 +45,7 @@ sub tests {
   my $sql = qq/
     SELECT description, COUNT(*) 
       FROM homology 
-    WHERE wga_coverage IS NOT NULL 
+    WHERE goc_score IS NOT NULL 
       GROUP BY description
   /;
 
@@ -54,10 +53,9 @@ sub tests {
   my $curr_results = $curr_helper->execute_into_hash( -SQL => $sql );
 
   foreach my $type ( keys %$prev_results ) {
-    my $desc = "There are the same number of wga_coverage populated rows between releases for $type";
+    my $desc = "There are the same number of goc_score populated rows between releases for $type";
     cmp_ok( $curr_results->{$type}, ">=", $prev_results->{$type}, $desc );
   }
-
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckWGACoverageStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckWGACoverageStats.pm
@@ -1,0 +1,64 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::CheckWGACoverageStats;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::Utils::SqlHelper;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'CheckWGACoverageStats',
+  DESCRIPTION    => 'The number of rows for WGA coverage have not dropped from previous release',
+  GROUPS         => ['compara', 'compara_multiple_alignments', 'compara_pairwise_alignments', 'compara_protein_trees'],
+  DATACHECK_TYPE => 'critical',
+  DB_TYPES       => ['compara'],
+  TABLES         => ['homology']
+};
+
+sub tests {
+  my ($self) = @_;
+  my $prev_dba = $self->registry->get_DBAdaptor('compara_prev', 'compara') || $self->get_old_dba;
+
+  my $curr_helper = $self->dba->dbc->sql_helper;
+  my $prev_helper = $prev_dba->dbc->sql_helper;
+
+  my $sql = qq/
+    SELECT description, COUNT(*) 
+      FROM homology 
+    WHERE wga_coverage IS NOT NULL 
+      GROUP BY description
+  /;
+
+  my $prev_results = $prev_helper->execute_into_hash( -SQL => $sql );
+  my $curr_results = $curr_helper->execute_into_hash( -SQL => $sql );
+
+  foreach my $type ( keys %$prev_results ) {
+    my $desc = "There are the same number of rows between releases for $type";
+    cmp_ok( $curr_results->{$type}, ">=", $prev_results->{$type}, $desc );
+  }
+
+}
+
+1;
+

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -258,6 +258,16 @@
       "name" : "CheckFlatProteinTrees",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckFlatProteinTrees"
    },
+   "CheckGOCScoreStats" : {
+      "datacheck_type" : "critical",
+      "description" : "The number of rows for GOC have not dropped from previous release",
+      "groups" : [
+         "compara",
+         "compara_protein_trees"
+      ],
+      "name" : "CheckGOCScoreStats",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckGOCScoreStats"
+   },
    "CheckGeneGainLossData" : {
       "datacheck_type" : "critical",
       "description" : "ncRNA and protein trees must have gene Gain/Loss trees",
@@ -482,8 +492,6 @@
       "description" : "The number of rows for WGA coverage have not dropped from previous release",
       "groups" : [
          "compara",
-         "compara_multiple_alignments",
-         "compara_pairwise_alignments",
          "compara_protein_trees"
       ],
       "name" : "CheckWGACoverageStats",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -477,6 +477,18 @@
       "name" : "CheckTableSizes",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckTableSizes"
    },
+   "CheckWGACoverageStats" : {
+      "datacheck_type" : "critical",
+      "description" : "The number of rows for WGA coverage have not dropped from previous release",
+      "groups" : [
+         "compara",
+         "compara_multiple_alignments",
+         "compara_pairwise_alignments",
+         "compara_protein_trees"
+      ],
+      "name" : "CheckWGACoverageStats",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckWGACoverageStats"
+   },
    "ChromosomesAnnotated" : {
       "datacheck_type" : "critical",
       "description" : "Chromosomal seq_regions have appropriate attribute",


### PR DESCRIPTION
Two new compara datachecks to ensure that the number of rows between the previous and current release have not dropped for wga_coverage and goc_score following issue in release/100 for WGA scores.

I have put these into two different checks because they are generated by two different pipelines.

There is already a datacheck: `CheckOrthologyQCThresholds.pm` that tests there is at least one row for each of wga_coverage and goc_score that IS NOT NULL. Possibly this could be swapped out, or these two new datachecks merged into it?