### PR TITLE
Use the 'genebuild.method' meta key to test whether gene versions are…

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/VersionedGenes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/VersionedGenes.pm
@@ -40,10 +40,10 @@ sub tests {
   my $species_id = $self->dba->species_id;
 
   my $mca = $self->dba->get_adaptor('MetaContainer');
-  my $division = $mca->get_division;
+  my $method = $mca->get_single_value_by_key('genebuild.method');
 
   my $version_expected = 0;
-  if ($division eq 'EnsemblVertebrates') {
+  if ($method =~ /build/) {
     $version_expected = 1;
   }
 


### PR DESCRIPTION
… expected, rather than making assumptions based on division.