### PR TITLE
Fix datacheck pipeline end timestamp

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/DataCheckSubmission.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/DataCheckSubmission.pm
@@ -69,7 +69,10 @@ sub write_output {
   # In order to prevent people from inadvertently overwriting existing
   # output, append a subdirectory. 
   if (defined $self->param('output_dir')) {
-    my $subdir = $ENV{'USER'}.'_'.time.'_'.$$;
+    my @chars = ("A".."Z", "a".."z", 0..9);
+    my $rand_string;
+    $rand_string .= $chars[rand @chars] for 1..12;
+    my $subdir = $ENV{'USER'}.'_'.$rand_string;
     my $dir = path($self->param('output_dir'), $subdir)->stringify;
     $self->param('output_dir', $dir);
   }

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/DataCheckSummary.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/DataCheckSummary.pm
@@ -28,6 +28,7 @@ use warnings;
 use feature 'say';
 
 use JSON;
+use Time::Piece;
 
 use base ('Bio::EnsEMBL::Hive::RunnableDB::NotifyByEmail');
 
@@ -41,6 +42,11 @@ sub run {
   my $tag          = $self->param('tag');
   my $email        = $self->param('email');
   my $timestamp    = $self->param('timestamp');
+
+  my $end_timestamp = localtime->cdate;
+  my $start = Time::Piece->strptime($timestamp,'%a %b %d %H:%M:%S %Y');
+  my $end = Time::Piece->strptime($end_timestamp,'%a %b %d %H:%M:%S %Y');
+  my $runtime_sec = $end - $start;
 
   my $sql = q/
     SELECT dbname, passed, failed, skipped FROM datacheck_results
@@ -71,7 +77,8 @@ sub run {
     history_file => $history_file,
     output_dir   => $output_dir,
     tag          => $tag,
-    timestamp    => $timestamp,
+    timestamp    => $end_timestamp,
+    runtime_sec  => "$runtime_sec",
   );
 
   $self->param('output', \%output);


### PR DESCRIPTION
Make the timestamp in the 'output' result parameter reflect the completion of all jobs connected to the submission job. Also add a 'runtime_sec' parameter, for convenience.