### PR TITLE
remove known phenotype descriptions

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/PhenotypeDescription.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/PhenotypeDescription.pm
@@ -75,7 +75,7 @@ sub tests {
   my $sql_non_term = qq/
       SELECT phenotype_id
       FROM phenotype
-      WHERE lower(description) in ("none", "not provided", "not specified", "not in omim", "variant of unknown significance", "not_provided", "clinvar: phenotype not specified", "?", ".")
+      WHERE lower(description) in ( "?", ".")
   /;
   is_rows_zero($self->dba, $sql_non_term, $desc_non_term, $diag_non_term);
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/PhenotypeDescription.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/PhenotypeDescription.pm
@@ -74,8 +74,9 @@ sub tests {
   my $diag_non_term = 'Row description is not useful';
   my $sql_non_term = qq/
       SELECT phenotype_id
-      FROM phenotype
-      WHERE lower(description) in ( "?", ".")
+      FROM phenotype p JOIN attrib a ON p.class_attrib_id = a.attrib_id
+      WHERE lower(description) in ("none", "not provided", "not specified", "not in omim", "variant of unknown significance", "not_provided", "clinvar: phenotype not specified", "?", ".")
+      AND a.value != 'non_specified'
   /;
   is_rows_zero($self->dba, $sql_non_term, $desc_non_term, $diag_non_term);
 


### PR DESCRIPTION
Updating known and accepted phenotype descriptions in check.

Before this change the DC would fail if 'none' would be present as a phenotype description. This is accepted as long as the phenotype class attrib is 'non_specified'.