### PR TITLE
Force datachecks that rely on multiple databases to always be run...

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CoreTables.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CoreTables.pm
@@ -32,7 +32,8 @@ use constant {
   DESCRIPTION => 'Requisite core-like tables are identical to those in the core database',
   GROUPS      => ['corelike'],
   DB_TYPES    => ['cdna', 'otherfeatures', 'rnaseq'],
-  TABLES      => ['assembly', 'coord_system', 'seq_region']
+  TABLES      => ['assembly', 'coord_system', 'seq_region'],
+  FORCE       => 1
 };
 
 sub tests {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/FeaturePosition.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/FeaturePosition.pm
@@ -32,7 +32,8 @@ use constant {
   DESCRIPTION => 'Feature co-ordinates are within the bounds of their seq_region',
   GROUPS      => ['funcgen', 'ersa'],
   DB_TYPES    => ['funcgen'],
-  TABLES      => ['external_feature', 'mirna_target_feature', 'motif_feature', 'peak', 'regulatory_feature']
+  TABLES      => ['external_feature', 'mirna_target_feature', 'motif_feature', 'peak', 'regulatory_feature'],
+  FORCE       => 1
 };
 
 sub tests {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysMultiDB.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysMultiDB.pm
@@ -31,7 +31,8 @@ use constant {
   NAME        => 'ForeignKeysMultiDB',
   DESCRIPTION => 'Foreign key relationships between tables from different databases are not violated',
   GROUPS      => ['funcgen', 'schema', 'variation'],
-  DB_TYPES    => ['funcgen', 'variation']
+  DB_TYPES    => ['funcgen', 'variation'],
+  FORCE       => 1
 };
 
 sub tests {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaCoord.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaCoord.pm
@@ -31,6 +31,7 @@ use constant {
   DESCRIPTION => 'The meta_coord table is correctly populated',
   GROUPS      => ['annotation', 'core', 'corelike', 'funcgen', 'geneset', 'protein_features', 'variation'],
   DB_TYPES    => ['cdna', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
+  FORCE       => 1
 };
 
 sub tests {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConsistent.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConsistent.pm
@@ -32,7 +32,8 @@ use constant {
   DESCRIPTION => 'Assembly and species meta keys are identical between core and core-like databases',
   GROUPS      => ['corelike', 'meta'],
   DB_TYPES    => ['cdna', 'otherfeatures', 'rnaseq'],
-  TABLES      => ['meta']
+  TABLES      => ['meta'],
+  FORCE       => 1
 };
 
 sub tests {


### PR DESCRIPTION
... because we do not have a way to track changes in multiple databases, and can't be sure that nothing has changed.
(Currently, the need is not so great that we need to check across databases - there are not many instances of this, it's much more complicated to track changes in multiple dbs, and in many cases the other database will have changed, so we'd have to run the datachecks anyway.)