### PR TITLE
"ancestral_sequences" is what the Compara API uses to link GenomeDBs to Core DBAdaptors

### DIFF
--- a/scripts/run_datachecks.pl
+++ b/scripts/run_datachecks.pl
@@ -205,7 +205,7 @@ if ($dbname) {
   if ($dbtype =~ /^(compara|ontology|production)$/) {
     $species = 'multi';
   } elsif ($dbname =~ /ancestral/) {
-    $species = 'Ancestral sequences';
+    $species = 'ancestral_sequences';
   } else {
     my $sql = q/
       SELECT meta_value FROM meta


### PR DESCRIPTION
Not really a bug, but in case we want to check the ancestral database against a compara database, `ancestral_sequences` is the best way of linking both (we have such a check as a separate script that we might consider porting to the DC framework).
`Ancestral sequences` is indeed the default Registry name for Vertebrates, but it only works because `ancestral_sequences` is added as an alias.