### PR TITLE
Misc Compara changes

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckConservationScorePerBlock.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckConservationScorePerBlock.pm
@@ -46,8 +46,7 @@ sub tests {
     FROM method_link_species_set mlss
       JOIN method_link USING(method_link_id)
       LEFT JOIN method_link_species_set_tag mlsst ON (mlss.method_link_species_set_id = mlsst.method_link_species_set_id AND tag = "msa_mlss_id" AND value != "")
-    WHERE (type = "GERP_CONSERVATION_SCORE" 
-      OR class LIKE "ConservationScore%") 
+    WHERE type = "GERP_CONSERVATION_SCORE"
       AND tag IS NULL;
   /;
   
@@ -59,8 +58,7 @@ sub tests {
     FROM method_link_species_set 
       LEFT JOIN method_link USING(method_link_id) 
       LEFT JOIN method_link_species_set_tag USING(method_link_species_set_id) 
-    WHERE (type = "GERP_CONSERVATION_SCORE" 
-      OR class LIKE "ConservationScore%") 
+    WHERE type = "GERP_CONSERVATION_SCORE"
       AND tag = "msa_mlss_id";
   /;
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGOCScoreStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGOCScoreStats.pm
@@ -54,7 +54,7 @@ sub tests {
 
   foreach my $type ( keys %$prev_results ) {
     my $desc = "There are the same number of goc_score populated rows between releases for $type";
-    cmp_ok( $curr_results->{$type}, ">=", $prev_results->{$type}, $desc );
+    cmp_ok( $curr_results->{$type} // 0, ">=", $prev_results->{$type}, $desc );
   }
 }
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGOCScoreStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGOCScoreStats.pm
@@ -37,7 +37,7 @@ use constant {
 
 sub tests {
   my ($self) = @_;
-  my $prev_dba = $self->registry->get_DBAdaptor('compara_prev', 'compara') || $self->get_old_dba;
+  my $prev_dba = $self->get_old_dba;
 
   my $curr_helper = $self->dba->dbc->sql_helper;
   my $prev_helper = $prev_dba->dbc->sql_helper;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignMTs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignMTs.pm
@@ -71,9 +71,7 @@ sub tests {
         JOIN genome_db USING(genome_db_id)
         JOIN dnafrag USING(genome_db_id)
       WHERE cellular_component = 'MT' 
-        AND (class LIKE 'GenomicAlignTree%' 
-          OR class LIKE 'GenomicAlign%multiple%') 
-        AND (type NOT LIKE 'CACTUS_HAL%')
+        AND type IN ("EPO", "EPO_EXTENDED", "PECAN")
     /;
   
   my $entries_array = $helper->execute(  

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMethodLinkSpeciesSetNames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMethodLinkSpeciesSetNames.pm
@@ -57,7 +57,7 @@ sub tests {
       unlike( $mlss_name, qr/^(protein|nc|species)/, $desc_1 );
       # Since there are many species_sets below first_release 81 in plants that have no name at all, set a
       # threshold to avoid checking them (and failing)
-      next if $species_set->first_release <= 80;
+      next if ($species_set->first_release // 0) <= 80;
       my $desc_2 = "species_set $species_set_id for mlss $mlss_name ($mlss_id) starts with the species_set name $species_set_name";
 
       if ( $species_set_name =~ /collection/ ) {
@@ -67,7 +67,7 @@ sub tests {
         is( $species_set_name, $mlss_p1, $desc_2 );
       }
     }
-    next if $species_set->first_release <= 80;
+    next if ($species_set->first_release // 0) <= 80;
     if ( $gdb_count >= 1 && $gdb_count <=2 ) {
       my @species_count = split /-/, $species_set_name;
       my $desc_3 = "For $mlss_name ($mlss_id) the species_set $species_set_name ($species_set_id) is appropriately named with the correct number of genomes";

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckWGACoverageStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckWGACoverageStats.pm
@@ -55,7 +55,7 @@ sub tests {
 
   foreach my $type ( keys %$prev_results ) {
     my $desc = "There are the same number of wga_coverage populated rows between releases for $type";
-    cmp_ok( $curr_results->{$type}, ">=", $prev_results->{$type}, $desc );
+    cmp_ok( $curr_results->{$type} // 0, ">=", $prev_results->{$type}, $desc );
   }
 
 }

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckWGACoverageStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckWGACoverageStats.pm
@@ -38,7 +38,7 @@ use constant {
 
 sub tests {
   my ($self) = @_;
-  my $prev_dba = $self->registry->get_DBAdaptor('compara_prev', 'compara') || $self->get_old_dba;
+  my $prev_dba = $self->get_old_dba;
 
   my $curr_helper = $self->dba->dbc->sql_helper;
   my $prev_helper = $prev_dba->dbc->sql_helper;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
@@ -114,7 +114,7 @@ sub compara_fk {
       SELECT method_link_id FROM method_link
       WHERE
         method_link_id < 100 AND
-        class NOT LIKE "ConstrainedElement.%" AND
+        class LIKE "GenomicAlign%" AND
         type NOT LIKE "CACTUS_HAL%"
     )
   /;


### PR DESCRIPTION
This PR was intended to replace the `class` filters with `type` in several places in order to be more consistent across the HCs, but I also found two occurrences of `compara_prev` that needed to be replaced (they were introduced in parallel of my PR #206 , that's why I had missed them).

I've left some occurrences of `class` in ForeignKeysCompara because it's meant to be really generic, but all others DCs are now using `type` only.

(leaving this as a draft because I want to check something with Cristi first)