### PR TITLE
Revert "Also check when the assembly length is too long"

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AssemblySeqregion.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AssemblySeqregion.pm
@@ -85,19 +85,15 @@ sub tests {
   is_rows_zero($self->dba, $sql_5, $desc_5);
 
   my $desc_6 = 'assembly and seq_region lengths consistent';
-  my $diag_6 = 'seq_region length != largest asm_end value';
+  my $diag_6 = 'seq_region length < largest asm_end value';
   my $sql_6  = q/
-    SELECT
-      sr.name AS seq_region_name,
-      cs.name AS coord_system_name,
-      sr.length AS seq_length,
-      MAX(a.asm_end) AS max_asm_end
+    SELECT sr.name AS seq_region_name, sr.length, cs.name AS coord_system_name
     FROM
       seq_region sr INNER JOIN
       coord_system cs ON sr.coord_system_id = cs.coord_system_id INNER JOIN
       assembly a ON a.asm_seq_region_id = sr.seq_region_id
     GROUP BY a.asm_seq_region_id
-    HAVING sr.length != MAX(a.asm_end)
+    HAVING sr.length < MAX(a.asm_end)
   /;
   is_rows_zero($self->dba, $sql_6, $desc_6, $diag_6);
 }


### PR DESCRIPTION
There is at least one assembly (_Ciona intestinalis_) which violates the stricter condition that was added - this doesn't exactly make sense, it means that there is a "gap" at the end of the sequence. It would be customary to trim those trailing Ns; but the datacheck needs to tolerate existing assemblies where this is not done (since it does not cause any errors, _per se_).

If this stricter condition is useful as a warning, it could be added as an advisory datacheck.