### PR TITLE
 Add division condition to "old_db" metadata query...

### DIFF
--- a/t/test-genome-DBs/multi/metadata/division.txt
+++ b/t/test-genome-DBs/multi/metadata/division.txt
@@ -1,1 +1,1 @@
-1 EnsemblMetazoa  EM
+1	EnsemblMetazoa	EM

--- a/t/test-genome-DBs/multi/metadata/division.txt
+++ b/t/test-genome-DBs/multi/metadata/division.txt
@@ -1,0 +1,1 @@
+1 EnsemblMetazoa  EM


### PR DESCRIPTION
... for retrieving the name of the database in the previous release - this is necessary to distinguish between species that are shared between Ensembl and EnsemblGenomes.

