### PR TITLE
Rename EPO_LOW_COVERAGE->EPO_EXTENDED in compara datacheck modules

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignGenomeDBs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignGenomeDBs.pm
@@ -40,7 +40,7 @@ use constant {
 sub skip_tests {
     my ($self) = @_;
     my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
-    my @methods = qw (PECAN EPO EPO_LOW_COVERAGE LASTZ_NET LASTZ_PATCH);
+    my @methods = qw (PECAN EPO EPO_EXTENDED LASTZ_NET LASTZ_PATCH);
     my $db_name = $self->dba->dbc->dbname;
 
     my @mlsses;
@@ -60,7 +60,7 @@ sub tests {
   my $helper = $dba->dbc->sql_helper;
   my $mlss_adap = $dba->get_MethodLinkSpeciesSetAdaptor;
   my $gdb_adap = $dba->get_GenomeDBAdaptor;
-  my @mlss_types = qw ( PECAN EPO EPO_LOW_COVERAGE LASTZ_NET LASTZ_PATCH);
+  my @mlss_types = qw ( PECAN EPO EPO_EXTENDED LASTZ_NET LASTZ_PATCH);
   my $ancestral = $gdb_adap->fetch_all_by_name('ancestral_sequences');
   my @mlsses;
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignMTs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignMTs.pm
@@ -39,7 +39,7 @@ use constant {
 sub skip_tests {
     my ($self) = @_;
     my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
-    my @methods = qw( EPO EPO_LOW_COVERAGE PECAN );
+    my @methods = qw( EPO EPO_EXTENDED PECAN );
     my $db_name = $self->dba->dbc->dbname;
 
     my @mlsses;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignTreeTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignTreeTable.pm
@@ -39,7 +39,7 @@ use constant {
 sub skip_tests {
     my ($self) = @_;
     my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
-    my @methods = qw( EPO EPO_LOW_COVERAGE );
+    my @methods = qw( EPO EPO_EXTENDED );
     my $db_name = $self->dba->dbc->dbname;
     
     my @mlsses;
@@ -57,7 +57,7 @@ sub skip_tests {
 sub tests {
   my ($self) = @_;
   my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
-  my @methods = qw( EPO EPO_LOW_COVERAGE );
+  my @methods = qw( EPO EPO_EXTENDED );
   my $db_name = $self->dba->dbc->dbname;
   my $dbc = $self->dba->dbc;
   my $helper = $dbc->sql_helper;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMSANames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMSANames.pm
@@ -38,7 +38,7 @@ use constant {
 sub skip_tests {
     my ($self) = @_;
     my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
-    my @methods = qw( EPO EPO_LOW_COVERAGE PECAN );
+    my @methods = qw( EPO EPO_EXTENDED PECAN );
     my $db_name = $self->dba->dbc->dbname;
     
     my @mlsses;
@@ -56,7 +56,7 @@ sub skip_tests {
 sub tests {
   my ($self) = @_;
   my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
-  my @methods = qw( EPO EPO_LOW_COVERAGE PECAN );
+  my @methods = qw( EPO EPO_EXTENDED PECAN );
   my $db_name = $self->dba->dbc->dbname;
   my $dbc = $self->dba->dbc;
   my @mlsses;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMultipleAlignCoverage.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMultipleAlignCoverage.pm
@@ -39,7 +39,7 @@ use constant {
 sub skip_tests {
     my ($self) = @_;
     my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
-    my @methods = qw( EPO EPO_LOW_COVERAGE PECAN );
+    my @methods = qw( EPO EPO_EXTENDED PECAN );
     my $db_name = $self->dba->dbc->dbname;
 
     my @mlsses;
@@ -63,7 +63,7 @@ sub tests {
     SELECT method_link_species_set_id 
       FROM method_link_species_set 
         JOIN method_link USING(method_link_id) 
-      WHERE method_link.type IN ('EPO', 'EPO_LOW_COVERAGE', 'PECAN')
+      WHERE method_link.type IN ('EPO', 'EPO_EXTENDED', 'PECAN')
     /;
   
   my $msa_mlss_array = $helper->execute_simple(-SQL => $msa_mlss_sql);

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareMSANames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareMSANames.pm
@@ -47,7 +47,7 @@ sub tests {
   my $prev_db_name = $prev_dba->dbc->dbname;
   my $curr_mlss_adap = $curr_dba->get_MethodLinkSpeciesSetAdaptor;
   my $prev_mlss_adap = $prev_dba->get_MethodLinkSpeciesSetAdaptor;
-  my @mlss_types = qw ( PECAN EPO EPO_LOW_COVERAGE CACTUS_HAL );
+  my @mlss_types = qw ( PECAN EPO EPO_EXTENDED CACTUS_HAL );
   my @curr_mlsses;
   my @prev_mlsses;
   

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MultipleGenomicAlignBlockIds.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MultipleGenomicAlignBlockIds.pm
@@ -39,7 +39,7 @@ use constant {
 sub skip_tests {
     my ($self) = @_;
     my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
-    my @methods = qw (PECAN CACTUS_HAL LASTZ_NET LASTZ_PATCH EPO_LOW_COVERAGE);
+    my @methods = qw (PECAN CACTUS_HAL LASTZ_NET LASTZ_PATCH EPO_EXTENDED);
     my $db_name = $self->dba->dbc->dbname;
 
     my @mlsses;
@@ -58,7 +58,7 @@ sub tests {
   my $dba = $self->dba;
   my $dbc = $dba->dbc;
   my $mlss_adap = $dba->get_MethodLinkSpeciesSetAdaptor;
-  my @mlss_types = qw (PECAN CACTUS_HAL LASTZ_NET LASTZ_PATCH EPO_LOW_COVERAGE);
+  my @mlss_types = qw (PECAN CACTUS_HAL LASTZ_NET LASTZ_PATCH EPO_EXTENDED);
   my @mlsses;
   
   # The tests are excluded from the EPO methods because these have ancestral sequences in


### PR DESCRIPTION
Jira ticket: [ENSINT-334](https://www.ebi.ac.uk/panda/jira/browse/ENSINT-334)
_EPO\_LOW\_COVERAGE_, a `method_link.type` has been renamed for e101 to _EPO\_EXTENDED_ to better reflect what actually it is.
We use the `method_link.type` in the datachecks to access the compara API `method_link_species_set`.