### PR TITLE
Bugfix/compara

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckTableSizes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckTableSizes.pm
@@ -41,10 +41,6 @@ sub tests {
   my $curr_dba = $self->dba;
   my $curr_helper = $curr_dba->dbc->sql_helper;
   my $prev_dba = $self->get_old_dba;
-  unless ($prev_dba) {
-      fail("Neither 'registry_file' nor 'old_server_uri' parameter given. Cannot find the previous database");
-      return;
-  }
   my $prev_helper = $prev_dba->dbc->sql_helper;
   
   my $table_sql = "SHOW TABLES";

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareMSANames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareMSANames.pm
@@ -39,10 +39,6 @@ sub tests {
 
   my $curr_dba = $self->dba;
   my $prev_dba = $self->get_old_dba;
-  unless ($prev_dba) {
-      fail("Neither 'registry_file' nor 'old_server_uri' parameter given. Cannot find the previous database");
-      return;
-  }
   my $curr_db_name = $curr_dba->dbc->dbname;
   my $prev_db_name = $prev_dba->dbc->dbname;
   my $curr_mlss_adap = $curr_dba->get_MethodLinkSpeciesSetAdaptor;
@@ -78,14 +74,10 @@ sub tests {
   cmp_ok( ( scalar keys %$curr_mlss_names ), '==', ( scalar keys %$prev_mlss_names ), $desc_2 );
   
   foreach my $species_set_name ( keys %$prev_mlss_names ) {
-    my $desc_4 = "$species_set_name is present in $curr_db_name";
-    if ( exists ($curr_mlss_names->{$species_set_name}) ) {
-      pass( $desc_4 );
-      my $desc_3 = "The number of multiple alignments for species_set <$species_set_name> in $curr_db_name is the same or more than in $prev_db_name";
-      cmp_ok( @{ $curr_mlss_names->{$species_set_name} }, '<=', @{ $prev_mlss_names->{$species_set_name} }, $desc_3 );
-    }
-    else {
-      fail( $desc_4 );
+    my $desc_3 = "$species_set_name is present in $curr_db_name";
+    if ( ok(exists $curr_mlss_names->{$species_set_name}, $desc_3) ) {
+      my $desc_4 = "The number of multiple alignments for species_set <$species_set_name> in $curr_db_name is the same or more than in $prev_db_name";
+      cmp_ok( @{ $curr_mlss_names->{$species_set_name} }, '<=', @{ $prev_mlss_names->{$species_set_name} }, $desc_4 );
     }
   }
 }


### PR DESCRIPTION
The 'fail' method is now redundant, following the removal of the reference to 'compara_prev'; execution will never get this far if there is a problem. If the previous release's database can't be found, the 'get_old_dba' method will raise an error, which is now caught and reported as a test failure. So the datacheck is safely aborted, and you should automatically get a (hopefully) more informative message.