### PR TITLE
 New datacheck to ensure correct display of NCBI gene and transcript accessions

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/NCBIGeneLabels.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/NCBIGeneLabels.pm
@@ -47,12 +47,14 @@ sub tests {
       gene INNER JOIN
       object_xref ON gene_id = ensembl_id INNER JOIN
       xref USING (xref_id) INNER JOIN
-      external_db USING (external_db_id)
+      external_db USING (external_db_id) INNER JOIN
+      analysis ON gene.analysis_id = analysis.analysis_id
     WHERE
       ensembl_object_type = 'Gene' AND
       db_name = 'EntrezGene' AND
       stable_id NOT IN (dbprimary_acc, display_label) AND
-      display_xref_id IS NULL
+      display_xref_id IS NULL AND
+      logic_name = 'refseq_import'
     /;
   is_rows_zero($self->dba, $sql_1, $desc_1);
 
@@ -62,12 +64,14 @@ sub tests {
       transcript INNER JOIN
       object_xref ON gene_id = ensembl_id INNER JOIN
       xref USING (xref_id) INNER JOIN
-      external_db USING (external_db_id)
+      external_db USING (external_db_id) INNER JOIN
+      analysis ON transcript.analysis_id = analysis.analysis_id
     WHERE
       ensembl_object_type = 'Transcript' AND
       db_name = 'EntrezGene' AND
       stable_id NOT IN (dbprimary_acc, display_label) AND
-      display_xref_id IS NULL
+      display_xref_id IS NULL AND
+      logic_name = 'refseq_import'
     /;
   is_rows_zero($self->dba, $sql_2, $desc_2);
 }

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/NCBIGeneLabels.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/NCBIGeneLabels.pm
@@ -1,0 +1,75 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::NCBIGeneLabels;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'NCBIGeneLabels',
+  DESCRIPTION    => 'NCBI genes have display xrefs',
+  GROUPS         => ['corelike', 'xref'],
+  DB_TYPES       => ['otherfeatures'],
+  TABLES         => ['external_db', 'gene', 'object_xref', 'transcript', 'xref'],
+};
+
+sub tests {
+  my ($self) = @_;
+
+  # If a RefSeq geneset has been loaded with arbitrary
+  # generic IDs as stable_ids, the display_xref must be set
+  # in order for the browser to show the appropriate accession.
+  my $desc_1 = 'NCBI genes have accession as either stable_id or display_xref';
+  my $sql_1  = qq/
+    SELECT stable_id FROM
+      gene INNER JOIN
+      object_xref ON gene_id = ensembl_id INNER JOIN
+      xref USING (xref_id) INNER JOIN
+      external_db USING (external_db_id)
+    WHERE
+      ensembl_object_type = 'Gene' AND
+      db_name = 'EntrezGene' AND
+      stable_id NOT IN (dbprimary_acc, display_label) AND
+      display_xref_id IS NULL
+    /;
+  is_rows_zero($self->dba, $sql_1, $desc_1);
+
+  my $desc_2 = 'NCBI transcripts have accession as either stable_id or display_xref';
+  my $sql_2  = qq/
+    SELECT stable_id FROM
+      transcript INNER JOIN
+      object_xref ON gene_id = ensembl_id INNER JOIN
+      xref USING (xref_id) INNER JOIN
+      external_db USING (external_db_id)
+    WHERE
+      ensembl_object_type = 'Transcript' AND
+      db_name = 'EntrezGene' AND
+      stable_id NOT IN (dbprimary_acc, display_label) AND
+      display_xref_id IS NULL
+    /;
+  is_rows_zero($self->dba, $sql_2, $desc_2);
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1410,6 +1410,16 @@
       "name" : "MySQLStorageEngine",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MySQLStorageEngine"
    },
+   "NCBIGeneLabels" : {
+      "datacheck_type" : "critical",
+      "description" : "NCBI genes have display xrefs",
+      "groups" : [
+         "corelike",
+         "xref"
+      ],
+      "name" : "NCBIGeneLabels",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::NCBIGeneLabels"
+   },
    "NoDataOnGenomeComponents" : {
       "datacheck_type" : "critical",
       "description" : "Data is only allowed on principle genomes and not components",


### PR DESCRIPTION
If a RefSeq geneset has been loaded with arbitrary generic IDs as stable_ids, the display_xref must be set in order for the browser to show the appropriate accession.
This datacheck will prevent recurrence of known bug ENSINT-440.