### PR TITLE
Updating Denormalized and MultipleSeqRegions

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/Denormalized.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/Denormalized.pm
@@ -31,7 +31,8 @@ use constant {
   NAME        => 'Denormalized',
   DESCRIPTION => 'Denormalized columns are synchronised',
   GROUPS      => ['variation', 'schema'],
-  DB_TYPES    => ['variation']
+  DB_TYPES    => ['variation'],
+  TABLES      => ['structural_variation', 'structural_variation_feature', 'transcript_variation', 'variation', 'variation_feature']
 };
 
 sub tests {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MultipleSeqRegions.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MultipleSeqRegions.pm
@@ -24,21 +24,30 @@ use strict;
 use Moose;
 use Test::More;
 use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+use Bio::EnsEMBL::DataCheck::Utils qw/sql_count/;
 
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
-  NAME           => 'MultipleSeqRegions',
-  DESCRIPTION    => 'Tables have multiple seq regions',
-  GROUPS         => ['variation'],
-  DATACHECK_TYPE => 'advisory',
-  DB_TYPES       => ['variation'],
-  TABLES         => ['structural_variation_feature', 'variation_feature']
+  NAME        => 'MultipleSeqRegions',
+  DESCRIPTION => 'Tables have multiple seq regions',
+  GROUPS      => ['variation'],
+  DB_TYPES    => ['variation'],
+  TABLES      => ['structural_variation_feature', 'variation_feature']
 };
+
+sub skip_tests {
+  my ($self) = @_;
+
+  my $sql = 'SELECT COUNT(*) FROM seq_region';
+
+  if ( sql_count($self->dba, $sql) == 1 ) {
+    return (1, 'The database has a single seq_region');
+  }
+}
 
 sub tests {
   my ($self) = @_;
-  
   # Check that tables have multiple distinct seq_region_id
   foreach my $table (@{$self->tables}) {
     my $desc = "Table $table does not have 1 distinct seq region id";

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MultipleSeqRegions.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MultipleSeqRegions.pm
@@ -28,46 +28,25 @@ use Bio::EnsEMBL::DataCheck::Test::DataCheck;
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
-  NAME        => 'MultipleSeqRegions',
-  DESCRIPTION => 'Tables have multiple seq regions',
-  GROUPS      => ['variation'],
-  DB_TYPES    => ['variation'],
-  TABLES      => ['structural_variation_feature', 'variation_feature']
+  NAME           => 'MultipleSeqRegions',
+  DESCRIPTION    => 'Tables have multiple seq regions',
+  GROUPS         => ['variation'],
+  DATACHECK_TYPE => 'advisory',
+  DB_TYPES       => ['variation'],
+  TABLES         => ['structural_variation_feature', 'variation_feature']
 };
-
-sub skip_tests {
-  my ($self) = @_;
-
-  my $desc_dna_dba = 'Core database found';
-  my $dna_dba = $self->get_dna_dba();
-  my $pass = ok(defined $dna_dba, $desc_dna_dba);
-
-  # Note that if $pass is false, we will still execute the 'tests'
-  # method; which is either not required, or will need to be done again,
-  # because the datacheck will fail. But it's complicated to do
-  # otherwise, and it doesn't really matter for this datacheck,
-  # because the query runs quickly.
-  if ($pass) {
-    my $mca = $dna_dba->get_adaptor("MetaContainer");
-    my $division = $mca->get_division;
-
-    if ($division eq 'EnsemblViruses') {
-      return (1, "$division can have tables with a single seq region");
-    }
-  }
-}
 
 sub tests {
   my ($self) = @_;
   
   # Check that tables have multiple distinct seq_region_id
   foreach my $table (@{$self->tables}) {
-       my $desc = "Table $table does not have 1 distinct seq region id";
-       my $sql  = qq/
-         SELECT COUNT(DISTINCT seq_region_id)
-         FROM $table
-       /;
-       cmp_rows($self->dba, $sql, '!=', 1, $desc);
+    my $desc = "Table $table does not have 1 distinct seq region id";
+    my $sql  = qq/
+      SELECT COUNT(DISTINCT seq_region_id)
+      FROM $table
+    /;
+    cmp_rows($self->dba, $sql, '!=', 1, $desc);
   }
 }
 

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1473,7 +1473,7 @@
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MultipleGenomicAlignBlockIds"
    },
    "MultipleSeqRegions" : {
-      "datacheck_type" : "advisory",
+      "datacheck_type" : "critical",
       "description" : "Tables have multiple seq regions",
       "groups" : [
          "variation"

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1473,7 +1473,7 @@
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MultipleGenomicAlignBlockIds"
    },
    "MultipleSeqRegions" : {
-      "datacheck_type" : "critical",
+      "datacheck_type" : "advisory",
       "description" : "Tables have multiple seq regions",
       "groups" : [
          "variation"


### PR DESCRIPTION
The Denormalized datacheck needs a set of tables to be defined, in order to prevent this long-running check from executing redundantly.
For MultipleSeqRegions, base the skipping condition on our expectation that if multiple seq_regions are present in the variation db, there will be variants annotated on more than one seq_region - this avoids the need to make division-based assumptions (based on discussion in #241).