### PR TITLE
Brc4 fixes

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledAnalysisVersion.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledAnalysisVersion.pm
@@ -23,6 +23,7 @@ use strict;
 
 use Moose;
 use Test::More;
+use Bio::EnsEMBL::DataCheck::Utils qw/sql_count/;
 
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
@@ -35,6 +36,16 @@ use constant {
   TABLES         => ['analysis', 'analysis_description'],
   PER_DB         => 1
 };
+
+sub skip_tests {
+  my ($self) = @_;
+
+  my $sql = 'SELECT COUNT(*) FROM analysis';
+
+  if (! sql_count($self->dba, $sql) ) {
+    return (1, 'No analyses.');
+  }
+}
 
 sub tests {
   my ($self) = @_;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MTCodonTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MTCodonTable.pm
@@ -40,31 +40,18 @@ use constant {
 sub skip_tests {
   my ($self) = @_;
 
-  my $species_id = $self->dba->species_id;
-
-  my $sql = qq/
-    SELECT COUNT(*) FROM
-      seq_region INNER JOIN
-      coord_system USING (coord_system_id) INNER JOIN
-      seq_region_attrib USING (seq_region_id) INNER JOIN
-      attrib_type USING (attrib_type_id)
-    WHERE
-      species_id = $species_id AND
-      code = 'sequence_location' AND
-      value = 'mitochondrial_chromosome'
-  /;
-  
-  if (! sql_count($self->dba, $sql) ) {
+  my $number_of_MT = $self->count_mitochondria();
+  if ($number_of_MT == 0) {
     return (1, 'No mitochondrional seq_region.');
   }
 }
 
 sub tests {
   my ($self) = @_;
-
+  
   my $species_id = $self->dba->species_id;
 
-  my $desc = 'MT region has codon table attribute';
+  my $desc = 'MT regions have codon table attribute';
   my $sql  = qq/
     SELECT COUNT(*) FROM
       seq_region INNER JOIN
@@ -79,7 +66,28 @@ sub tests {
       sra1.value = 'mitochondrial_chromosome' AND
       at2.code   = 'codon_table'
   /;
-  is_rows($self->dba, $sql, 1, $desc);
+  my $number_of_MT = $self->count_mitochondria();
+  is_rows($self->dba, $sql, $number_of_MT, $desc);
+}
+
+sub count_mitochondria {
+  my ($self) = @_;
+  
+  my $species_id = $self->dba->species_id;
+
+  my $sql = qq/
+    SELECT COUNT(*) FROM
+      seq_region INNER JOIN
+      coord_system USING (coord_system_id) INNER JOIN
+      seq_region_attrib USING (seq_region_id) INNER JOIN
+      attrib_type USING (attrib_type_id)
+    WHERE
+      species_id = $species_id AND
+      code = 'sequence_location' AND
+      value = 'mitochondrial_chromosome'
+  /;
+  
+  return sql_count($self->dba, $sql);
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyBRC4.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyBRC4.pm
@@ -37,20 +37,19 @@ use constant {
 sub tests {
   my ($self) = @_;
 
+  my $mca = $self->dba->get_adaptor("MetaContainer");
+
   my @expected = qw/
   assembly.accession
   species.taxonomy_id
   BRC4.component
   BRC4.organism_abbrev
   /;
-
-  my $mca = $self->dba->get_adaptor("MetaContainer");
-
   foreach my $meta_key (@expected) {
     my $values = $mca->list_value_by_key($meta_key);
 
-    my $desc = "Value exists for meta_key $meta_key";
-    ok(scalar @$values, $desc);
+    my $desc = "There is one value for meta_key $meta_key";
+    ok(scalar(@$values) == 1, $desc);
   }
   
   my $desc = "BRC4 component is valid";

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyBRC4.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyBRC4.pm
@@ -52,6 +52,26 @@ sub tests {
     my $desc = "Value exists for meta_key $meta_key";
     ok(scalar @$values, $desc);
   }
+  
+  my $desc = "BRC4 component is valid";
+  my %ok_components = map { $_ => 1 } qw(
+    AmoebaDB
+    CryptoDB
+    FungiDB
+    GiardiaDB
+    HostDB
+    MicrosporidiaDB
+    PiroplasmaDB
+    PlasmoDB
+    ToxoDB
+    TrichDB
+    TriTrypDB
+    VectorBase
+  );
+  my ($component) = @{ $mca->list_value_by_key("BRC4.component") };
+  if ($component) {
+    ok(exists $ok_components{$component}, $desc);
+  }
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionBRC4.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionBRC4.pm
@@ -40,7 +40,7 @@ sub tests {
 
   my $species_id = $self->dba->species_id;
 
-  $self->check_seq_attrib_name($species_id, 'BRC4_seq_region_name');
+  $self->check_top_level_seq_attrib_name($species_id, 'BRC4_seq_region_name');
 
   # Check for INSDC accession (not systematic in case out assembly is not in sync with INSDC)
   #$self->check_seq_synonym($species_id, 'INSDC');
@@ -71,7 +71,7 @@ sub tests {
   $self->check_seq_attrib_name_coord($species_id, $coord_id, 'toplevel');
 }
 
-sub check_seq_attrib_name {
+sub check_top_level_seq_attrib_name {
   my ($self, $species_id, $attrib_code) = @_;
 
   my $desc = "All toplevel seq_regions have a '$attrib_code' attribute";
@@ -80,6 +80,16 @@ sub check_seq_attrib_name {
     SELECT sr.name
     FROM seq_region sr
       INNER JOIN coord_system cs USING (coord_system_id)
+
+      INNER JOIN
+      (
+        SELECT seq_region_id, value FROM
+          seq_region_attrib INNER JOIN
+          attrib_type USING (attrib_type_id)
+        WHERE
+          code = 'toplevel'
+      ) toplevel ON sr.seq_region_id = toplevel.seq_region_id
+      
       LEFT OUTER JOIN
       (
         SELECT seq_region_id, value FROM

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesTaxonomy.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesTaxonomy.pm
@@ -48,7 +48,7 @@ sub tests {
   # or assemblies of the same species. Since the taxonomy database does
   # not always have that information, remove it before comparing.
   $sci_name =~ s/ \(GCA_\d+\)//;
-  $sci_name =~ s/ str\. .*//;
+  $sci_name =~ s/ (str\.|strain) .*//;
 
   my $desc_1 = 'Species-related meta data exists';
   ok(defined $taxon_id && defined $sci_name, $desc_1);
@@ -71,8 +71,9 @@ sub tests {
         # So we remove that here, if necessary. 
         my $tax_name = $node->name;
         if ($sci_name ne $tax_name) {
-          $tax_name =~ s/ $strain// if defined $strain;
-          $tax_name =~ s/ str\. .*//;
+          $tax_name =~ s/$strain// if defined $strain;
+          $tax_name =~ s/ (str\.|strain) .*//;
+          $tax_name =~ s/ $//;
         }
 
         my $alias = 0;
@@ -90,8 +91,9 @@ sub tests {
 
           foreach my $synonym (@synonyms) {
             if ($sci_name ne $synonym) {
-              $synonym =~ s/ $strain// if defined $strain;
-              $synonym =~ s/ str\. .*//;
+              $synonym =~ s/$strain// if defined $strain;
+              $synonym =~ s/ (str\.|strain) .*//;
+              $synonym =~ s/ $//;
             }
 
             if ($sci_name eq $synonym) {


### PR DESCRIPTION
3 BRC4 check update, as well as other corrections:
- ControlledAnalysisDescription should be skippable if there are no analysis in the database, like it is done for ControlledAnalysis
- Fix Species taxonomy when removing the strain from the scientific name, + also remove "strain" in addition to "str."
- Fix MTCodonTable to allow cases when there are several mitochondria (see Phlebotomus papatasi with 18).