### PR TITLE
Revert "When running the XrefPrefixes on vertebrates post xrefs, we discovere…"

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/XrefPrefixes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/XrefPrefixes.pm
@@ -99,15 +99,11 @@ sub tests {
 sub xref_prefixes_check {
   my ($self,$source_name,$pattern,$desc) = @_;    
   my $sql  = qq/
-      SELECT dbprimary_acc FROM xref x JOIN
-        external_db e USING(external_db_id) JOIN
-        object_xref ox USING (xref_id) JOIN
-        analysis a USING (analysis_id)
+      SELECT dbprimary_acc FROM xref x, external_db e
       WHERE
         x.external_db_id = e.external_db_id AND
         e.db_name = '$source_name' AND
-        x.dbprimary_acc NOT REGEXP '$pattern' AND
-        a.logic_name != 'xref_projection'
+        x.dbprimary_acc NOT REGEXP '$pattern'
     /;
   is_rows_zero($self->dba, $sql, $desc);
 }


### PR DESCRIPTION
The datacheck failures that you saw were valid - there is a genuine problem with these xrefs, for which there is a known bug: https://www.ebi.ac.uk/panda/jira/browse/ENSINT-438.
I have a fix lined up, as per https://www.ebi.ac.uk/panda/jira/browse/ENSPROD-5382.