### PR TITLE
More DC changes for Compara

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AlignmentCoordinates.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AlignmentCoordinates.pm
@@ -31,7 +31,7 @@ use constant {
   NAME           => 'AlignmentCoordinates',
   DESCRIPTION    => 'Alignment coordinates are within the length of their dnafrag',
   DATACHECK_TYPE => 'critical',
-  GROUPS         => ['compara', 'compara_pairwise_alignments', 'compara_multiple_alignments'],
+  GROUPS         => ['compara', 'compara_genome_alignments'],
   DB_TYPES       => ['compara'],
   TABLES         => ['dnafrag', 'genomic_align']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankEnums.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankEnums.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'BlankEnums',
   DESCRIPTION => 'Enum columns do not have empty string values',
-  GROUPS      => ['compara', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['compara', 'compara_master', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankEnums.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankEnums.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'BlankEnums',
   DESCRIPTION => 'Enum columns do not have empty string values',
-  GROUPS      => ['compara', 'compara_master', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['compara', 'compara_gene_trees', 'compara_master', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'BlankNulls',
   DESCRIPTION => 'Nullable columns do not have empty string values',
-  GROUPS      => ['compara', 'compara_master', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'BlankNulls',
   DESCRIPTION => 'Nullable columns do not have empty string values',
-  GROUPS      => ['compara', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['compara', 'compara_master', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckCAFETable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckCAFETable.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckCAFETable',
   DESCRIPTION    => 'Each row should show a one-to-many relationship',
-  GROUPS         => ['compara', 'compara_protein_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['cafe_species_gene']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckComparaStableIDs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckComparaStableIDs.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckComparaStableIDs',
   DESCRIPTION    => 'gene trees in gene_tree_root and family all have stable_ids generated',
-  GROUPS         => ['compara', 'compara_families', 'compara_protein_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['family', 'gene_tree_root']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckConservationScore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckConservationScore.pm
@@ -64,7 +64,11 @@ sub tests {
         AND method_link_species_set_id = $mlss_id
     /;
     my $desc_1 = "There is an msa_mlss_id tag for $mlss_name";
-    my $msa_mlss_id = $helper->execute_single_result( -SQL => $sql_1 );
+    my $msa_mlss_id = $helper->execute_single_result( -SQL => $sql_1, -NO_ERROR => 1 );
+    ok($msa_mlss_id, $desc_1);
+
+    # Can't test this mlss without an msa_mlss_id
+    next unless $msa_mlss_id;
     
     my $sql_2 = qq/
       SELECT COUNT(*) 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckConservationScore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckConservationScore.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckConservationScore',
   DESCRIPTION    => 'The MLSS for GERP_CONSERVATION_SCORE should have conservation score entries',
-  GROUPS         => ['compara', 'compara_pairwise_alignments'],
+  GROUPS         => ['compara', 'compara_genome_alignments'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['conservation_score', 'genomic_align_block', 'method_link', 'method_link_species_set', 'method_link_species_set_tag']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckConservationScorePerBlock.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckConservationScorePerBlock.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'CheckConservationScorePerBlock',
   DESCRIPTION => 'Multiple alignments with >3 species and >3 sequences must have a conservation score',
-  GROUPS      => ['compara', 'compara_multiple_alignments'],
+  GROUPS      => ['compara', 'compara_genome_alignments'],
   DB_TYPES    => ['compara'],
   TABLES      => ['conservation_score', 'dnafrag', 'genome_db', 'genomic_align', 'genomic_align_block', 'method_link', 'method_link_species_set', 'method_link_species_set_tag']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckConstrainedElementTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckConstrainedElementTable.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckConstrainedElementTable',
   DESCRIPTION    => 'Each row should show a one-to-many relationship',
-  GROUPS         => ['compara', 'compara_multiple_alignments'],
+  GROUPS         => ['compara', 'compara_genome_alignments'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['constrained_elements']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckDuplicatedTaxaNames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckDuplicatedTaxaNames.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckDuplicatedTaxaNames',
   DESCRIPTION    => 'Check that the ncbi_taxa_name contains only unique rows',
-  GROUPS         => ['compara', 'compara_master'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['ncbi_taxa_name']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckDuplicatedTaxaNames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckDuplicatedTaxaNames.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckDuplicatedTaxaNames',
   DESCRIPTION    => 'Check that the ncbi_taxa_name contains only unique rows',
-  GROUPS         => ['compara'],
+  GROUPS         => ['compara', 'compara_master'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['ncbi_taxa_name']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckEmptyLeavesTrees.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckEmptyLeavesTrees.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckEmptyLeavesTrees',
   DESCRIPTION    => 'Check that none of the gene tree leaves have children',
-  GROUPS         => ['compara', 'compara_protein_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['gene_tree_node']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckFlatProteinTrees.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckFlatProteinTrees.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckFlatProteinTrees',
   DESCRIPTION    => 'Check protein tree integrity ensuring number of leaves with parent node at root < 3',
-  GROUPS         => ['compara', 'compara_protein_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['gene_tree_node', 'gene_tree_root']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGOCScoreStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGOCScoreStats.pm
@@ -30,7 +30,7 @@ use constant {
   NAME           => 'CheckGOCScoreStats',
   DESCRIPTION    => 'The number of rows for GOC have not dropped from previous release',
   GROUPS         => ['compara', 'compara_gene_trees'],
-  DATACHECK_TYPE => 'critical',
+  DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['compara'],
   TABLES         => ['homology']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGOCScoreStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGOCScoreStats.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckGOCScoreStats',
   DESCRIPTION    => 'The number of rows for GOC have not dropped from previous release',
-  GROUPS         => ['compara', 'compara_protein_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['homology']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGOCScoreStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGOCScoreStats.pm
@@ -56,6 +56,10 @@ sub tests {
     my $desc = "There are the same number of goc_score populated rows between releases for $type";
     cmp_ok( $curr_results->{$type} // 0, ">=", $prev_results->{$type}, $desc );
   }
+
+  unless (%$prev_results) {
+    plan skip_all => "No MLSSs to test in this database";
+  }
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGeneGainLossData.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGeneGainLossData.pm
@@ -39,7 +39,7 @@ use constant {
 sub skip_tests {
   my ($self) = @_;
   my $division = $self->dba->get_division();
-  if ( $division !~ /vertebrates/ ) {
+  if ( $division !~ /vertebrates/ && $division !~ /plants/ ) {
     return( 1, "Protein and ncRNA gain/loss trees are not analysed for $division" );
   }
 }

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGeneGainLossData.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGeneGainLossData.pm
@@ -51,14 +51,15 @@ sub tests {
   my $sql = qq/
     SELECT member_type, COUNT(*) 
       FROM gene_tree_root gtr 
-        JOIN CAFE_gene_family cgf 
+        LEFT JOIN CAFE_gene_family cgf
           ON(gtr.root_id=cgf.gene_tree_root_id) 
     WHERE gtr.tree_type = 'tree' 
       GROUP BY gtr.member_type
+      HAVING COUNT(cgf.gene_tree_root_id) = 0
   /;
   
-  my $desc = "There is data for ncRNA and protein gain/loss trees in the gene_tree_root and CAFE_gene_family tables";
-  cmp_rows($dbc, $sql, "==", 2, $desc);
+  my $desc = "All member types have gain/loss trees";
+  is_rows_zero($self->dba, $sql, $desc);
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGeneGainLossData.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGeneGainLossData.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckGeneGainLossData',
   DESCRIPTION    => 'ncRNA and protein trees must have gene Gain/Loss trees',
-  GROUPS         => ['compara', 'compara_protein_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['CAFE_gene_family', 'gene_tree_root']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignGenomeDBs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignGenomeDBs.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckGenomicAlignGenomeDBs',
   DESCRIPTION    => 'Check all genome_dbs for each method_link_species_set is present in genomic_aligns',
-  GROUPS         => ['compara', 'compara_multiple_alignments', 'compara_pairwise_alignments'],
+  GROUPS         => ['compara', 'compara_genome_alignments'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['dnafrag', 'genome_db', 'genomic_align', 'genomic_align_block', 'method_link_species_set', 'species_set']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignMTs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignMTs.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'CheckGenomicAlignMTs',
   DESCRIPTION => 'The multiple alignments should include all the MT sequences',
-  GROUPS      => ['compara', 'compara_multiple_alignments'],
+  GROUPS      => ['compara', 'compara_genome_alignments'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES    => ['compara'],
   TABLES      => ['dnafrag', 'genome_db', 'genomic_align', 'method_link', 'method_link_species_set', 'species_set']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignTreeTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignTreeTable.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckGenomicAlignTreeTable',
   DESCRIPTION    => 'Check the consistency and validity of genomic_align_tree',
-  GROUPS         => ['compara', 'compara_multiple_alignments'],
+  GROUPS         => ['compara', 'compara_genome_alignments'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['genomic_align_tree', 'method_link_species_set']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomology.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomology.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckHomology',
   DESCRIPTION    => 'Check homology_id are all one-to-many for homology_members',
-  GROUPS         => ['compara', 'compara_protein_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['homology', 'homology_member']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckJSONObjects.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckJSONObjects.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckJSONObjects',
   DESCRIPTION    => 'Check that all JSON objects in gene_tree_object_store are valid',
-  GROUPS         => ['compara', 'compara_protein_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['gene_tree_object_store']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckLastZCoverage.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckLastZCoverage.pm
@@ -79,22 +79,13 @@ sub tests {
     /;
     
     my $lastz_summary_sql = qq/
-      SELECT SUM(IF(tag_coverage <= genomic_align_coverage, 1, 0)) AS coverage_ok
+      SELECT *
       FROM ( $genomic_coverage_sql ) y
+      WHERE tag_coverage > genomic_align_coverage
     /;
     
-    my $species_set_size_sql = qq/
-      SELECT ss.size 
-      FROM species_set_header ss JOIN method_link_species_set m USING(species_set_id) 
-      WHERE m.method_link_species_set_id = $mlss_id
-    /;
-    
-    my $lastz_summary_result = $helper->execute_single_result(-SQL => $lastz_summary_sql);
-    my $species_set_size_result = $helper->execute_single_result(-SQL => $species_set_size_sql);
-  
-    my $desc_1 = "genomic_align coverage = method_link_species_set_tag coverage for mlss_id: $mlss_id";
-    is($lastz_summary_result, $species_set_size_result, $desc_1);
-    
+    my $desc_1 = "genomic_align coverage >= method_link_species_set_tag coverage for mlss_id: $mlss_id";
+    is_rows_zero($self->dba, $lastz_summary_sql, $desc_1);
   }
 }
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckLastZCoverage.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckLastZCoverage.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'CheckLastZCoverage',
   DESCRIPTION => 'Coverage for a LastZ MLSS matches the coverage recorded in the  mlss_tag table',
-  GROUPS      => ['compara', 'compara_pairwise_alignments'],
+  GROUPS      => ['compara', 'compara_genome_alignments'],
   DB_TYPES    => ['compara'],
   TABLES      => ['dnafrag', 'genome_db', 'genomic_align', 'method_link', 'method_link_species_set', 'method_link_species_set_tag', 'species_set_header']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMLSSIDConsistencyInGenomicAlign.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMLSSIDConsistencyInGenomicAlign.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckMLSSIDConsistencyInGenomicAlign',
   DESCRIPTION    => 'Check that method_link_species_set_id are the same across genomic_align and genomic_align_block',
-  GROUPS         => ['compara', 'compara_multiple_alignments', 'compara_pairwise_alignments'],
+  GROUPS         => ['compara', 'compara_genome_alignments'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['genomic_align', 'genomic_align_block']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMSANames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMSANames.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckMSANames',
   DESCRIPTION    => 'Ensure that every MSA method has a name in species_set_header',
-  GROUPS         => ['compara', 'compara_master', 'compara_multiple_alignments'],
+  GROUPS         => ['compara', 'compara_master', 'compara_genome_alignments'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['method_link', 'method_link_species_set', 'species_set_header']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMSANames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMSANames.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckMSANames',
   DESCRIPTION    => 'Ensure that every MSA method has a name in species_set_header',
-  GROUPS         => ['compara', 'compara_multiple_alignments'],
+  GROUPS         => ['compara', 'compara_master', 'compara_multiple_alignments'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['method_link', 'method_link_species_set', 'species_set_header']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMethodLinkSpeciesSetNames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMethodLinkSpeciesSetNames.pm
@@ -31,7 +31,7 @@ use constant {
   NAME           => 'CheckMethodLinkSpeciesSetNames',
   DESCRIPTION    => 'Check for consistency of names in method_link_species_set (and species_set_header)',
   GROUPS         => ['compara', 'compara_gene_trees', 'compara_master', 'compara_syntenies'],
-  DATACHECK_TYPE => 'critical',
+  DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['compara'],
   TABLES         => ['genome_db', 'method_link_species_set', 'species_set', 'species_set_header']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMethodLinkSpeciesSetNames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMethodLinkSpeciesSetNames.pm
@@ -51,7 +51,7 @@ sub tests {
     my $gdbs = $species_set->genome_dbs;
     my $gdb_count = scalar( @$gdbs );
 
-    if ( $mlss_name =~ /^([a-zA-Z]+) / ) {
+    if ( $mlss_name =~ /^([a-zA-Z\-\.]+) / ) {
       my $mlss_p1 = $1;
       # Since there are many species_sets below first_release 81 in plants that have no name at all, set a
       # threshold to avoid checking them (and failing)

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMethodLinkSpeciesSetNames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMethodLinkSpeciesSetNames.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckMethodLinkSpeciesSetNames',
   DESCRIPTION    => 'Check for consistency of names in method_link_species_set (and species_set_header)',
-  GROUPS         => ['compara'],
+  GROUPS         => ['compara', 'compara_master'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['genome_db', 'method_link_species_set', 'species_set', 'species_set_header']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMethodLinkSpeciesSetNames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMethodLinkSpeciesSetNames.pm
@@ -53,8 +53,6 @@ sub tests {
 
     if ( $mlss_name =~ /^([a-zA-Z]+) / ) {
       my $mlss_p1 = $1;
-      my $desc_1 = "The current convention is in place for mlss $mlss_name ($mlss_id) and species_set $species_set_name ($species_set_id)";
-      unlike( $mlss_name, qr/^(protein|nc|species)/, $desc_1 );
       # Since there are many species_sets below first_release 81 in plants that have no name at all, set a
       # threshold to avoid checking them (and failing)
       next if ($species_set->first_release // 0) <= 80;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMethodLinkSpeciesSetNames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMethodLinkSpeciesSetNames.pm
@@ -43,6 +43,8 @@ sub tests {
   my $mlss = $mlss_adap->fetch_all;
 
   foreach my $mlss ( @$mlss ) {
+    # The convention only applies to MLSSs that have been released and are current
+    next if (!$mlss->first_release || $mlss->last_release);
     my $mlss_name = $mlss->name;
     my $mlss_id = $mlss->dbID;
     my $species_set = $mlss->species_set;
@@ -53,11 +55,7 @@ sub tests {
 
     if ( $mlss_name =~ /^([a-zA-Z\-\.]+) / ) {
       my $mlss_p1 = $1;
-      # Since there are many species_sets below first_release 81 in plants that have no name at all, set a
-      # threshold to avoid checking them (and failing)
-      next if ($species_set->first_release // 0) <= 80;
       my $desc_2 = "species_set $species_set_id for mlss $mlss_name ($mlss_id) starts with the species_set name $species_set_name";
-
       if ( $species_set_name =~ /collection/ ) {
         is( $species_set_name, "collection-$mlss_p1", $desc_2 );
       }
@@ -65,7 +63,6 @@ sub tests {
         is( $species_set_name, $mlss_p1, $desc_2 );
       }
     }
-    next if ($species_set->first_release // 0) <= 80;
     if ( $gdb_count >= 1 && $gdb_count <=2 ) {
       my @species_count = split /-/, $species_set_name;
       my $desc_3 = "For $mlss_name ($mlss_id) the species_set $species_set_name ($species_set_id) is appropriately named with the correct number of genomes";

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMethodLinkSpeciesSetNames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMethodLinkSpeciesSetNames.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckMethodLinkSpeciesSetNames',
   DESCRIPTION    => 'Check for consistency of names in method_link_species_set (and species_set_header)',
-  GROUPS         => ['compara', 'compara_master'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_master', 'compara_syntenies'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['genome_db', 'method_link_species_set', 'species_set', 'species_set_header']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMultipleAlignCoverage.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMultipleAlignCoverage.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'CheckMultipleAlignCoverage',
   DESCRIPTION => 'Coverage for a multiple whole genome alignment MLSS matches the coverage recorded in the  mlss_tag table',
-  GROUPS      => ['compara', 'compara_multiple_alignments'],
+  GROUPS      => ['compara', 'compara_genome_alignments'],
   DB_TYPES    => ['compara'],
   TABLES      => ['dnafrag', 'genome_db', 'genomic_align', 'method_link', 'method_link_species_set', 'species_tree_node', 'species_tree_node_tag']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMultipleAlignCoverage.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMultipleAlignCoverage.pm
@@ -95,7 +95,7 @@ sub tests {
 
     my $desc_2 = "genomic_align coverage matches species_tree_node_tag for mlss_id: $mlss_id";
 
-    my $summary_result = $helper->execute_single_result(-SQL => $msa_summary_sql);
+    my $summary_result = $helper->execute_single_result(-SQL => $msa_summary_sql, -NO_ERROR => 1);
     
     is($summary_result, 1, $desc_2);
     

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMultipleAlignCoverage.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMultipleAlignCoverage.pm
@@ -78,7 +78,7 @@ sub tests {
     /;
 
     my $tag_coverage_sql = qq/
-    SELECT n.genome_db_id, t.value AS tag_coverage, g.genomic_align_coverage 
+    SELECT n.genome_db_id, n.node_name, t.value AS tag_coverage, g.genomic_align_coverage
       FROM species_tree_node n 
         JOIN species_tree_root r USING(root_id)
         JOIN species_tree_node_tag t USING(node_id) 
@@ -86,18 +86,12 @@ sub tests {
       WHERE n.genome_db_id IS NOT NULL 
         AND t.tag = 'genome_coverage' 
         AND r.method_link_species_set_id = $mlss_id
-    /;
-
-    my $msa_summary_sql = qq/
-      SELECT FORMAT(AVG(IF(genomic_align_coverage >= tag_coverage, 1, 0)), '#') 
-        FROM ( $tag_coverage_sql ) c
+        AND g.genomic_align_coverage < t.value
     /;
 
     my $desc_2 = "genomic_align coverage matches species_tree_node_tag for mlss_id: $mlss_id";
 
-    my $summary_result = $helper->execute_single_result(-SQL => $msa_summary_sql, -NO_ERROR => 1);
-    
-    is($summary_result, 1, $desc_2);
+    is_rows_zero($self->dba, $tag_coverage_sql, $desc_2);
     
   }
 }

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckOrthologyQCThresholds.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckOrthologyQCThresholds.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckOrthologyQCThresholds',
   DESCRIPTION    => 'Check that some wga_coverage and goc_score thresholds have been populated',
-  GROUPS         => ['compara', 'compara_protein_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['method_link_species_set_attr']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckPairAlignerUniqueMethod.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckPairAlignerUniqueMethod.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckPairAlignerUniqueMethod',
   DESCRIPTION    => 'Ensure that there is only one method for pairwise alignment per species_set',
-  GROUPS         => ['compara', 'compara_master', 'compara_pairwise_alignments'],
+  GROUPS         => ['compara', 'compara_master', 'compara_genome_alignments'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['method_link', 'method_link_species_set']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckPairAlignerUniqueMethod.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckPairAlignerUniqueMethod.pm
@@ -62,8 +62,6 @@ sub tests {
   foreach my $method ( @methods ) {
     my $mlsses = $mlss_adap->fetch_all_by_method_link_type($method);
     foreach my $mlss ( @$mlsses ){
-      my $mlss_id = $mlss->dbID;
-      my $mlss_name = $mlss->name;
       my $ss_name = $mlss->species_set->name;
       my $ss_id = $mlss->species_set->dbID;
       my $ss_key = $ss_name ? "$ss_id ($ss_name)" : $ss_id;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckPairAlignerUniqueMethod.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckPairAlignerUniqueMethod.pm
@@ -66,7 +66,8 @@ sub tests {
       my $mlss_name = $mlss->name;
       my $ss_name = $mlss->species_set->name;
       my $ss_id = $mlss->species_set->dbID;
-      $species_sets{"$ss_id ($ss_name)"}++;
+      my $ss_key = $ss_name ? "$ss_id ($ss_name)" : $ss_id;
+      $species_sets{$ss_key}++;
     }
   }
   foreach my $species_set ( sort keys %species_sets ) {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckPairAlignerUniqueMethod.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckPairAlignerUniqueMethod.pm
@@ -62,6 +62,10 @@ sub tests {
   foreach my $method ( @methods ) {
     my $mlsses = $mlss_adap->fetch_all_by_method_link_type($method);
     foreach my $mlss ( @$mlsses ){
+      if (!$mlss->first_release || $mlss->last_release) {
+        # the rule only applies to current MLSSs
+        next;
+      }
       my $ss_name = $mlss->species_set->name;
       my $ss_id = $mlss->species_set->dbID;
       my $ss_key = $ss_name ? "$ss_id ($ss_name)" : $ss_id;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckPairAlignerUniqueMethod.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckPairAlignerUniqueMethod.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckPairAlignerUniqueMethod',
   DESCRIPTION    => 'Ensure that there is only one method for pairwise alignment per species_set',
-  GROUPS         => ['compara', 'compara_pairwise_alignments'],
+  GROUPS         => ['compara', 'compara_master', 'compara_pairwise_alignments'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['method_link', 'method_link_species_set']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckReleaseConsistency.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckReleaseConsistency.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckReleaseConsistency',
   DESCRIPTION    => 'Check for consistency between retired genomes and species_sets',
-  GROUPS         => ['compara'],
+  GROUPS         => ['compara', 'compara_master'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['genome_db', 'method_link_species_set', 'species_set_header']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckReleaseConsistency.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckReleaseConsistency.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckReleaseConsistency',
   DESCRIPTION    => 'Check for consistency between retired genomes and species_sets',
-  GROUPS         => ['compara', 'compara_master'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_master', 'compara_syntenies'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['genome_db', 'method_link_species_set', 'species_set_header']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckReleaseNulls.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckReleaseNulls.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckReleaseNulls',
   DESCRIPTION    => 'For release DB the last_release must be NULL but cannot have a NULL first_release',
-  GROUPS         => ['compara'],
+  GROUPS         => ['compara', 'compara_master'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['genome_db', 'method_link_species_set', 'species_set_header']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckReleaseNulls.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckReleaseNulls.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckReleaseNulls',
   DESCRIPTION    => 'For release DB the last_release must be NULL but cannot have a NULL first_release',
-  GROUPS         => ['compara', 'compara_master'],
+  GROUPS         => ['compara', 'compara_master', 'compara_syntenies'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['genome_db', 'method_link_species_set', 'species_set_header']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSequenceTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSequenceTable.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckSequenceTable',
   DESCRIPTION    => 'Check for sequence length and availability',
-  GROUPS         => ['compara'],
+  GROUPS         => ['compara', 'compara_gene_trees'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['sequence']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetSizeByMethod.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetSizeByMethod.pm
@@ -68,7 +68,7 @@ sub tests {
       my $gdbs = $species_set->genome_dbs;
       my $gdb_count = scalar( @$gdbs );
 
-      if ( ($method eq 'LASTZ_NET') && ($gdb_count == 1) && ($species_set_name !~ /-/) ) {
+      if ( ($method eq 'LASTZ_NET' || $method eq 'SYNTENY') && ($gdb_count == 1) && ($species_set_name !~ /-/) ) {
         $allowable_count = 1;
       }
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetSizeByMethod.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetSizeByMethod.pm
@@ -54,6 +54,7 @@ sub tests {
     "SYNTENY"               => 2
   );
 
+  my $found = 0;
   foreach my $method ( keys %methods ) {
     next if ( $method eq "ENSEMBL_PARALOGUES" && $self->dba->dbc->dbname =~ /master/ );
     my $mlsss = $mlss_adap->fetch_all_by_method_link_type($method);
@@ -78,7 +79,11 @@ sub tests {
       if ( $mlss_name =~ /(^[0-9]+) / ) {
         is($1, $gdb_count, "species_set $species_set_name and mlss $mlss_name both link to $gdb_count genomes");
       }
+      $found = 1;
     }
+  }
+  unless ($found) {
+    plan skip_all => "No MLSSs to test in this database";
   }
 }
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetSizeByMethod.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetSizeByMethod.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckSpeciesSetSizeByMethod',
   DESCRIPTION    => 'Checks that the species-sets have the expected number of genomes',
-  GROUPS         => ['compara', 'compara_master', 'compara_pairwise_alignments', 'compara_protein_trees', 'compara_syntenies'],
+  GROUPS         => ['compara', 'compara_master', 'compara_genome_alignments', 'compara_gene_trees', 'compara_syntenies'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['method_link', 'method_link_species_set', 'species_set']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetSizeByMethod.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetSizeByMethod.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckSpeciesSetSizeByMethod',
   DESCRIPTION    => 'Checks that the species-sets have the expected number of genomes',
-  GROUPS         => ['compara', 'compara_pairwise_alignments', 'compara_protein_trees', 'compara_syntenies'],
+  GROUPS         => ['compara', 'compara_master', 'compara_pairwise_alignments', 'compara_protein_trees', 'compara_syntenies'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['method_link', 'method_link_species_set', 'species_set']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetSizeByMethod.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetSizeByMethod.pm
@@ -68,10 +68,12 @@ sub tests {
       my $gdbs = $species_set->genome_dbs;
       my $gdb_count = scalar( @$gdbs );
 
-      my $desc = "For MLSS $mlss_name there are $allowable_count genome_dbs for species_set $species_set_name ($species_set_id), as expected";
       if ( ($method eq 'LASTZ_NET') && ($gdb_count == 1) && ($species_set_name !~ /-/) ) {
         $allowable_count = 1;
       }
+
+      my $desc = "For MLSS $mlss_name there are $allowable_count genome_dbs for species_set $species_set_name ($species_set_id), as expected";
+
       is( $gdb_count, $allowable_count, $desc );
       if ( $mlss_name =~ /(^[0-9]+) / ) {
         is($1, $gdb_count, "species_set $species_set_name and mlss $mlss_name both link to $gdb_count genomes");

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetTable.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckSpeciesSetTable',
   DESCRIPTION    => 'Check species_set_tags have no orphans and species_sets are unique',
-  GROUPS         => ['compara'],
+  GROUPS         => ['compara', 'compara_master'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['species_set']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetTable.pm
@@ -33,7 +33,7 @@ use constant {
   GROUPS         => ['compara'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
-  TABLES         => ['species_set', 'species_set_tag']
+  TABLES         => ['species_set']
 };
 
 sub tests {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetTable.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckSpeciesSetTable',
   DESCRIPTION    => 'Check species_set_tags have no orphans and species_sets are unique',
-  GROUPS         => ['compara', 'compara_master'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['species_set']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetTable.pm
@@ -39,7 +39,7 @@ use constant {
 sub tests {
   my ($self) = @_;
   my $dbc = $self->dba->dbc;
-  my $helper = $self->dba->dbc->sql_helper;
+  my $helper = $dbc->sql_helper;
     
   my $sql = q/
     SELECT species_set_id, genome_db_id
@@ -75,4 +75,3 @@ sub tests {
 }
 
 1;
-

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesTreeNodeAttr.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesTreeNodeAttr.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckSpeciesTreeNodeAttr',
   DESCRIPTION    => 'Check some entries in species_tree_node_attr are > 0',
-  GROUPS         => ['compara', 'compara_protein_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['species_tree_node_attr', 'species_tree_root']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckTableSizes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckTableSizes.pm
@@ -57,11 +57,27 @@ sub tests {
   foreach my $table ( @$curr_tables ) {
     $curr_tables{$table}++;
   }
+
+  # Tables that are not expected to grow
+  my @constant_tables = qw(method_link species_tree_root species_set_tag);
+  my $division = $curr_dba->get_division();
+  if ($division eq 'pan') {
+    # The number of species is pan is frozen
+    push @constant_tables, qw(genome_db method_link_species_set species_set species_set_header);
+  }
+  my %constant_tables = map {$_ => 1} @constant_tables;
   
   foreach my $table ( @$curr_tables ) {
+
+    # The meta table is not expected to follow the same growth rules
+    next if $table eq 'meta';
+
     my $desc_1 = "The number of rows in $table for $curr_db_name has not increased by >10% from $prev_db_name";
     my $desc_2 = "The number of rows in $table for $curr_db_name has not decreased by >5% from $prev_db_name";
-    my $desc_3 = "The number of rows in $table has not remained static between $curr_db_name and $prev_db_name";
+    my $desc_3 = "The number of rows in $table has changed between $curr_db_name and $prev_db_name";
+    my $desc_5 = "Table $table has the same number of rows as in $prev_db_name";
+    my $desc_6 = "Table $table is still empty";
+    my $desc_7 = "Table $table is still not empty";
     my $sql = qq/
       SELECT COUNT(*) FROM $table
     /;
@@ -70,9 +86,28 @@ sub tests {
       my $prev_row_count = $prev_helper->execute_single_result( -SQL => $sql );
       my $curr_row_count = $curr_helper->execute_single_result( -SQL => $sql );
 
-      cmp_ok( $curr_row_count, '<=', ($prev_row_count*1.1), $desc_1 );
-      cmp_ok( $curr_row_count, '>=', ($prev_row_count*0.95), $desc_2 );
-      cmp_ok( $curr_row_count, '!=', $prev_row_count, $desc_3 );
+      if ($constant_tables{$table}) {
+        # Tables that should have a constant size
+        is($curr_row_count, $prev_row_count, $desc_5);
+
+      } elsif ($prev_row_count) {
+        # Non empty tables should remain not empty
+        isnt( $curr_row_count, 0, $desc_7);
+
+        # Don't bother doing these tests since we not they will fail and
+        # the reason has already been reported
+        if ($curr_row_count) {
+          # Both tables have some data, we expect the new size to be
+          # different and within the [95%, 110%] interval
+          cmp_ok( $curr_row_count, '<=', ($prev_row_count*1.1), $desc_1 );
+          cmp_ok( $curr_row_count, '>=', ($prev_row_count*0.95), $desc_2 );
+          isnt( $curr_row_count, $prev_row_count, $desc_3 );
+        }
+
+      } else {
+        # Empty tables should remain empty
+        is($curr_row_count, 0, $desc_6);
+      }
         
     } else {
       my $desc_4 = "New table: $table is populated with data";

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckTableSizes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckTableSizes.pm
@@ -62,7 +62,7 @@ sub tests {
   my @constant_tables = qw(method_link species_tree_root species_set_tag);
   my $division = $curr_dba->get_division();
   if ($division eq 'pan') {
-    # The number of species is pan is frozen
+    # The number of species in pan is frozen
     push @constant_tables, qw(genome_db method_link_species_set species_set species_set_header);
   }
   my %constant_tables = map {$_ => 1} @constant_tables;
@@ -94,7 +94,7 @@ sub tests {
         # Non empty tables should remain not empty
         isnt( $curr_row_count, 0, $desc_7);
 
-        # Don't bother doing these tests since we not they will fail and
+        # Don't bother doing these tests since we know they will fail and
         # the reason has already been reported
         if ($curr_row_count) {
           # Both tables have some data, we expect the new size to be
@@ -122,4 +122,3 @@ sub tests {
 }
 
 1;
-

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckTableSizes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckTableSizes.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckTableSizes',
   DESCRIPTION    => 'Tables must be populated and not differ significantly in row numbers',
-  GROUPS         => ['compara', 'compara_tables'],
+  GROUPS         => ['compara'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['compara'],
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckWGACoverageStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckWGACoverageStats.pm
@@ -31,7 +31,7 @@ use constant {
   NAME           => 'CheckWGACoverageStats',
   DESCRIPTION    => 'The number of rows for WGA coverage have not dropped from previous release',
   GROUPS         => ['compara', 'compara_gene_trees'],
-  DATACHECK_TYPE => 'critical',
+  DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['compara'],
   TABLES         => ['homology']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckWGACoverageStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckWGACoverageStats.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckWGACoverageStats',
   DESCRIPTION    => 'The number of rows for WGA coverage have not dropped from previous release',
-  GROUPS         => ['compara', 'compara_protein_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['homology']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckWGACoverageStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckWGACoverageStats.pm
@@ -58,6 +58,9 @@ sub tests {
     cmp_ok( $curr_results->{$type} // 0, ">=", $prev_results->{$type}, $desc );
   }
 
+  unless (%$prev_results) {
+    plan skip_all => "No MLSSs to test in this database";
+  }
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CigarCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CigarCheck.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CigarCheck',
   DESCRIPTION    => 'The cigar_line must not have negative numbers or zeros in it',
-  GROUPS         => ['compara', 'compara_pairwise_alignments'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['family_member', 'gene_align_member', 'genomic_align', 'homology_member', 'peptide_align_feature'],

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareMSANames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareMSANames.pm
@@ -28,7 +28,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CompareMSANames',
   DESCRIPTION    => 'The species_sets from the previous database are still present',
-  GROUPS         => ['compara', 'compara_multiple_alignments'],
+  GROUPS         => ['compara'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['compara'],
   TABLES         => ['method_link', 'method_link_species_set', 'species_set_header']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DatabaseCollation.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DatabaseCollation.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'DatabaseCollation',
   DESCRIPTION => 'All tables have the same collation (latin1_swedish_ci)',
-  GROUPS      => ['compara', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['compara', 'compara_master', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DatabaseCollation.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DatabaseCollation.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'DatabaseCollation',
   DESCRIPTION => 'All tables have the same collation (latin1_swedish_ci)',
-  GROUPS      => ['compara', 'compara_master', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
@@ -32,7 +32,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'ForeignKeysCompara',
   DESCRIPTION => 'Foreign key relationships are not violated',
-  GROUPS      => ['compara'],
+  GROUPS      => ['compara', 'compara_master'],
   DB_TYPES    => ['compara'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
@@ -55,6 +55,10 @@ sub tests {
       my ($col1, $table2, $col2) = $line =~
         /\s*FOREIGN\s+KEY\s+\((\S+)\)\s+REFERENCES\s+(\S+)\s*\((\S+)\)/i;
       if (defined $col1 && defined $table2 && defined $col2) {
+        # Because the master database may have old genomes linked to deprecated taxon_ids
+        if ($self->dba->dbc->dbname =~ /master/) {
+          next if "$table1 $col1 $table2 $col2" eq 'genome_db taxon_id ncbi_taxa_node taxon_id';
+        }
         fk($self->dba, $table1, $col1, $table2, $col2);
       } else {
         push @failed_to_parse, $line;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
@@ -32,7 +32,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'ForeignKeysCompara',
   DESCRIPTION => 'Foreign key relationships are not violated',
-  GROUPS      => ['compara', 'compara_master'],
+  GROUPS      => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies'],
   DB_TYPES    => ['compara'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/HighConfidence.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/HighConfidence.pm
@@ -38,6 +38,12 @@ use constant {
 
 sub skip_tests {
   my ($self) = @_;
+
+  my $division = $self->dba->get_division();
+  if ( $division =~ /fungi/ ) {
+    return( 1, "HighConfidence data are not generated for $division" );
+  }
+
   my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
   my $mlss = $mlss_adap->fetch_all_by_method_link_type('ENSEMBL_ORTHOLOGUES');
   my $db_name = $self->dba->dbc->dbname;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/HighConfidence.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/HighConfidence.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'HighConfidence',
   DESCRIPTION    => 'Checks that the HighConfidenceOrthologs pipeline has been run',
-  GROUPS         => ['compara', 'compara_protein_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['homology']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MemberProductionCounts.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MemberProductionCounts.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'MemberProductionCounts',
   DESCRIPTION    => 'Checks that the gene_member counts are appropriately populated',
-  GROUPS         => ['compara', 'compara_protein_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['CAFE_gene_family', 'family', 'gene_member', 'gene_member_hom_stats', 'gene_tree_root', 'genome_db']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MemberProductionCounts.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MemberProductionCounts.pm
@@ -159,7 +159,7 @@ sub tests {
     /;
     is_rows_zero( $dbc, $sqlBrokenGainLossCounts, $desc_10 );
 
-    my $desc_11 = "Columns in gene_member_hom_stats have been correctly populated for the $collection collection";
+    my $desc_11 = "All gene_trees>1 have an actual gene-tree for the $collection collection";
     my $sqlPopulateGMHS = qq/
       SELECT COUNT(*) 
         FROM gene_member_hom_stats 
@@ -173,7 +173,7 @@ sub tests {
     /;
     is_rows_zero( $dbc, $sqlPopulateGMHS, $desc_11 );
 
-    my $desc_12 = "Columns in gene_member_hom_stats have been correctly populated with gene_tree_root for the $collection collection";
+    my $desc_12 = "All gene_trees=0 have no gene-tree for the $collection collection";
     my $sqlPopulatewithGTR = qq/
       SELECT COUNT(*) 
         FROM gene_member_hom_stats 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MemberProductionCounts.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MemberProductionCounts.pm
@@ -179,7 +179,7 @@ sub tests {
         FROM gene_member_hom_stats 
           JOIN gene_member 
             USING (gene_member_id) 
-          LEFT JOIN gene_tree_node 
+          JOIN gene_tree_node
             ON canonical_member_id = seq_member_id
           JOIN gene_tree_root USING (root_id)
       WHERE gene_trees = 0 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MemberProductionCounts.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MemberProductionCounts.pm
@@ -61,6 +61,8 @@ sub tests {
   my $helper = $dbc->sql_helper;
   my $gdb_adap = $dba->get_GenomeDBAdaptor;
 
+  my $division = $dba->get_division();
+
   my $sql_sums = qq/
     SELECT SUM(families) AS sum_families, SUM(gene_trees) AS sum_gene_trees, SUM(gene_gain_loss_trees) AS sum_gene_gain_loss_trees, SUM(orthologues) AS sum_orthologues, SUM(paralogues) AS sum_paralogues, SUM(homoeologues) AS sum_homoeologues 
       FROM gene_member_hom_stats 
@@ -114,7 +116,7 @@ sub tests {
     
     my @counts = ($family_count, $genetree_count, $cafetrees_count, $genetree_count, $genetree_count, $polyploid_count);
 
-    if ( $dba->get_division() =~ /vertebrates/ && $collection =~ /default/ ) {
+    if ( $division =~ /vertebrates/ && $collection =~ /default/ ) {
       my $desc_5 = "The sum of entries for families in gene_member_hom_stats > 0 for the $collection collection";
       cmp_ok( $sums->[0]->{sum_families}, ">", 0, $desc_5 );
       my $desc_6 = "There are entries in the family table";
@@ -123,7 +125,7 @@ sub tests {
       my $desc_8 = "There were no unexpected entries in gene_member_hom_stats with families > 0 for the $collection collection";
       is( $sums->[0]->{sum_families} > 0, $counts[0] > 0, $desc_7 );
     }
-    if ( $dba->get_division() =~ /vertebrates/ || $collection =~ /default/ ) {
+    if ( $division =~ /vertebrates/ || $collection =~ /default/ ) {
       my $desc_5 = "The sum of entries for gene_trees in gene_member_hom_stats > 0 for the $collection collection";
       cmp_ok( $sums->[0]->{sum_gene_trees}, ">", 0, $desc_5 );
       my $desc_6 = "There are entries in the gene_tree table";

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyLevel.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyLevel.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'MetaKeyLevel',
   DESCRIPTION => 'Meta keys are correctly assigned at species or database level',
-  GROUPS      => ['compara', 'compara_master', 'core', 'corelike', 'funcgen', 'meta', 'variation'],
+  GROUPS      => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'meta', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyLevel.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyLevel.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'MetaKeyLevel',
   DESCRIPTION => 'Meta keys are correctly assigned at species or database level',
-  GROUPS      => ['core', 'corelike', 'funcgen', 'meta', 'variation'],
+  GROUPS      => ['compara', 'core', 'corelike', 'funcgen', 'meta', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyLevel.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyLevel.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'MetaKeyLevel',
   DESCRIPTION => 'Meta keys are correctly assigned at species or database level',
-  GROUPS      => ['compara', 'core', 'corelike', 'funcgen', 'meta', 'variation'],
+  GROUPS      => ['compara', 'compara_master', 'core', 'corelike', 'funcgen', 'meta', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MultipleGenomicAlignBlockIds.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MultipleGenomicAlignBlockIds.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'MultipleGenomicAlignBlockIds',
   DESCRIPTION    => 'Check that every genomic_align_block_id has more than one genomic_align_id',
-  GROUPS         => ['compara', 'compara_pairwise_alignments'],
+  GROUPS         => ['compara', 'compara_genome_alignments'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['genomic_align', 'method_link', 'method_link_species_set']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/NoDataOnGenomeComponents.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/NoDataOnGenomeComponents.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'NoDataOnGenomeComponents',
   DESCRIPTION    => 'Data is only allowed on principle genomes and not components',
-  GROUPS         => ['compara', 'compara_multiple_alignments', 'compara_pairwise_alignments', 'compara_protein_trees', 'compara_syntenies'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_syntenies'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['constrained_element', 'dnafrag', 'dnafrag_region', 'gene_member', 'genome_db', 'genomic_align', 'seq_member']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaPatchesApplied.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaPatchesApplied.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SchemaPatchesApplied',
   DESCRIPTION => 'Schema patches are up-to-date',
-  GROUPS      => ['compara', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['compara', 'compara_master', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'production', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaPatchesApplied.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaPatchesApplied.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SchemaPatchesApplied',
   DESCRIPTION => 'Schema patches are up-to-date',
-  GROUPS      => ['compara', 'compara_master', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'production', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaType.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaType.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SchemaType',
   DESCRIPTION => 'The schema type meta key matches the DB name',
-  GROUPS      => ['compara', 'compara_master', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaType.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaType.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SchemaType',
   DESCRIPTION => 'The schema type meta key matches the DB name',
-  GROUPS      => ['compara', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['compara', 'compara_master', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/TagCoverageStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/TagCoverageStats.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'TagCoverageStats',
   DESCRIPTION    => 'The coverage must not exceed the genome lengths',
-  GROUPS         => ['compara', 'compara_pairwise_alignments'],
+  GROUPS         => ['compara', 'compara_genome_alignments', 'compara_syntenies'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['method_link_species_set_tag', 'species_tree_node_tag'],

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1399,6 +1399,7 @@
       "datacheck_type" : "critical",
       "description" : "Meta keys are correctly assigned at species or database level",
       "groups" : [
+         "compara",
          "core",
          "corelike",
          "funcgen",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -370,7 +370,7 @@
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckMSANames"
    },
    "CheckMethodLinkSpeciesSetNames" : {
-      "datacheck_type" : "critical",
+      "datacheck_type" : "advisory",
       "description" : "Check for consistency of names in method_link_species_set (and species_set_header)",
       "groups" : [
          "compara",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -146,6 +146,7 @@
       "description" : "Enum columns do not have empty string values",
       "groups" : [
          "compara",
+         "compara_master",
          "core",
          "corelike",
          "funcgen",
@@ -160,6 +161,7 @@
       "description" : "Nullable columns do not have empty string values",
       "groups" : [
          "compara",
+         "compara_master",
          "core",
          "corelike",
          "funcgen",
@@ -234,7 +236,8 @@
       "datacheck_type" : "critical",
       "description" : "Check that the ncbi_taxa_name contains only unique rows",
       "groups" : [
-         "compara"
+         "compara",
+         "compara_master"
       ],
       "name" : "CheckDuplicatedTaxaNames",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckDuplicatedTaxaNames"
@@ -356,6 +359,7 @@
       "description" : "Ensure that every MSA method has a name in species_set_header",
       "groups" : [
          "compara",
+         "compara_master",
          "compara_multiple_alignments"
       ],
       "name" : "CheckMSANames",
@@ -365,7 +369,8 @@
       "datacheck_type" : "critical",
       "description" : "Check for consistency of names in method_link_species_set (and species_set_header)",
       "groups" : [
-         "compara"
+         "compara",
+         "compara_master"
       ],
       "name" : "CheckMethodLinkSpeciesSetNames",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckMethodLinkSpeciesSetNames"
@@ -395,6 +400,7 @@
       "description" : "Ensure that there is only one method for pairwise alignment per species_set",
       "groups" : [
          "compara",
+         "compara_master",
          "compara_pairwise_alignments"
       ],
       "name" : "CheckPairAlignerUniqueMethod",
@@ -404,7 +410,8 @@
       "datacheck_type" : "critical",
       "description" : "Check for consistency between retired genomes and species_sets",
       "groups" : [
-         "compara"
+         "compara",
+         "compara_master"
       ],
       "name" : "CheckReleaseConsistency",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckReleaseConsistency"
@@ -413,7 +420,8 @@
       "datacheck_type" : "critical",
       "description" : "For release DB the last_release must be NULL but cannot have a NULL first_release",
       "groups" : [
-         "compara"
+         "compara",
+         "compara_master"
       ],
       "name" : "CheckReleaseNulls",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckReleaseNulls"
@@ -432,6 +440,7 @@
       "description" : "Checks that the species-sets have the expected number of genomes",
       "groups" : [
          "compara",
+         "compara_master",
          "compara_pairwise_alignments",
          "compara_protein_trees",
          "compara_syntenies"
@@ -443,7 +452,8 @@
       "datacheck_type" : "critical",
       "description" : "Check species_set_tags have no orphans and species_sets are unique",
       "groups" : [
-         "compara"
+         "compara",
+         "compara_master"
       ],
       "name" : "CheckSpeciesSetTable",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckSpeciesSetTable"
@@ -865,6 +875,7 @@
       "description" : "All tables have the same collation (latin1_swedish_ci)",
       "groups" : [
          "compara",
+         "compara_master",
          "core",
          "corelike",
          "funcgen",
@@ -1101,7 +1112,8 @@
       "datacheck_type" : "critical",
       "description" : "Foreign key relationships are not violated",
       "groups" : [
-         "compara"
+         "compara",
+         "compara_master"
       ],
       "name" : "ForeignKeysCompara",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ForeignKeysCompara"
@@ -1400,6 +1412,7 @@
       "description" : "Meta keys are correctly assigned at species or database level",
       "groups" : [
          "compara",
+         "compara_master",
          "core",
          "corelike",
          "funcgen",
@@ -1681,6 +1694,7 @@
       "description" : "Schema patches are up-to-date",
       "groups" : [
          "compara",
+         "compara_master",
          "core",
          "corelike",
          "funcgen",
@@ -1695,6 +1709,7 @@
       "description" : "The schema type meta key matches the DB name",
       "groups" : [
          "compara",
+         "compara_master",
          "core",
          "corelike",
          "funcgen",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -15,8 +15,7 @@
       "description" : "Alignment coordinates are within the length of their dnafrag",
       "groups" : [
          "compara",
-         "compara_pairwise_alignments",
-         "compara_multiple_alignments"
+         "compara_genome_alignments"
       ],
       "name" : "AlignmentCoordinates",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::AlignmentCoordinates"
@@ -146,7 +145,9 @@
       "description" : "Enum columns do not have empty string values",
       "groups" : [
          "compara",
+         "compara_gene_trees",
          "compara_master",
+         "compara_syntenies",
          "core",
          "corelike",
          "funcgen",
@@ -161,7 +162,10 @@
       "description" : "Nullable columns do not have empty string values",
       "groups" : [
          "compara",
+         "compara_gene_trees",
+         "compara_genome_alignments",
          "compara_master",
+         "compara_syntenies",
          "core",
          "corelike",
          "funcgen",
@@ -186,7 +190,7 @@
       "description" : "Each row should show a one-to-many relationship",
       "groups" : [
          "compara",
-         "compara_protein_trees"
+         "compara_gene_trees"
       ],
       "name" : "CheckCAFETable",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckCAFETable"
@@ -196,8 +200,7 @@
       "description" : "gene trees in gene_tree_root and family all have stable_ids generated",
       "groups" : [
          "compara",
-         "compara_families",
-         "compara_protein_trees"
+         "compara_gene_trees"
       ],
       "name" : "CheckComparaStableIDs",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckComparaStableIDs"
@@ -207,7 +210,7 @@
       "description" : "The MLSS for GERP_CONSERVATION_SCORE should have conservation score entries",
       "groups" : [
          "compara",
-         "compara_pairwise_alignments"
+         "compara_genome_alignments"
       ],
       "name" : "CheckConservationScore",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckConservationScore"
@@ -217,7 +220,7 @@
       "description" : "Multiple alignments with >3 species and >3 sequences must have a conservation score",
       "groups" : [
          "compara",
-         "compara_multiple_alignments"
+         "compara_genome_alignments"
       ],
       "name" : "CheckConservationScorePerBlock",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckConservationScorePerBlock"
@@ -227,7 +230,7 @@
       "description" : "Each row should show a one-to-many relationship",
       "groups" : [
          "compara",
-         "compara_multiple_alignments"
+         "compara_genome_alignments"
       ],
       "name" : "CheckConstrainedElementTable",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckConstrainedElementTable"
@@ -237,7 +240,10 @@
       "description" : "Check that the ncbi_taxa_name contains only unique rows",
       "groups" : [
          "compara",
-         "compara_master"
+         "compara_gene_trees",
+         "compara_genome_alignments",
+         "compara_master",
+         "compara_syntenies"
       ],
       "name" : "CheckDuplicatedTaxaNames",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckDuplicatedTaxaNames"
@@ -247,7 +253,7 @@
       "description" : "Check that none of the gene tree leaves have children",
       "groups" : [
          "compara",
-         "compara_protein_trees"
+         "compara_gene_trees"
       ],
       "name" : "CheckEmptyLeavesTrees",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckEmptyLeavesTrees"
@@ -257,7 +263,7 @@
       "description" : "Check protein tree integrity ensuring number of leaves with parent node at root < 3",
       "groups" : [
          "compara",
-         "compara_protein_trees"
+         "compara_gene_trees"
       ],
       "name" : "CheckFlatProteinTrees",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckFlatProteinTrees"
@@ -267,7 +273,7 @@
       "description" : "The number of rows for GOC have not dropped from previous release",
       "groups" : [
          "compara",
-         "compara_protein_trees"
+         "compara_gene_trees"
       ],
       "name" : "CheckGOCScoreStats",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckGOCScoreStats"
@@ -277,7 +283,7 @@
       "description" : "ncRNA and protein trees must have gene Gain/Loss trees",
       "groups" : [
          "compara",
-         "compara_protein_trees"
+         "compara_gene_trees"
       ],
       "name" : "CheckGeneGainLossData",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckGeneGainLossData"
@@ -287,8 +293,7 @@
       "description" : "Check all genome_dbs for each method_link_species_set is present in genomic_aligns",
       "groups" : [
          "compara",
-         "compara_multiple_alignments",
-         "compara_pairwise_alignments"
+         "compara_genome_alignments"
       ],
       "name" : "CheckGenomicAlignGenomeDBs",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckGenomicAlignGenomeDBs"
@@ -298,7 +303,7 @@
       "description" : "The multiple alignments should include all the MT sequences",
       "groups" : [
          "compara",
-         "compara_multiple_alignments"
+         "compara_genome_alignments"
       ],
       "name" : "CheckGenomicAlignMTs",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckGenomicAlignMTs"
@@ -308,7 +313,7 @@
       "description" : "Check the consistency and validity of genomic_align_tree",
       "groups" : [
          "compara",
-         "compara_multiple_alignments"
+         "compara_genome_alignments"
       ],
       "name" : "CheckGenomicAlignTreeTable",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckGenomicAlignTreeTable"
@@ -318,7 +323,7 @@
       "description" : "Check homology_id are all one-to-many for homology_members",
       "groups" : [
          "compara",
-         "compara_protein_trees"
+         "compara_gene_trees"
       ],
       "name" : "CheckHomology",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckHomology"
@@ -328,7 +333,7 @@
       "description" : "Check that all JSON objects in gene_tree_object_store are valid",
       "groups" : [
          "compara",
-         "compara_protein_trees"
+         "compara_gene_trees"
       ],
       "name" : "CheckJSONObjects",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckJSONObjects"
@@ -338,7 +343,7 @@
       "description" : "Coverage for a LastZ MLSS matches the coverage recorded in the  mlss_tag table",
       "groups" : [
          "compara",
-         "compara_pairwise_alignments"
+         "compara_genome_alignments"
       ],
       "name" : "CheckLastZCoverage",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckLastZCoverage"
@@ -348,8 +353,7 @@
       "description" : "Check that method_link_species_set_id are the same across genomic_align and genomic_align_block",
       "groups" : [
          "compara",
-         "compara_multiple_alignments",
-         "compara_pairwise_alignments"
+         "compara_genome_alignments"
       ],
       "name" : "CheckMLSSIDConsistencyInGenomicAlign",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckMLSSIDConsistencyInGenomicAlign"
@@ -360,7 +364,7 @@
       "groups" : [
          "compara",
          "compara_master",
-         "compara_multiple_alignments"
+         "compara_genome_alignments"
       ],
       "name" : "CheckMSANames",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckMSANames"
@@ -370,7 +374,9 @@
       "description" : "Check for consistency of names in method_link_species_set (and species_set_header)",
       "groups" : [
          "compara",
-         "compara_master"
+         "compara_gene_trees",
+         "compara_master",
+         "compara_syntenies"
       ],
       "name" : "CheckMethodLinkSpeciesSetNames",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckMethodLinkSpeciesSetNames"
@@ -380,7 +386,7 @@
       "description" : "Coverage for a multiple whole genome alignment MLSS matches the coverage recorded in the  mlss_tag table",
       "groups" : [
          "compara",
-         "compara_multiple_alignments"
+         "compara_genome_alignments"
       ],
       "name" : "CheckMultipleAlignCoverage",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckMultipleAlignCoverage"
@@ -390,7 +396,7 @@
       "description" : "Check that some wga_coverage and goc_score thresholds have been populated",
       "groups" : [
          "compara",
-         "compara_protein_trees"
+         "compara_gene_trees"
       ],
       "name" : "CheckOrthologyQCThresholds",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckOrthologyQCThresholds"
@@ -401,7 +407,7 @@
       "groups" : [
          "compara",
          "compara_master",
-         "compara_pairwise_alignments"
+         "compara_genome_alignments"
       ],
       "name" : "CheckPairAlignerUniqueMethod",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckPairAlignerUniqueMethod"
@@ -411,7 +417,9 @@
       "description" : "Check for consistency between retired genomes and species_sets",
       "groups" : [
          "compara",
-         "compara_master"
+         "compara_gene_trees",
+         "compara_master",
+         "compara_syntenies"
       ],
       "name" : "CheckReleaseConsistency",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckReleaseConsistency"
@@ -421,7 +429,8 @@
       "description" : "For release DB the last_release must be NULL but cannot have a NULL first_release",
       "groups" : [
          "compara",
-         "compara_master"
+         "compara_master",
+         "compara_syntenies"
       ],
       "name" : "CheckReleaseNulls",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckReleaseNulls"
@@ -430,7 +439,8 @@
       "datacheck_type" : "critical",
       "description" : "Check for sequence length and availability",
       "groups" : [
-         "compara"
+         "compara",
+         "compara_gene_trees"
       ],
       "name" : "CheckSequenceTable",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckSequenceTable"
@@ -441,8 +451,8 @@
       "groups" : [
          "compara",
          "compara_master",
-         "compara_pairwise_alignments",
-         "compara_protein_trees",
+         "compara_genome_alignments",
+         "compara_gene_trees",
          "compara_syntenies"
       ],
       "name" : "CheckSpeciesSetSizeByMethod",
@@ -453,7 +463,10 @@
       "description" : "Check species_set_tags have no orphans and species_sets are unique",
       "groups" : [
          "compara",
-         "compara_master"
+         "compara_gene_trees",
+         "compara_genome_alignments",
+         "compara_master",
+         "compara_syntenies"
       ],
       "name" : "CheckSpeciesSetTable",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckSpeciesSetTable"
@@ -463,7 +476,7 @@
       "description" : "Check some entries in species_tree_node_attr are > 0",
       "groups" : [
          "compara",
-         "compara_protein_trees"
+         "compara_gene_trees"
       ],
       "name" : "CheckSpeciesTreeNodeAttr",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckSpeciesTreeNodeAttr"
@@ -492,8 +505,7 @@
       "datacheck_type" : "advisory",
       "description" : "Tables must be populated and not differ significantly in row numbers",
       "groups" : [
-         "compara",
-         "compara_tables"
+         "compara"
       ],
       "name" : "CheckTableSizes",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckTableSizes"
@@ -503,7 +515,7 @@
       "description" : "The number of rows for WGA coverage have not dropped from previous release",
       "groups" : [
          "compara",
-         "compara_protein_trees"
+         "compara_gene_trees"
       ],
       "name" : "CheckWGACoverageStats",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckWGACoverageStats"
@@ -523,7 +535,8 @@
       "description" : "The cigar_line must not have negative numbers or zeros in it",
       "groups" : [
          "compara",
-         "compara_pairwise_alignments"
+         "compara_gene_trees",
+         "compara_genome_alignments"
       ],
       "name" : "CigarCheck",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CigarCheck"
@@ -578,8 +591,7 @@
       "datacheck_type" : "advisory",
       "description" : "The species_sets from the previous database are still present",
       "groups" : [
-         "compara",
-         "compara_multiple_alignments"
+         "compara"
       ],
       "name" : "CompareMSANames",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareMSANames"
@@ -875,7 +887,10 @@
       "description" : "All tables have the same collation (latin1_swedish_ci)",
       "groups" : [
          "compara",
+         "compara_gene_trees",
+         "compara_genome_alignments",
          "compara_master",
+         "compara_syntenies",
          "core",
          "corelike",
          "funcgen",
@@ -1113,7 +1128,10 @@
       "description" : "Foreign key relationships are not violated",
       "groups" : [
          "compara",
-         "compara_master"
+         "compara_gene_trees",
+         "compara_genome_alignments",
+         "compara_master",
+         "compara_syntenies"
       ],
       "name" : "ForeignKeysCompara",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ForeignKeysCompara"
@@ -1268,7 +1286,7 @@
       "description" : "Checks that the HighConfidenceOrthologs pipeline has been run",
       "groups" : [
          "compara",
-         "compara_protein_trees"
+         "compara_gene_trees"
       ],
       "name" : "HighConfidence",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::HighConfidence"
@@ -1334,7 +1352,7 @@
       "description" : "Checks that the gene_member counts are appropriately populated",
       "groups" : [
          "compara",
-         "compara_protein_trees"
+         "compara_gene_trees"
       ],
       "name" : "MemberProductionCounts",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MemberProductionCounts"
@@ -1412,7 +1430,10 @@
       "description" : "Meta keys are correctly assigned at species or database level",
       "groups" : [
          "compara",
+         "compara_gene_trees",
+         "compara_genome_alignments",
          "compara_master",
+         "compara_syntenies",
          "core",
          "corelike",
          "funcgen",
@@ -1437,7 +1458,7 @@
       "description" : "Check that every genomic_align_block_id has more than one genomic_align_id",
       "groups" : [
          "compara",
-         "compara_pairwise_alignments"
+         "compara_genome_alignments"
       ],
       "name" : "MultipleGenomicAlignBlockIds",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MultipleGenomicAlignBlockIds"
@@ -1479,9 +1500,8 @@
       "description" : "Data is only allowed on principle genomes and not components",
       "groups" : [
          "compara",
-         "compara_multiple_alignments",
-         "compara_pairwise_alignments",
-         "compara_protein_trees",
+         "compara_gene_trees",
+         "compara_genome_alignments",
          "compara_syntenies"
       ],
       "name" : "NoDataOnGenomeComponents",
@@ -1694,7 +1714,10 @@
       "description" : "Schema patches are up-to-date",
       "groups" : [
          "compara",
+         "compara_gene_trees",
+         "compara_genome_alignments",
          "compara_master",
+         "compara_syntenies",
          "core",
          "corelike",
          "funcgen",
@@ -1709,7 +1732,10 @@
       "description" : "The schema type meta key matches the DB name",
       "groups" : [
          "compara",
+         "compara_gene_trees",
+         "compara_genome_alignments",
          "compara_master",
+         "compara_syntenies",
          "core",
          "corelike",
          "funcgen",
@@ -1886,7 +1912,8 @@
       "description" : "The coverage must not exceed the genome lengths",
       "groups" : [
          "compara",
-         "compara_pairwise_alignments"
+         "compara_genome_alignments",
+         "compara_syntenies"
       ],
       "name" : "TagCoverageStats",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::TagCoverageStats"

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -269,7 +269,7 @@
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckFlatProteinTrees"
    },
    "CheckGOCScoreStats" : {
-      "datacheck_type" : "critical",
+      "datacheck_type" : "advisory",
       "description" : "The number of rows for GOC have not dropped from previous release",
       "groups" : [
          "compara",
@@ -511,7 +511,7 @@
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckTableSizes"
    },
    "CheckWGACoverageStats" : {
-      "datacheck_type" : "critical",
+      "datacheck_type" : "advisory",
       "description" : "The number of rows for WGA coverage have not dropped from previous release",
       "groups" : [
          "compara",


### PR DESCRIPTION
I have run the DCs on all our e100 databases, master databases, and final EG databases in order to improve them. In summary I have:
- [ENSCOMPARASW-2908] confirmed the `compara` group and added four groups: `compara_master`, `compara_genome_alignments`, `compara_syntenies` and `compara_gene_trees`
- [ENSCOMPARASW-2911] updated some _critical_ / _advisory_ to match our expectations, but also others' [ENSCOMPARASW-2906]
- Improved the DC setup to skip / tune according to the divisions [ENSCOMPARASW-2906]
- Minor changes:
  - Don't raise an exception and let the test fails: `CheckConservationScore`, `CheckMultipleAlignCoverage`
  - Don't make the test fail unnecessarily: `CheckSpeciesSetSizeByMethod`, `ForeignKeysCompara`
  - The SQL query in `CheckGeneGainLossData` now reports the "bad" rows, and we can simply use `is_rows_zero`
  - Simpler rule to decide when to apply the convention in `CheckMethodLinkSpeciesSetNames` (and extended it to more MLSSs)
- Major changes:
  - `CheckSpeciesSetTable` was using `GROUP_CONCAT` which truncates the data to 1,024 characters. We've got much bigger species-sets than that !
  - `CheckLastZCoverage` had some tricky rules to mimic the "unidirectional" vs "bidirectional" netting parameters that are being used. The new implementation (based on the previous "bidirectional" one) actually works in all cases, and I've made it simpler.

To make the review simpler I have created sub-branches:
 - DC code changes only: https://github.com/Ensembl/ensembl-datacheck/compare/release/101...muffato:dc_code
 - DC group changes only: https://github.com/muffato/ensembl-datacheck/compare/dc_code...muffato:dc_groups
 - DC type changes only: https://github.com/muffato/ensembl-datacheck/compare/dc_groups...muffato:dc_advisory
I have kept them all together because they are related but I can make separate pull-requests if you prefer.