### PR TITLE
Determine old version of compara and ontology databases

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareOntologyTerm.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareOntologyTerm.pm
@@ -38,17 +38,16 @@ use constant {
 
 sub tests {
   my ($self) = @_;
-  SKIP: {
-    my $old_dba = $self->get_old_dba();
 
-    skip 'No old version of database', 1 unless defined $old_dba;
+  # Inherited code from DbCheck will always fail if the previous
+  # release's database cannot be found - so don't need to test
+  # for that here.
+  my $old_dba = $self->get_old_dba();
 
-    my $desc = "Term count has not decreased in ".
-               $self->dba->dbc->dbname.' compared to '.$old_dba->dbc->dbname;
-    my $sql  = 'SELECT COUNT(*) FROM term';
-    row_totals($self->dba, $old_dba, $sql, undef, 1.00, $desc);
-  }
+  my $desc = 'Term count has not decreased in '.
+             $self->dba->dbc->dbname.' compared to '.$old_dba->dbc->dbname;
+  my $sql  = 'SELECT COUNT(*) FROM term';
+  row_totals($self->dba, $old_dba, $sql, undef, 1.00, $desc);
 }
 
 1;
-

--- a/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
@@ -366,6 +366,15 @@ sub get_old_dba {
   if (exists $params{'-DBNAME'}) {
     my $message = 'Specified database does not exist';
     $dbh = $self->test_db_connection($uri, $params{'-DBNAME'}, $message);
+  } elsif ($group =~ /compara|ontology/) {
+    my $dbname = $self->dba->dbc->dbname;
+    my $current = $mca->schema_version;
+    $dbname =~ s/$current/$db_version/; # Ensembl version
+    my ($eg_current, $eg_version) = ($current-53, $db_version-53);
+    $dbname =~ s/$eg_current/$eg_version/; # EG version
+    $params{'-DBNAME'} = $dbname;
+    my $message = 'Previous version of database does not exist';
+    $dbh = $self->test_db_connection($uri, $params{'-DBNAME'}, $message);
   } else {
     my $meta_dba = $self->registry->get_DBAdaptor("multi", "metadata");
     die "No metadata database found in the registry" unless defined $meta_dba;

--- a/scripts/run_datachecks.pl
+++ b/scripts/run_datachecks.pl
@@ -195,8 +195,6 @@ if ($dbname) {
   my $adaptor = 'Bio::EnsEMBL::DBSQL::DBAdaptor';
   $adaptor = 'Bio::EnsEMBL::Compara::DBSQL::DBAdaptor'    if $dbtype eq 'compara';
   $adaptor = 'Bio::EnsEMBL::Funcgen::DBSQL::DBAdaptor'    if $dbtype eq 'funcgen';
-  $adaptor = 'Bio::EnsEMBL::Ontology::DBSQL::DBAdaptor'   if $dbtype eq 'ontology';
-  $adaptor = 'Bio::EnsEMBL::Production::DBSQL::DBAdaptor' if $dbtype eq 'production';
   $adaptor = 'Bio::EnsEMBL::Variation::DBSQL::DBAdaptor'  if $dbtype eq 'variation';
 
   my $multispecies_db = $dbname =~ /^\w+_collection_core_\w+$/;


### PR DESCRIPTION
Determine old dbnames for ontology and compara dbs, by regexing the release versions. This method wouldn't work for the names of other db types, due to the 'assembly version' suffix, but it's fine for the simpler name patterns (which are not easily accessible in the metadata db).

Removed the skip block from the CompareOntologyTerm datacheck - it wouldn't work any more, because DbCheck wil now always cause a failure in the absence of an old ontology db. Such a db should always be available on a server (in contrast to a core db, which might be brand new); if the old ontology db cannot be found, then some run-time parameters must have been incorrect.


