### PR TITLE
Add variation test - check somatic structural variants

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/StructuralVariationFeature.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/StructuralVariationFeature.pm
@@ -32,7 +32,7 @@ use constant {
   DESCRIPTION => 'StructuralVariationFeature table data is present and correct',
   GROUPS      => ['variation'],
   DB_TYPES    => ['variation'],
-  TABLES      => ['structural_variation_feature']
+  TABLES      => ['structural_variation_feature','structural_variation']
 };
 
 sub tests {
@@ -51,6 +51,24 @@ sub tests {
     HAVING COUNT(structural_variation_id) > 1
   /;
   is_rows_zero($self->dba, $sql, $desc);
+
+  # Structural variants imported from COSMIC must have somatic status
+  # Checks structural_variation_feature and structural_variation
+  my $svf_somatic = 'Structural variation features from COSMIC are somatic';
+  my $sql_svf  = qq/
+    SELECT COUNT(*) FROM structural_variation_feature svf
+    LEFT JOIN study st ON svf.study_id = st.study_id
+    WHERE svf.somatic = 0 AND st.description LIKE '%cosmic%';
+  /;
+  is_rows_zero($self->dba, $sql_svf, $svf_somatic);
+
+  my $sv_somatic = 'Structural variations from COSMIC are somatic';
+  my $sql_sv  = qq/
+    SELECT COUNT(*) FROM structural_variation sv
+    LEFT JOIN study st ON sv.study_id = st.study_id
+    WHERE sv.somatic = 0 AND st.description LIKE '%cosmic%';
+  /;
+  is_rows_zero($self->dba, $sql_sv, $sv_somatic);
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/StructuralVariationFeature.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/StructuralVariationFeature.pm
@@ -32,7 +32,7 @@ use constant {
   DESCRIPTION => 'StructuralVariationFeature table data is present and correct',
   GROUPS      => ['variation'],
   DB_TYPES    => ['variation'],
-  TABLES      => ['structural_variation_feature','structural_variation']
+  TABLES      => ['structural_variation_feature']
 };
 
 sub tests {
@@ -51,24 +51,6 @@ sub tests {
     HAVING COUNT(structural_variation_id) > 1
   /;
   is_rows_zero($self->dba, $sql, $desc);
-
-  # Structural variants imported from COSMIC must have somatic status
-  # Checks structural_variation_feature and structural_variation
-  my $svf_somatic = 'Structural variation features from COSMIC are somatic';
-  my $sql_svf  = qq/
-    SELECT COUNT(*) FROM structural_variation_feature svf
-    LEFT JOIN study st ON svf.study_id = st.study_id
-    WHERE svf.somatic = 0 AND st.description LIKE '%cosmic%';
-  /;
-  is_rows_zero($self->dba, $sql_svf, $svf_somatic);
-
-  my $sv_somatic = 'Structural variations from COSMIC are somatic';
-  my $sql_sv  = qq/
-    SELECT COUNT(*) FROM structural_variation sv
-    LEFT JOIN study st ON sv.study_id = st.study_id
-    WHERE sv.somatic = 0 AND st.description LIKE '%cosmic%';
-  /;
-  is_rows_zero($self->dba, $sql_sv, $sv_somatic);
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/StructuralVariationSomatic.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/StructuralVariationSomatic.pm
@@ -1,0 +1,60 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::StructuralVariationSomatic;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'StructuralVariationSomatic',
+  DESCRIPTION => 'Structural variants imported from COSMIC are somatic',
+  GROUPS      => ['variation'],
+  DB_TYPES    => ['variation'],
+  TABLES      => ['structural_variation_feature','structural_variation']
+};
+
+sub tests {
+  my ($self) = @_;
+
+  # Structural variants imported from COSMIC must have somatic status
+  # Checks structural_variation_feature and structural_variation
+  my $svf_somatic = 'Structural variation features from COSMIC are somatic';
+  my $sql_svf  = qq/
+    SELECT COUNT(*) FROM structural_variation_feature svf
+    LEFT JOIN study st ON svf.study_id = st.study_id
+    WHERE svf.somatic = 0 AND st.description LIKE '%cosmic%';
+  /;
+  is_rows_zero($self->dba, $sql_svf, $svf_somatic);
+
+  my $sv_somatic = 'Structural variations from COSMIC are somatic';
+  my $sql_sv  = qq/
+    SELECT COUNT(*) FROM structural_variation sv
+    LEFT JOIN study st ON sv.study_id = st.study_id
+    WHERE sv.somatic = 0 AND st.description LIKE '%cosmic%';
+  /;
+  is_rows_zero($self->dba, $sql_sv, $sv_somatic);
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/StructuralVariationSomatic.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/StructuralVariationSomatic.pm
@@ -38,23 +38,29 @@ use constant {
 sub tests {
   my ($self) = @_;
 
-  # Structural variants imported from COSMIC must have somatic status
-  # Checks structural_variation_feature and structural_variation
-  my $svf_somatic = 'Structural variation features from COSMIC are somatic';
-  my $sql_svf  = qq/
-    SELECT COUNT(*) FROM structural_variation_feature svf
-    LEFT JOIN study st ON svf.study_id = st.study_id
-    WHERE svf.somatic = 0 AND st.description LIKE '%cosmic%';
-  /;
-  is_rows_zero($self->dba, $sql_svf, $svf_somatic);
+  SKIP: {
+    my $species = $self->species;
 
-  my $sv_somatic = 'Structural variations from COSMIC are somatic';
-  my $sql_sv  = qq/
-    SELECT COUNT(*) FROM structural_variation sv
-    LEFT JOIN study st ON sv.study_id = st.study_id
-    WHERE sv.somatic = 0 AND st.description LIKE '%cosmic%';
-  /;
-  is_rows_zero($self->dba, $sql_sv, $sv_somatic);
+    skip 'Structural variants from COSMIC not expected', 1 unless $species =~ /homo_sapiens/;
+
+    # Structural variants imported from COSMIC must have somatic status
+    # Checks structural_variation_feature and structural_variation
+    my $svf_somatic = 'Structural variation features from COSMIC are somatic';
+    my $sql_svf  = qq/
+      SELECT COUNT(*) FROM structural_variation_feature svf
+      JOIN study st ON svf.study_id = st.study_id
+      WHERE svf.somatic != 1 AND st.description LIKE '%cosmic%';
+    /;
+    is_rows_zero($self->dba, $sql_svf, $svf_somatic);
+
+    my $sv_somatic = 'Structural variations from COSMIC are somatic';
+    my $sql_sv  = qq/
+      SELECT COUNT(*) FROM structural_variation sv
+      JOIN study st ON sv.study_id = st.study_id
+      WHERE sv.somatic != 1 AND st.description LIKE '%cosmic%';
+    /;
+    is_rows_zero($self->dba, $sql_sv, $sv_somatic);
+  }
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1805,6 +1805,15 @@
       "name" : "StructuralVariationFeature",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::StructuralVariationFeature"
    },
+   "StructuralVariationSomatic" : {
+      "datacheck_type" : "critical",
+      "description" : "Structural variants imported from COSMIC are somatic",
+      "groups" : [
+         "variation"
+      ],
+      "name" : "StructuralVariationSomatic",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::StructuralVariationSomatic"
+   },
    "TagCoverageStats" : {
       "datacheck_type" : "critical",
       "description" : "The coverage must not exceed the genome lengths",


### PR DESCRIPTION
Structural variants imported from COSMIC must have somatic = 1 in two tables: structural_variation and structural_variation_feature