### PR TITLE
 Catch run-time errors and present them as test failures

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/BaseCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/BaseCheck.pm
@@ -131,7 +131,11 @@ sub skip_datacheck {
 sub run_datacheck {
   # Method can be overridden by a subclass, if required.
   my $self = shift;
-  $self->tests(@_);
+  eval { $self->tests(@_) };
+  if ($@) {
+    fail("Datacheck ran without errors");
+    diag($@);
+  }
 }
 
 sub skip_tests {

--- a/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
@@ -183,7 +183,7 @@ sub _registry_default {
     $registry->clear;
     $registry->load_registry_from_url($self->server_uri);
   } else {
-    die "The '.$self->name.' datacheck needs data from another database, ".
+    die "The '".$self->name."' datacheck needs data from another database, ".
         "for which a registry needs to be specified with 'registry_file' or 'server_uri'";
   }
 
@@ -326,8 +326,6 @@ sub get_dna_dba {
   if (defined $dna_dba) {
     $self->registry->add_DNAAdaptor($self->species, $self->dba->group, $self->species, 'core');
     push @{$self->dba_list}, $dna_dba;
-  } else {
-    die "Could not retrieve DNA database for ".$self->dba->dbc->dbname;
   }
 
   return $dna_dba;
@@ -495,7 +493,11 @@ sub run_datacheck {
 
           plan skip_all => $skip_reason if $skip;
 
-          $self->tests(@_);
+          eval { $self->tests(@_) };
+          if ($@) {
+            fail("Datacheck ran without errors");
+            diag($@);
+          }
         }
       };
     }
@@ -518,7 +520,11 @@ sub run_datacheck {
 
         plan skip_all => $skip_reason if $skip;
 
-        $self->tests(@_);
+        eval { $self->tests(@_) };
+        if ($@) {
+          fail("Datacheck ran without errors");
+          diag($@);
+        }
       }
     }
   }

--- a/scripts/parse_results.pl
+++ b/scripts/parse_results.pl
@@ -113,7 +113,7 @@ foreach my $tap_file (@tap_files) {
 	  } elsif ($result->as_string =~ /^\s{8}((?:ok|.* # SKIP).*)/ && $passed) {
         $test = $1;
         $tests{$test} = [];
-	  } elsif ($result->as_string =~ /^\s{8}#\s(\s+.*)/) {
+	  } elsif ($result->as_string =~ /^\s{8}#\s(\s*.*)/) {
 	    push @{$tests{$test}}, $1;
 	  }
     } elsif ($result->is_test) {

--- a/t/DbCheck_noncore.t
+++ b/t/DbCheck_noncore.t
@@ -91,11 +91,6 @@ subtest 'Fetch DNA DBA from registry', sub {
     dba        => $dba,
     server_uri => $server_uri,
   );
-
-  throws_ok(
-    sub { $check->get_dna_dba },
-    qr/Could not retrieve DNA database/,
-    'DbCheck->get_dna_dba fails if core database is not in registry');
 };
 
 done_testing();


### PR DESCRIPTION
Catch run-time errors and present them as test failures, so that a) pipelines can run to completion, and b) users get useful information on errors.

Minor fix to parsing script also included.

