### PR TITLE
New compara datachecks

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DNAFragCore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DNAFragCore.pm
@@ -1,0 +1,42 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::DNAFragCore;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'DNAFragCore',
+  DESCRIPTION => 'Top-level sequences in the core database match dnafrags in compara database',
+  GROUPS      => ['compara'],
+  DB_TYPES    => ['compara']
+};
+
+sub tests {
+  my ($self) = @_;
+
+}
+
+1;
+

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeys.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeys.pm
@@ -66,7 +66,10 @@ sub tests {
   is(scalar(@failed_to_parse), 0, $desc_parsed) ||
     diag explain @failed_to_parse;
 
-  if ($self->dba->group =~ /(cdna|core|otherfeatures|rnaseq)/) {
+  if ($self->dba->group eq 'core') {
+    $self->core_fk();
+    $self->dna_fk();
+  } elsif ($self->dba->group =~ /(cdna|otherfeatures|rnaseq)/) {
     $self->core_fk();
   } elsif ($self->dba->group eq 'funcgen') {
     $self->funcgen_fk();
@@ -116,6 +119,14 @@ sub core_fk {
   fk($self->dba, 'supporting_feature',            'feature_id', 'protein_align_feature', 'protein_align_feature_id', 'feature_type = "protein_align_feature"');
   fk($self->dba, 'transcript_supporting_feature', 'feature_id', 'dna_align_feature',     'dna_align_feature_id',     'feature_type = "dna_align_feature"');
   fk($self->dba, 'transcript_supporting_feature', 'feature_id', 'protein_align_feature', 'protein_align_feature_id', 'feature_type = "protein_align_feature"');
+}
+
+sub dna_fk {
+  my ($self) = @_;
+
+  # Cases in which we need to restrict to a subset of rows, using a constraint
+  fk($self->dba, 'seq_region', 'seq_region_id', 'dna', 'seq_region_id',
+    'coord_system_id IN (SELECT coord_system_id FROM coord_system WHERE attrib LIKE "%sequence_level%")');
 }
 
 sub funcgen_fk {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
@@ -196,6 +196,18 @@ sub compara_fk {
     ref_root_id IS NULL
   /;
   fk($self->dba, "gene_member_hom_stats", "collection", "gene_tree_root", "clusterset_id", $hom_stats_constraint);
+
+  my $mlss_tag_genome_constraint = q/
+    tag LIKE '%reference_species'
+  /;
+  fk($self->dba, "method_link_species_set_tag", "value", "genome_db", "name", $mlss_tag_genome_constraint);
+
+  my $mlss_tag_msa_constraint = q/
+    tag = 'msa_mlss_id'
+  /;
+  fk($self->dba, "method_link_species_set_tag", "value", "method_link_species_set", "method_link_species_set_id", $mlss_tag_msa_constraint);
+
+  
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneTreeHighlighting.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneTreeHighlighting.pm
@@ -1,0 +1,73 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::GeneTreeHighlighting;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'GeneTreeHighlighting',
+  DESCRIPTION => 'GO and InterPro xrefs are loaded for highlighting annotated genes',
+  GROUPS      => ['compara_annot_highlight'],
+  DB_TYPES    => ['compara'],
+  TABLES      => ['gene_member', 'member_xref']
+};
+
+sub skip_tests {
+  my ($self) = @_;
+
+  if ( $self->dba->get_division eq 'vertebrates' ) {
+    return( 1, "Gene tree highlighting is not done for vertebrates" );
+  } else {
+    my $mlssa = $self->dba->get_adaptor("MethodLinkSpeciesSet");
+    my $mlss = $mlssa->fetch_all_by_method_link_type('PROTEIN_TREES');
+
+    if ( scalar(@$mlss) == 0 ) {
+      return( 1, 'No gene trees in database' );
+    }
+  }
+}
+
+sub tests {
+  my ($self) = @_;
+
+  my @sources = ('GO', 'InterPro');
+  foreach my $source (@sources) {
+    my $desc = "Gene tree nodes annotated with $source";
+    my $sql  = qq/
+      SELECT COUNT(*) FROM
+        external_db INNER JOIN
+        member_xref USING (external_db_id) INNER JOIN
+        gene_member USING (gene_member_id) 
+      WHERE db_name = '$source'
+    /;
+    is_rows_nonzero($self->dba, $sql, $desc);
+  }
+  
+  fk($self->dba, 'member_xref', 'gene_member_id', 'gene_member');
+}
+
+1;
+

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GenomeDBCore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GenomeDBCore.pm
@@ -1,0 +1,42 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::GenomeDBCore;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'GenomeDBCore',
+  DESCRIPTION => 'Species, assembly, and geneset metadata are the same in core and compara databases',
+  GROUPS      => ['compara'],
+  DB_TYPES    => ['compara']
+};
+
+sub tests {
+  my ($self) = @_;
+
+}
+
+1;
+

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagGERP.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagGERP.pm
@@ -39,7 +39,7 @@ use constant {
 sub skip_tests {
   my ($self) = @_;
   my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
-  my @methods = qw( EPO EPO_LOW_COVERAGE );
+  my @methods = qw( EPO EPO_EXTENDED );
   my $db_name = $self->dba->dbc->dbname;
   
   my @mlsses;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagHomology.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagHomology.pm
@@ -1,0 +1,63 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::MLSSTagHomology;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::Compara;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'MLSSTagHomology',
+  DESCRIPTION => 'Homologies have appropriate tags',
+  GROUPS      => ['compara', 'compara_protein_trees'],
+  DB_TYPES    => ['compara'],
+  TABLES      => ['method_link', 'method_link_species_set', 'method_link_species_set_tag']
+};
+
+sub tests {
+  my ($self) = @_;
+
+  my $orthologue_tags = [
+    'n_protein_many-to-many_groups',
+    'n_protein_many-to-many_pairs',
+    'n_protein_many-to-one_groups',
+    'n_protein_many-to-one_pairs',
+    'n_protein_one-to-many_groups',
+    'n_protein_one-to-many_pairs',
+    'n_protein_one-to-one_groups',
+    'n_protein_one-to-one_pairs'
+  ];
+  my $paralogue_tags = [
+    'n_protein_within_species_paralog_genes',
+    'n_protein_within_species_paralog_groups',
+    'n_protein_within_species_paralog_pairs',
+    'avg_protein_within_species_paralog_perc_id'
+  ];
+
+  has_tags($self->dba, 'ENSEMBL_ORTHOLOGUES', $orthologue_tags);
+  has_tags($self->dba, 'ENSEMBL_PARALOGUES', $paralogue_tags);
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagHomology.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagHomology.pm
@@ -31,10 +31,27 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'MLSSTagHomology',
   DESCRIPTION => 'Homologies have appropriate tags',
-  GROUPS      => ['compara', 'compara_protein_trees'],
+  GROUPS      => ['compara', 'compara_gene_trees'],
   DB_TYPES    => ['compara'],
   TABLES      => ['method_link', 'method_link_species_set', 'method_link_species_set_tag']
 };
+
+sub skip_tests {
+  my ($self) = @_;
+  my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
+  my @methods = qw( PROTEIN_TREES NC_TREES );
+  my $db_name = $self->dba->dbc->dbname;
+  
+  my @mlsses;
+  foreach my $method ( @methods ) {
+    my $mlss = $mlss_adap->fetch_all_by_method_link_type($method);
+    push @mlsses, @$mlss;
+  }
+  
+  if ( scalar(@mlsses) == 0 ) {
+    return( 1, "There are no gene trees in $db_name" );
+  }
+}
 
 sub tests {
   my ($self) = @_;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagMaxAlign.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagMaxAlign.pm
@@ -1,0 +1,93 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::MLSSTagMaxAlign;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Utils qw/ hash_diff /;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'MLSSTagMaxAlign',
+  DESCRIPTION => 'Max align tags have correct values',
+  GROUPS      => ['compara', 'compara_genome_alignments'],
+  DB_TYPES    => ['compara'],
+  TABLES      => ['method_link', 'method_link_species_set', 'method_link_species_set_tag']
+};
+
+sub tests {
+  my ($self) = @_;
+
+  my $desc = "MLSS tags have correct max_align values";
+  my $max_align_values = $self->max_align_values();
+  my $dnafrag_calcs    = $self->dnafrag_calcs();
+
+  is_deeply($max_align_values, $dnafrag_calcs, $desc) ||
+    diag explain hash_diff($max_align_values, $dnafrag_calcs, 'tag values', 'dnafrags');
+}
+
+sub max_align_values {
+  my ($self) = @_;
+
+  my $helper = $self->dba->dbc->sql_helper;
+
+  my $sql = qq/
+    SELECT
+      method_link_species_set_id,
+      value
+    FROM
+      method_link_species_set_tag
+    WHERE
+      tag = "max_align"
+  /;
+  my $max_align_values = $helper->execute_into_hash(-SQL => $sql);
+
+  return $max_align_values;
+}
+
+sub dnafrag_calcs {
+  my ($self) = @_;
+
+  my $helper = $self->dba->dbc->sql_helper;
+
+  my $sql = qq/
+    SELECT
+      method_link_species_set_id,
+      MAX(dnafrag_end - dnafrag_start) + 2 AS max_align
+    FROM
+      constrained_element
+    GROUP BY method_link_species_set_id
+    UNION
+    SELECT
+      method_link_species_set_id,
+      MAX(dnafrag_end - dnafrag_start) + 2 AS max_align
+    FROM
+      genomic_align
+    GROUP BY method_link_species_set_id
+  /;
+  my $dnafrag_calcs = $helper->execute_into_hash(-SQL => $sql);
+
+  return $dnafrag_calcs;
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagMultipleAlignment.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagMultipleAlignment.pm
@@ -39,7 +39,7 @@ use constant {
 sub skip_tests {
   my ($self) = @_;
   my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
-  my @methods = qw( EPO EPO_LOW_COVERAGE PECAN );
+  my @methods = qw( EPO EPO_EXTENDED PECAN );
   my $db_name = $self->dba->dbc->dbname;
   
   my @mlsses;
@@ -65,9 +65,9 @@ sub tests {
   has_tags($self->dba, 'PECAN', $tags);
 
   push @$tags, 'base_mlss_id';
-  has_tags($self->dba, 'EPO_LOW_COVERAGE', $tags);
+  has_tags($self->dba, 'EPO_EXTENDED', $tags);
 
-  my $desc = "Low coverage alignments tagged with base MSA MLSS ID";
+  my $desc = "Extended multiple sequence alignments tagged with base MSA MLSS ID";
   my $sql = qq/
     SELECT
       mlss1.method_link_species_set_id,
@@ -86,7 +86,7 @@ sub tests {
             type = "EPO"
         ) mlss2 ON mlsst.value = mlss2.method_link_species_set_id
     WHERE
-      ml1.type = "EPO_LOW_COVERAGE" AND
+      ml1.type = "EPO_EXTENDED" AND
       mlsst.tag = "base_mlss_id" AND
       mlss2.method_link_species_set_id IS NULL
   /;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagMultipleAlignment.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagMultipleAlignment.pm
@@ -1,0 +1,52 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::MLSSTagMultipleAlignment;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::Compara;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'MLSSTagMultipleAlignment',
+  DESCRIPTION => 'Multiple alignments have appropriate tags',
+  GROUPS      => ['compara', 'compara_multiple_alignments'],
+  DB_TYPES    => ['compara'],
+  TABLES      => ['method_link', 'method_link_species_set', 'method_link_species_set_tag']
+};
+
+sub tests {
+  my ($self) = @_;
+
+  my $tags = [
+    'num_blocks',
+    'max_align',
+  ];
+
+  has_tags($self->dba, 'EPO', $tags);
+  has_tags($self->dba, 'PECAN', $tags);
+  has_tags($self->dba, 'EPO_LOW_COVERAGE', $tags);
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagPairwiseAlignment.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagPairwiseAlignment.pm
@@ -31,10 +31,27 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'MLSSTagPairwiseAlignment',
   DESCRIPTION => 'Pairwise alignments have appropriate tags',
-  GROUPS      => ['compara', 'compara_pairwise_alignments'],
+  GROUPS      => ['compara', 'compara_genome_alignments'],
   DB_TYPES    => ['compara'],
   TABLES      => ['method_link', 'method_link_species_set', 'method_link_species_set_tag']
 };
+
+sub skip_tests {
+  my ($self) = @_;
+  my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
+  my @methods = qw( LASTZ_NET BLASTZ_NET TRANSLATED_BLAT_NET );
+  my $db_name = $self->dba->dbc->dbname;
+  
+  my @mlsses;
+  foreach my $method ( @methods ) {
+    my $mlss = $mlss_adap->fetch_all_by_method_link_type($method);
+    push @mlsses, @$mlss;
+  }
+  
+  if ( scalar(@mlsses) == 0 ) {
+    return( 1, "There are no multiple alignments in $db_name" );
+  }
+}
 
 sub tests {
   my ($self) = @_;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagPairwiseAlignment.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagPairwiseAlignment.pm
@@ -1,0 +1,68 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::MLSSTagPairwiseAlignment;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::Compara;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'MLSSTagPairwiseAlignment',
+  DESCRIPTION => 'Pairwise alignments have appropriate tags',
+  GROUPS      => ['compara', 'compara_pairwise_alignments'],
+  DB_TYPES    => ['compara'],
+  TABLES      => ['method_link', 'method_link_species_set', 'method_link_species_set_tag']
+};
+
+sub tests {
+  my ($self) = @_;
+
+  my $tags = [
+    'non_ref_coding_exon_length',
+    'non_ref_genome_coverage',
+    'non_ref_genome_length',
+    'non_ref_insertions',
+    'non_ref_matches',
+    'non_ref_mis_matches',
+    'non_ref_uncovered',
+    'ref_coding_exon_length',
+    'ref_genome_coverage',
+    'ref_genome_length',
+    'ref_insertions',
+    'ref_matches',
+    'ref_mis_matches',
+    'ref_uncovered'
+  ];
+
+  has_tags($self->dba, 'BLASTZ_NET', $tags);
+  has_tags($self->dba, 'LASTZ_NET', $tags);
+  has_tags($self->dba, 'TRANSLATED_BLAT_NET', $tags);
+
+  cmp_tag($self->dba, 'BLASTZ_NET', 'non_ref_coding_exon_length', '>', 0);
+  cmp_tag($self->dba, 'LASTZ_NET', 'non_ref_coding_exon_length', '>', 0);
+  cmp_tag($self->dba, 'TRANSLATED_BLAT_NET', 'non_ref_coding_exon_length', '>', 0);
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagSynteny.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagSynteny.pm
@@ -36,6 +36,17 @@ use constant {
   TABLES      => ['method_link', 'method_link_species_set', 'method_link_species_set_tag']
 };
 
+sub skip_tests {
+  my ($self) = @_;
+  my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
+  my $mlss = $mlss_adap->fetch_all_by_method_link_type('SYNTENY');
+  my $db_name = $self->dba->dbc->dbname;
+
+  if ( scalar(@$mlss) == 0 ) {
+    return( 1, "There are no SYNTENY MLSS in $db_name" );
+  }
+}
+
 sub tests {
   my ($self) = @_;
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagSynteny.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagSynteny.pm
@@ -1,0 +1,63 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::MLSSTagSynteny;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::Compara;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'MLSSTagSynteny',
+  DESCRIPTION => 'Syntenies have appropriate tags',
+  GROUPS      => ['compara', 'compara_syntenies'],
+  DB_TYPES    => ['compara'],
+  TABLES      => ['method_link', 'method_link_species_set', 'method_link_species_set_tag']
+};
+
+sub tests {
+  my ($self) = @_;
+
+  my $tags = [
+    'num_blocks',
+    'non_reference_species',
+    'non_ref_coding_exon_length',
+    'non_ref_covered',
+    'non_ref_genome_coverage',
+    'non_ref_genome_length',
+    'non_ref_uncovered',
+    'reference_species',
+    'ref_coding_exon_length',
+    'ref_covered',
+    'ref_genome_coverage',
+    'ref_genome_length',
+    'ref_uncovered',
+  ];
+
+  has_tags($self->dba, 'SYNTENY', $tags);
+
+  cmp_tag($self->dba, 'SYNTENY', 'non_ref_coding_exon_length', '>', 0);
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagThresholdDs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagThresholdDs.pm
@@ -1,0 +1,67 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::MLSSTagThresholdDs;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::Compara;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+use Bio::EnsEMBL::DataCheck::Utils qw/sql_count/;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'MLSSTagThresholdDs',
+  DESCRIPTION => 'Threshold values for ds exist, if appropriate',
+  GROUPS      => ['compara'],
+  DB_TYPES    => ['compara'],
+  TABLES      => ['method_link', 'method_link_species_set', 'method_link_species_set_attr']
+};
+
+sub tests {
+  my ($self) = @_;
+
+  my $sql_count = 'SELECT ds FROM homology WHERE ds IS NOT NULL LIMIT 1';
+  my $sql_1  = q/
+    SELECT COUNT(*) FROM method_link_species_set_attr
+    WHERE threshold_on_ds IS NOT NULL
+  /;
+  my $sql_2  = q/
+    SELECT COUNT(*) FROM method_link_species_set_attr
+    WHERE threshold_on_ds IS NOT NULL AND threshold_on_ds NOT IN (1,2)
+  /;
+  
+  if ( sql_count($self->dba, $sql_count) ) {
+    my $desc_1 = 'ds threshold defined for at least one row';
+    is_rows_nonzero($self->dba, $sql_1, $desc_1);
+    
+    my $desc_2 = 'ds threshold defined for at least one row';
+    is_rows_zero($self->dba, $sql_2, $desc_2);
+
+  } else {
+    my $desc_3 = 'ds threshold not defined';
+    is_rows_zero($self->dba, $sql_1, $desc_3);
+
+  }
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagThresholdDs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagThresholdDs.pm
@@ -32,7 +32,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'MLSSTagThresholdDs',
   DESCRIPTION => 'Threshold values for ds exist, if appropriate',
-  GROUPS      => ['compara'],
+  GROUPS      => ['compara', 'compara_gene_trees'],
   DB_TYPES    => ['compara'],
   TABLES      => ['method_link', 'method_link_species_set', 'method_link_species_set_attr']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Test/Compara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Test/Compara.pm
@@ -1,0 +1,148 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::DataCheck::Test::Compara
+
+=head1 DESCRIPTION
+
+Collection of Test::More style tests for Ensembl compara data.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Test::Compara;
+
+use warnings;
+use strict;
+use feature 'say';
+
+use Test::Builder::Module;
+
+our $VERSION = 1.00;
+our @ISA     = qw(Test::Builder::Module);
+our @EXPORT  = qw(
+  tags_exist coding_coverage
+);
+
+my $CLASS = __PACKAGE__;
+
+=head2 Compara-specific tests
+
+=over 4
+
+=item B<has_tags>
+
+has_tags($dba, $method_link_type, $expected_tags, $test_name);
+
+For each MLSS of type C<$method_link_type>, test whether all of the
+C<$expected_tags> exist.
+
+C<$test_name> is a short description of the test that will be printed
+out; if not provided, a default will be used.
+
+=cut
+
+sub has_tags {
+  my ( $dba, $method_link_type, $expected_tags, $name ) =  @_;
+
+  $name = "All $method_link_type analyses have required tags" unless defined $name;
+
+  my $tb = $CLASS->builder;
+
+  # Don't use a test for every single mlss/tag combo, because there
+  # would be a very high number of 'ok's in the output. Collect
+  # missing tags as we go, do one test, then report any missing data
+  # as diagnostic messages.
+  my @diag_msg = ();
+  my $mlssa = $dba->get_MethodLinkSpeciesSetAdaptor;
+
+  my $mlss_list = $mlssa->fetch_all_by_method_link_type($method_link_type);
+  foreach my $mlss (@$mlss_list) {
+    foreach my $tag (@$expected_tags) {
+      if (! $mlss->has_tag($tag)) {
+        push @diag_msg, "$method_link_type (MLSS ID: ".$mlss->dbID.") lacks tag $tag";
+      } elsif (! defined $mlss->get_value_for_tag($tag)) {
+        push @diag_msg, "$method_link_type (MLSS ID: ".$mlss->dbID.") tag $tag undefined";
+      }
+    }
+  }
+  my $result = $tb->is_eq(scalar(@diag_msg), 0, $name);
+
+  if (scalar(@diag_msg)) {
+    # We could limit the number of diagnostic messages,
+    # but probably more useful to get a complete set.
+    foreach my $row ( @diag_msg ) {
+      $tb->diag( $row );
+    }
+  }
+
+  return $result;
+}
+
+=item B<cmp_tag>
+
+cmp_tag($dba, $method_link_type, $tag_name, $operator, $expected, $test_name);
+
+For each MLSS of type C<$method_link_type>, test whether the coding
+coverage tag has a non-zero value.
+
+C<$test_name> is a short description of the test that will be printed
+out; if not provided, a default will be used.
+
+=cut
+
+sub cmp_tag {
+  my ( $dba, $method_link_type, $tag_name, $operator, $expected, $name ) =  @_;
+
+  $name = "$method_link_type $tag_name $operator $expected" unless defined $name;
+
+  my $tb = $CLASS->builder;
+
+  # Don't use a test for every single mlss/tag combo, because there
+  # would be a very high number of 'ok's in the output. Collect
+  # missing tags as we go, do one test, then report any missing data
+  # as diagnostic messages.
+  my @diag_msg = ();
+  my $mlssa = $dba->get_MethodLinkSpeciesSetAdaptor;
+
+  my $mlss_list = $mlssa->fetch_all_by_method_link_type($method_link_type);
+  foreach my $mlss (@$mlss_list) {
+	my $tag_value = $mlss->get_value_for_tag($tag_name);
+	if (defined $tag_value) {
+	  if (! $tb->cmp_ok( $tag_value, $operator, $expected )) {
+        push @diag_msg, "$method_link_type (MLSS ID: ".$mlss->dbID.") $tag_name value $tag_value is not $operator $expected";
+      }
+    } else {
+      push @diag_msg, "$method_link_type (MLSS ID: ".$mlss->dbID.") tag $tag_name undefined";
+    }
+  }
+  my $result = $tb->is_eq(scalar(@diag_msg), 0, $name);
+
+  if (scalar(@diag_msg)) {
+    # We could limit the number of diagnostic messages,
+    # but probably more useful to get a complete set.
+    foreach my $row ( @diag_msg ) {
+      $tb->diag( $row );
+    }
+  }
+
+  return $result;
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Test/Compara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Test/Compara.pm
@@ -37,7 +37,7 @@ use Test::Builder::Module;
 our $VERSION = 1.00;
 our @ISA     = qw(Test::Builder::Module);
 our @EXPORT  = qw(
-  tags_exist coding_coverage
+  has_tags cmp_tag
 );
 
 my $CLASS = __PACKAGE__;
@@ -99,8 +99,8 @@ sub has_tags {
 
 cmp_tag($dba, $method_link_type, $tag_name, $operator, $expected, $test_name);
 
-For each MLSS of type C<$method_link_type>, test whether the coding
-coverage tag has a non-zero value.
+For each MLSS of type C<$method_link_type>, test whether the value
+for a given tag is expected.
 
 C<$test_name> is a short description of the test that will be printed
 out; if not provided, a default will be used.
@@ -110,7 +110,7 @@ out; if not provided, a default will be used.
 sub cmp_tag {
   my ( $dba, $method_link_type, $tag_name, $operator, $expected, $name ) =  @_;
 
-  $name = "$method_link_type $tag_name $operator $expected" unless defined $name;
+  $name = "All $method_link_type $tag_name $operator $expected" unless defined $name;
 
   my $tb = $CLASS->builder;
 
@@ -123,9 +123,9 @@ sub cmp_tag {
 
   my $mlss_list = $mlssa->fetch_all_by_method_link_type($method_link_type);
   foreach my $mlss (@$mlss_list) {
-	my $tag_value = $mlss->get_value_for_tag($tag_name);
-	if (defined $tag_value) {
-	  if (! $tb->cmp_ok( $tag_value, $operator, $expected )) {
+    my $tag_value = $mlss->get_value_for_tag($tag_name);
+    if (defined $tag_value) {
+      if (! $tb->cmp_ok( $tag_value, $operator, $expected, $mlss->name . ": $tag_name")) {
         push @diag_msg, "$method_link_type (MLSS ID: ".$mlss->dbID.") $tag_name value $tag_value is not $operator $expected";
       }
     } else {

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -882,6 +882,15 @@
       "name" : "DNAEmpty",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DNAEmpty"
    },
+   "DNAFragCore" : {
+      "datacheck_type" : "critical",
+      "description" : "Top-level sequences in the core database match dnafrags in compara database",
+      "groups" : [
+         "compara"
+      ],
+      "name" : "DNAFragCore",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DNAFragCore"
+   },
    "DataFilesExist" : {
       "datacheck_type" : "critical",
       "description" : "Data files are defined where necessary, and exist on the filesystem",
@@ -1257,6 +1266,15 @@
       ],
       "name" : "GeneTreeHighlighting",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::GeneTreeHighlighting"
+   },
+   "GenomeDBCore" : {
+      "datacheck_type" : "critical",
+      "description" : "Species, assembly, and geneset metadata are the same in core and compara databases",
+      "groups" : [
+         "compara"
+      ],
+      "name" : "GenomeDBCore",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::GenomeDBCore"
    },
    "GenomeStatistics" : {
       "datacheck_type" : "critical",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1249,6 +1249,15 @@
       "name" : "GeneStrands",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::GeneStrands"
    },
+   "GeneTreeHighlighting" : {
+      "datacheck_type" : "critical",
+      "description" : "GO and InterPro xrefs are loaded for highlighting annotated genes",
+      "groups" : [
+         "compara_annot_highlight"
+      ],
+      "name" : "GeneTreeHighlighting",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::GeneTreeHighlighting"
+   },
    "GenomeStatistics" : {
       "datacheck_type" : "critical",
       "description" : "Genome statistics are present and correct",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1346,22 +1346,42 @@
       "name" : "LRG",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::LRG"
    },
+   "MLSSTagGERP" : {
+      "datacheck_type" : "critical",
+      "description" : "GERP analyses have appropriate tags",
+      "groups" : [
+         "compara",
+         "compara_genome_alignments"
+      ],
+      "name" : "MLSSTagGERP",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MLSSTagGERP"
+   },
    "MLSSTagHomology" : {
       "datacheck_type" : "critical",
       "description" : "Homologies have appropriate tags",
       "groups" : [
          "compara",
-         "compara_protein_trees"
+         "compara_gene_trees"
       ],
       "name" : "MLSSTagHomology",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MLSSTagHomology"
+   },
+   "MLSSTagMaxAlign" : {
+      "datacheck_type" : "critical",
+      "description" : "Max align tags have correct values",
+      "groups" : [
+         "compara",
+         "compara_genome_alignments"
+      ],
+      "name" : "MLSSTagMaxAlign",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MLSSTagMaxAlign"
    },
    "MLSSTagMultipleAlignment" : {
       "datacheck_type" : "critical",
       "description" : "Multiple alignments have appropriate tags",
       "groups" : [
          "compara",
-         "compara_multiple_alignments"
+         "compara_genome_alignments"
       ],
       "name" : "MLSSTagMultipleAlignment",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MLSSTagMultipleAlignment"
@@ -1371,7 +1391,7 @@
       "description" : "Pairwise alignments have appropriate tags",
       "groups" : [
          "compara",
-         "compara_pairwise_alignments"
+         "compara_genome_alignments"
       ],
       "name" : "MLSSTagPairwiseAlignment",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MLSSTagPairwiseAlignment"
@@ -1390,7 +1410,8 @@
       "datacheck_type" : "critical",
       "description" : "Threshold values for ds exist, if appropriate",
       "groups" : [
-         "compara"
+         "compara",
+         "compara_gene_trees"
       ],
       "name" : "MLSSTagThresholdDs",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MLSSTagThresholdDs"

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1337,6 +1337,55 @@
       "name" : "LRG",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::LRG"
    },
+   "MLSSTagHomology" : {
+      "datacheck_type" : "critical",
+      "description" : "Homologies have appropriate tags",
+      "groups" : [
+         "compara",
+         "compara_protein_trees"
+      ],
+      "name" : "MLSSTagHomology",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MLSSTagHomology"
+   },
+   "MLSSTagMultipleAlignment" : {
+      "datacheck_type" : "critical",
+      "description" : "Multiple alignments have appropriate tags",
+      "groups" : [
+         "compara",
+         "compara_multiple_alignments"
+      ],
+      "name" : "MLSSTagMultipleAlignment",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MLSSTagMultipleAlignment"
+   },
+   "MLSSTagPairwiseAlignment" : {
+      "datacheck_type" : "critical",
+      "description" : "Pairwise alignments have appropriate tags",
+      "groups" : [
+         "compara",
+         "compara_pairwise_alignments"
+      ],
+      "name" : "MLSSTagPairwiseAlignment",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MLSSTagPairwiseAlignment"
+   },
+   "MLSSTagSynteny" : {
+      "datacheck_type" : "critical",
+      "description" : "Syntenies have appropriate tags",
+      "groups" : [
+         "compara",
+         "compara_syntenies"
+      ],
+      "name" : "MLSSTagSynteny",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MLSSTagSynteny"
+   },
+   "MLSSTagThresholdDs" : {
+      "datacheck_type" : "critical",
+      "description" : "Threshold values for ds exist, if appropriate",
+      "groups" : [
+         "compara"
+      ],
+      "name" : "MLSSTagThresholdDs",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MLSSTagThresholdDs"
+   },
    "MTCodonTable" : {
       "datacheck_type" : "critical",
       "description" : "MT seq region has codon table attribute",


### PR DESCRIPTION
Adding new compara datachecks.

ForeignKeys gets an update, because there was a healthcheck specific to the ancestral db for the dna table, which is generally useful.

Added to ForeignKeysCompara, to check for MLSS tag links.

Batch of MLSS tag datachecks converted from healthchecks, and a new module, Bio::EnsEMBL::DataCheck::Test::Compara, which contains test methods used by multiple datachecks, to prevent repetitive code.

Gene tree highlighting datacheck, which is for non-verts only, and is not part of the 'compara' group, because it only makes sense to apply it after handover, when the Production team have run the relevant pipeline.
