### PR TITLE
When running the XrefPrefixes on vertebrates post xrefs, we discovere…

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/XrefPrefixes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/XrefPrefixes.pm
@@ -99,11 +99,15 @@ sub tests {
 sub xref_prefixes_check {
   my ($self,$source_name,$pattern,$desc) = @_;    
   my $sql  = qq/
-      SELECT dbprimary_acc FROM xref x, external_db e
+      SELECT dbprimary_acc FROM xref x JOIN
+        external_db e USING(external_db_id) JOIN
+        object_xref ox USING (xref_id) JOIN
+        analysis a USING (analysis_id)
       WHERE
         x.external_db_id = e.external_db_id AND
         e.db_name = '$source_name' AND
-        x.dbprimary_acc NOT REGEXP '$pattern'
+        x.dbprimary_acc NOT REGEXP '$pattern' AND
+        a.logic_name != 'xref_projection'
     /;
   is_rows_zero($self->dba, $sql, $desc);
 }


### PR DESCRIPTION
…d that this test is failing on most vertebrates for HGNC. This is because we project HGNC gene names from human to vertebrates but the gene name is projected not the HGNC: id. I've updated this check to exclude projections. The upside is that this test will now pass for vertebrates but it will take longer to run because I am joining to the object_xref table.

Example of failing species:

mysql-ens-sta-1 rhinopithecus_bieti_core_101_1 -e "SELECT dbprimary_acc FROM xref x, external_db e WHERE x.external_db_id = e.external_db_id AND e.db_name = 'HGNC' AND x.dbprimary_acc NOT REGEXP '^HGNC:' limit 10"
dbprimary_acc
A1BG
A1CF
A2M
A2ML1
A3GALT2
A4GALT
A4GNT
AAAS
AACS
AADAC