### PR TITLE
Misc. fixes

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckJSONObjects.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckJSONObjects.pm
@@ -49,11 +49,14 @@ sub tests {
 
   foreach my $data_label ( @data_labels ) {
     my @bad_root_id;
-    my $objects = $helper->execute(
+    my $it = $helper->execute(
       -SQL => $sql_1,
       -PARAMS => [$data_label],
       -USE_HASHREFS => 1,
-      -CALLBACK => sub {
+      -ITERATOR => 1,
+      -PREPARE_PARAMS => [{'mysql_use_result' => 1}],
+    );
+    $it->each( sub {
         my $row = shift @_;
         my $json_check = eval{ decode_json($row->{json_string}) };
         if ( $@ ) {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSyntenySanity.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSyntenySanity.pm
@@ -66,7 +66,7 @@ sub tests {
     my $gab_mlss_list = $mlss->get_all_sister_mlss_by_class('GenomicAlignBlock.pairwise_alignment');
     my $gdbs = $mlss->species_set->genome_dbs;
     
-    #Collect dnafrag_ids longer than 1Mb with exceptions
+    #Collect dnafrag_ids of karyotype-level regions
     foreach my $gdb ( @$gdbs ) {
       my $gdb_id = $gdb->dbID;
       my $karyo_dnafrags = $dnafrag_adap->fetch_all_karyotype_DnaFrags_by_GenomeDB($gdb);

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckTableSizes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckTableSizes.pm
@@ -40,9 +40,7 @@ sub tests {
   
   my $curr_dba = $self->dba;
   my $curr_helper = $curr_dba->dbc->sql_helper;
-  my $prev_dba;
-  $prev_dba = $self->registry->get_DBAdaptor('compara_prev', 'compara') if $self->registry_file;
-  $prev_dba = $self->get_old_dba if $self->old_server_uri && !$prev_dba;
+  my $prev_dba = $self->get_old_dba;
   unless ($prev_dba) {
       fail("Neither 'registry_file' nor 'old_server_uri' parameter given. Cannot find the previous database");
       return;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareMSANames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareMSANames.pm
@@ -38,9 +38,7 @@ sub tests {
   my ($self) = @_;
 
   my $curr_dba = $self->dba;
-  my $prev_dba;
-  $prev_dba = $self->registry->get_DBAdaptor('compara_prev', 'compara') if $self->registry_file;
-  $prev_dba = $self->get_old_dba if $self->old_server_uri && !$prev_dba;
+  my $prev_dba = $self->get_old_dba;
   unless ($prev_dba) {
       fail("Neither 'registry_file' nor 'old_server_uri' parameter given. Cannot find the previous database");
       return;

--- a/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
@@ -167,6 +167,7 @@ sub _registry_default {
   $self->dba->dbc->disconnect_if_idle();
 
   if (defined $self->registry_file) {
+    $registry->disconnect_all;
     $registry->clear;
     $registry->load_all($self->registry_file);
   } elsif (defined $self->server_uri) {
@@ -178,6 +179,7 @@ sub _registry_default {
         die "species and group parameters are required if the URI includes a database name";
       }
     }
+    $registry->disconnect_all;
     $registry->clear;
     $registry->load_registry_from_url($self->server_uri);
   } else {


### PR DESCRIPTION
Hello

These are four unrelated changes:
1. Minor comment fix
2. Test the objects as they come instead of preloading them into memory (don't need to allocate GBs of RAM any more to run the DCs)
3. Fix a Registry bug whereby database connections are closed at the handle level without letting the object now. Causes "MySQL server has gone away" errors
4. Got rid of some Compara-specific code