### PR TITLE
Updated datachecks

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyCardinality.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyCardinality.pm
@@ -65,8 +65,10 @@ sub tests {
     species.production_name
     species.scientific_name
     species.species_name
+    species.strain_group
     species.taxonomy_id
     species.url
+    strain.type
   /;
 
   my $mca = $self->dba->get_adaptor("MetaContainer");

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
@@ -45,6 +45,7 @@ sub tests {
     $self->havana_species();
     $self->projected_transcripts();
     $self->repeat_analysis();
+    $self->strain_type();
   } elsif ($self->dba->group eq 'variation') {
     $self->has_polyphen();
     $self->has_sift();
@@ -156,6 +157,21 @@ sub repeat_analysis {
     my $mca = $self->dba->get_adaptor('MetaContainer');
     my @values = sort @{ $mca->list_value_by_key('repeat.analysis') };
     is_deeply(\@values, \@logic_names, $desc);
+  }
+}
+
+sub strain_type {
+  my ($self) = @_;
+
+  my $mca = $self->dba->get_adaptor('MetaContainer');
+  my $strain_group = $mca->list_value_by_key('species.strain_group');
+
+  SKIP: {
+    skip 'No strain group', 1 unless scalar @$strain_group;
+
+    my $desc = "'strain.type' meta_key exists";
+    my $strain_type = $mca->list_value_by_key('strain.type');
+    ok(scalar @$strain_type, $desc);
   }
 }
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
@@ -23,6 +23,7 @@ use strict;
 
 use Moose;
 use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
 
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
@@ -76,13 +77,48 @@ sub gencode_species {
   SKIP: {
     skip 'Not a GENCODE species', 1 unless exists $gencode_species{$self->species};
 
+    my $mca = $self->dba->get_adaptor('MetaContainer');
+
     my @meta_keys = ('gencode.version');
     foreach my $meta_key (@meta_keys) {
       my $desc = "'$meta_key' meta_key exists";
-      my $mca = $self->dba->get_adaptor('MetaContainer');
       my $values = $mca->list_value_by_key($meta_key);
       ok(scalar @$values, $desc);
     }
+
+    my $old_dba = $self->get_old_dba();
+    my $old_mca = $old_dba->get_adaptor('MetaContainer');
+
+    my $cur_geneset_update = $mca->single_value_by_key('genebuild.last_geneset_update');
+    my $old_geneset_update = $old_mca->single_value_by_key('genebuild.last_geneset_update');
+    my $cur_gencode_version = $mca->single_value_by_key('gencode.version');
+    my $old_gencode_version = $old_mca->single_value_by_key('gencode.version');
+    my $cur_datafreeze_date = $mca->single_value_by_key('genebuild.havana_datafreeze_date');
+    my $old_datafreeze_date = $old_mca->single_value_by_key('genebuild.havana_datafreeze_date');
+
+    if ($cur_geneset_update eq $old_geneset_update) {
+      my $desc_1 = 'Same geneset as previous release, same GENCODE version';
+      is($cur_gencode_version, $old_gencode_version, $desc_1);
+      my $desc_2 = 'Same geneset as previous release, same HAVANA datafreeze date';
+      is($cur_datafreeze_date, $old_datafreeze_date, $desc_2);
+    } else {
+      my $desc_1 = 'Updated geneset from previous release, updated GENCODE version';
+      isnt($cur_gencode_version, $old_gencode_version, $desc_1);
+      my $desc_2 = 'Updated geneset from previous release, updated HAVANA datafreeze date';
+      isnt($cur_datafreeze_date, $old_datafreeze_date, $desc_2);
+    }
+
+    my $desc = 'Web data matches GENCODE version meta key';
+    my $diag = 'Mismatched GENCODE version';
+    my $sql = qq/
+      SELECT logic_name, web_data FROM
+        analysis INNER JOIN
+        analysis_description USING (analysis_id)
+      WHERE
+        web_data LIKE '%GENCODE%' AND
+        web_data NOT LIKE '%$cur_gencode_version%'
+    /;
+    is_rows_zero($self->dba, $sql, $desc, $diag);
   }
 }
 

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1849,16 +1849,6 @@
       "name" : "UnreviewedXrefs",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::UnreviewedXrefs"
    },
-   "UnversionedGenes" : {
-      "datacheck_type" : "critical",
-      "description" : "Genes are unversioned in non-vertebrate databases",
-      "groups" : [
-         "core",
-         "geneset"
-      ],
-      "name" : "UnversionedGenes",
-      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::UnversionedGenes"
-   },
    "ValidTranscripts" : {
       "datacheck_type" : "critical",
       "description" : "Transcripts have translations, if appropriate",
@@ -1961,6 +1951,16 @@
       ],
       "name" : "VariationSubset",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::VariationSubset"
+   },
+   "VersionedGenes" : {
+      "datacheck_type" : "critical",
+      "description" : "Genes are versioned in vertebrate databases, and unversioned in non-vertebrate databases",
+      "groups" : [
+         "core",
+         "geneset"
+      ],
+      "name" : "VersionedGenes",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::VersionedGenes"
    },
    "XrefFormat" : {
       "datacheck_type" : "critical",


### PR DESCRIPTION
Adding new tests to some existing core-db-related datachecks:
* Check for non-NULL gene versions for vertebrates
* Conditionally check for presence of 'strain.type' meta_key
* For GENCODE species, check that meta data has been updated if the geneset was updated, and that web_data for tracks has the correct GENCODE version

These address JIRA tickets ENSPROD-4862, ENSPROD-4339, ENSPROD-5000.