### PR TITLE
Improvements to datacheck pipeline, and output parsing

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
@@ -183,7 +183,8 @@ sub _registry_default {
     $registry->clear;
     $registry->load_registry_from_url($self->server_uri);
   } else {
-    die "Registry requires a 'registry_file' or 'server_uri' attribute";
+    die "The '.$self->name.' datacheck needs data from another database, ".
+        "for which a registry needs to be specified with 'registry_file' or 'server_uri'";
   }
 
   if ($self->dba->is_multispecies) {
@@ -284,6 +285,7 @@ sub load_registry {
 
 sub species {
   my $self = shift;
+
   my $mca = $self->dba->get_adaptor("MetaContainer");
 
   my $species;
@@ -477,8 +479,10 @@ sub run_datacheck {
         -species_id      => $species_ids{$species},
       );
       $self->dba($dba);
+      my $db_type = $dba->group;
+      my $db_name = $dba->dbc->dbname;
 
-      subtest $species => sub {
+      subtest "$species, $db_type, $db_name" => sub {
         SKIP: {
           my ($skip, $skip_reason) = $self->skip_tests(@_);
 
@@ -498,8 +502,10 @@ sub run_datacheck {
     if ($self->per_db && $self->dba->is_multispecies) {
       $label = 'all species in collection';
     }
+    my $db_type = $self->dba->group;
+    my $db_name = $self->dba->dbc->dbname;
 
-    subtest $label => sub {
+    subtest "$label, $db_type, $db_name" => sub {
       SKIP: {
         my ($skip, $skip_reason) = $self->skip_tests(@_);
 

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/DataCheckSubmission.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/DataCheckSubmission.pm
@@ -69,7 +69,7 @@ sub write_output {
   # In order to prevent people from inadvertently overwriting existing
   # output, append a subdirectory. 
   if (defined $self->param('output_dir')) {
-    my $subdir = $ENV{'USER'}.'_'.time;
+    my $subdir = $ENV{'USER'}.'_'.time.'_'.$$;
     my $dir = path($self->param('output_dir'), $subdir)->stringify;
     $self->param('output_dir', $dir);
   }
@@ -86,6 +86,7 @@ sub write_output {
     division     => $self->param('division'),
     run_all      => $self->param('run_all'),
     meta_filters => $self->param('meta_filters'),
+    dbname       => $self->param('dbname'),
     db_type      => $self->param('db_type'),
 
     datacheck_dir      => $self->param('datacheck_dir'),

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/DbDataChecks_conf.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/DbDataChecks_conf.pm
@@ -45,6 +45,7 @@ sub default_options {
     antispecies  => [],
     antitaxons   => [],
     meta_filters => {},
+    dbname       => [],
     db_type      => 'core',
 
     datacheck_dir      => undef,
@@ -150,6 +151,7 @@ sub pipeline_analyses {
                               antispecies  => $self->o('antispecies'),
                               antitaxons   => $self->o('antitaxons'),
                               meta_filters => $self->o('meta_filters'),
+                              dbname       => $self->o('dbname'),
                               db_type      => $self->o('db_type'),
 
                               datacheck_dir      => $self->o('datacheck_dir'),

--- a/scripts/parse_results.pl
+++ b/scripts/parse_results.pl
@@ -1,0 +1,142 @@
+#!/usr/bin/env perl
+
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 SYNOPSIS
+
+perl parse_results.pl [options]
+
+=head1 OPTIONS
+
+=over 8
+
+=item B<-t[ap]> <tap>
+
+The TAP source to process. Can be a TAP-format file, or a directory
+containing such files (sub-directories are ignored).
+
+=item B<-o[utput_file]> <output_file>
+
+The path to an output_file for saving the report.
+Defaults to STDOUT if not specified.
+
+=item B<-b[y_species]>
+
+Aggregate failures by species, rather than by datacheck.
+
+=item B<-p[assed]>
+
+Include results for datachecks that passed;
+the default is to include only failed datachecks.
+
+=item B<-h[elp]>
+
+Print usage information.
+
+=back
+
+=cut
+
+use warnings;
+use strict;
+use feature 'say';
+
+use Getopt::Long qw(:config no_ignore_case);
+use JSON;
+use Path::Tiny;
+use Pod::Usage;
+use TAP::Parser;
+
+my ($help, $tap, $output_file, $by_species, $passed);
+
+GetOptions(
+  "help!",         \$help,
+  "tap:s",         \$tap,
+  "output_file:s", \$output_file,
+  "by_species!",   \$by_species,
+  "passed!",       \$passed,
+);
+
+pod2usage(1) if $help;
+
+if (! defined $tap) {
+  die "Need a source of TAP data";
+} elsif (! -e $tap) {
+  die "TAP source does not exist: $tap";
+}
+
+my @tap_files;
+if (-d $tap) {
+  @tap_files = map { $_->stringify } path($tap)->children;
+} else {
+  push @tap_files, $tap;
+}
+
+my %results;
+my $datacheck;
+my $species;
+my $test;
+my %tests;
+
+foreach my $tap_file (@tap_files) {
+  my $tap = path($tap_file)->slurp;
+  my $parser = TAP::Parser->new( { tap => $tap } );
+
+  # to-do: extract test number, use that as key with test message and diag messages as lists.
+  while (my $result = $parser->next) {
+    if ($result->is_comment) {
+      next unless $result->as_string =~ /^# Subtest:/;
+      # Top-level comment will be the name of the datacheck,
+      # the next line will be the species.
+      ($datacheck) = $result->as_string =~ /^# Subtest: (.+)/;
+      $result = $parser->next;
+      ($species) = $result->as_string =~ /\s+# Subtest: (.+)/;
+      %tests = ();
+    } elsif ($result->is_unknown) {
+      if ($result->as_string =~ /^\s{8}((?:not ok|# No tests run).*)/) {
+	    $test = $1;
+        $tests{$test} = [];
+	  } elsif ($result->as_string =~ /^\s{8}((?:ok|.* # SKIP).*)/ && $passed) {
+        $test = $1;
+        $tests{$test} = [];
+	  } elsif ($result->as_string =~ /^\s{8}#\s(\s+.*)/) {
+	    push @{$tests{$test}}, $1;
+	  }
+    } elsif ($result->is_test) {
+      my $ok = $result->as_string =~ /^not ok/ ? 0 : 1;
+      if (!$ok || $passed) {
+        my %datacheck_tests = %tests;
+        if ($by_species) {
+		  $results{$species}{$datacheck}{'ok'} = $ok;
+          $results{$species}{$datacheck}{'tests'} = \%datacheck_tests;
+        } else {
+		  $results{$datacheck}{$species}{'ok'} = $ok;
+          $results{$datacheck}{$species}{'tests'} = \%datacheck_tests;
+        }
+	  }  
+	}
+  }
+}
+
+my $json = JSON->new->canonical->pretty->encode(\%results);
+
+if ($output_file) {
+  path($output_file)->parent->mkpath;
+  path($output_file)->spew($json)
+} else {
+  say $json;
+}

--- a/scripts/run_pipeline.pl
+++ b/scripts/run_pipeline.pl
@@ -110,6 +110,12 @@ The name of the taxon to exclude from datachecks
 Multiple antitaxons can be given as separate -antitaxons parameters, 
 or as a single comma-separated string.
 
+=item B<-dbname> <dbname>
+
+The name of the database on which to run datachecks.
+Multiple dbnames can be given as separate -dbname parameters, 
+or as a single comma-separated string.
+
 =item B<-names> <name>
 
 The name of the datacheck to execute.
@@ -213,7 +219,7 @@ my (
     $help,
     $host, $port, $user, $pass, $dbname, $drop_db,
     $registry_file, $old_server_uri, $data_file_path, $config_file, $dbtype,
-    @species, @taxons, @divisions, $run_all, @antispecies, @antitaxons,
+    @species, @taxons, @divisions, $run_all, @antispecies, @antitaxons, @dbnames,
     @names, @patterns, @groups, @datacheck_types,
     $datacheck_dir, $index_file, $history_file, $output_dir,
     $parallelize_datachecks,
@@ -241,6 +247,7 @@ GetOptions(
   "run_all",          \$run_all,
   "antispecies:s",    \@antispecies,
   "antitaxons:s",     \@antitaxons,
+  "dbnames:s",        \@dbnames,
 
   "names|n:s",         \@names,
   "patterns:s",        \@patterns,
@@ -306,6 +313,7 @@ if (! defined $datacheck_dir && defined $index_file) {
 @divisions = map { split(/[,\s]+/, $_) } @divisions if scalar @divisions;
 @antispecies = map { split(/[,\s]+/, $_) } @antispecies if scalar @antispecies;
 @antitaxons = map { split(/[,\s]+/, $_) } @antitaxons if scalar @antitaxons;
+@dbnames = map { split(/[,\s]+/, $_) } @dbnames if scalar @dbnames;
 
 # If datacheck parameters have been specified as comma-separated strings,
 # convert them into arrays.
@@ -359,6 +367,7 @@ $input_id{division} = \@divisions if scalar @divisions;
 $input_id{run_all} = $run_all if defined $run_all;
 $input_id{antispecies} = \@antispecies if scalar @antispecies;
 $input_id{antitaxons} = \@antitaxons if scalar @antitaxons;
+$input_id{dbname} = \@dbnames if scalar @dbnames;
 $input_id{datacheck_names} = \@names if scalar @names;
 $input_id{datacheck_patterns} = \@patterns if scalar @patterns;
 $input_id{datacheck_groups} = \@groups if scalar @groups;

--- a/t/DbCheck.t
+++ b/t/DbCheck.t
@@ -354,7 +354,7 @@ subtest 'Registry instantiation', sub {
 
   throws_ok(
     sub { $check->registry },
-    qr/Registry requires a 'registry_file' or 'server_uri' attribute/,
+    qr/registry needs to be specified with 'registry_file' or 'server_uri'/,
     'DbCheck->registry fails if a file or uri is not set');
 
   $check = TestChecks::DbCheck_1->new(


### PR DESCRIPTION
- Enable datacheck pipeline to accept a db name as input. This is particularly useful for running across a single collection db (or a subset of them).
- Slightly friendlier error message when a registry is missing. Include db name in the TAP output; it's used as the filename, but that's not much help if you're viewing results through a GUI, or want to merge output files together in order to consolidate results for easier inspection.
- New script to parse TAP output into JSON, and merge output from multiple files.


