### PR TITLE
Fix for detection of datacheck failures

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/BaseCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/BaseCheck.pm
@@ -178,7 +178,7 @@ sub run {
   # subtests, there will always be a single test result in the TAP output.
   # It will be at the same level of indentation as the 'Subtest' header.
   my ($indent) = $output =~ /(\s*)# Subtest: $name/m;
-  my $passed = $output =~ /^${indent}ok 1/m;
+  my $passed = $output =~ /^${indent}ok \d/m;
   $self->_passed($passed || 0);
 
   # Return value indicates failure, like a program exit code, i.e. 0 is fine.

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckComparaStableIDs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckComparaStableIDs.pm
@@ -32,6 +32,7 @@ use constant {
   DESCRIPTION    => 'gene trees in gene_tree_root and family all have stable_ids generated',
   GROUPS         => ['compara', 'compara_families', 'compara_protein_trees'],
   DATACHECK_TYPE => 'critical',
+  DB_TYPES       => ['compara'],
   TABLES         => ['family', 'gene_tree_root']
 };
 

--- a/scripts/run_datachecks.pl
+++ b/scripts/run_datachecks.pl
@@ -182,6 +182,10 @@ if ($dbname) {
   if (! defined $dbtype) {
     if ($dbname =~ /_compara_/) {
       $dbtype = 'compara';
+    } elsif ($dbname =~ /ensembl_ontology/) {
+      $dbtype = 'ontology';
+    } elsif ($dbname =~ /ensembl_production/) {
+      $dbtype = 'production';
     } else {
       ($dbtype) = $dbname =~ /_([a-z]+)[\d_]+$/;
     }
@@ -189,14 +193,16 @@ if ($dbname) {
   die "Could not derive database type from dbname" unless defined $dbtype;
 
   my $adaptor = 'Bio::EnsEMBL::DBSQL::DBAdaptor';
-  $adaptor = 'Bio::EnsEMBL::Compara::DBSQL::DBAdaptor'   if $dbtype eq 'compara';
-  $adaptor = 'Bio::EnsEMBL::Funcgen::DBSQL::DBAdaptor'   if $dbtype eq 'funcgen';
-  $adaptor = 'Bio::EnsEMBL::Variation::DBSQL::DBAdaptor' if $dbtype eq 'variation';
+  $adaptor = 'Bio::EnsEMBL::Compara::DBSQL::DBAdaptor'    if $dbtype eq 'compara';
+  $adaptor = 'Bio::EnsEMBL::Funcgen::DBSQL::DBAdaptor'    if $dbtype eq 'funcgen';
+  $adaptor = 'Bio::EnsEMBL::Ontology::DBSQL::DBAdaptor'   if $dbtype eq 'ontology';
+  $adaptor = 'Bio::EnsEMBL::Production::DBSQL::DBAdaptor' if $dbtype eq 'production';
+  $adaptor = 'Bio::EnsEMBL::Variation::DBSQL::DBAdaptor'  if $dbtype eq 'variation';
 
   my $multispecies_db = $dbname =~ /^\w+_collection_core_\w+$/;
 
   my $species;
-  if ($dbtype eq 'compara') {
+  if ($dbtype =~ /^(compara|ontology|production)$/) {
     $species = 'multi';
   } else {
     my $sql = q/


### PR DESCRIPTION
Detect successful subsequent attempts at running tests within the harness (e.g. if the harness fails initially due to I/O problems).

(Couple of other minor fixes included, to avoid multiple trivial PRs...)


