### PR TITLE
Sort transcripts to use the dna cache

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ProteinTranslation.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ProteinTranslation.pm
@@ -47,7 +47,8 @@ sub tests {
   my @zero_length = ();
   my @internal_stop = ();
 
-  for my $transcript (@$transcripts) {
+  # Sort the transcripts in order to use the cache
+  for my $transcript (sort { $a->seq_region_name cmp $b->seq_region_name or $a->start <=> $b->start } @$transcripts) {
     my $seq_obj = $transcript->translate();
     if (defined $seq_obj) {
       my $aa_seq = $seq_obj->seq();


### PR DESCRIPTION
ProteinTranslation can take a very long time on long sequences.
Sorting the transcripts by seq_region and start ensures the dna sequence
cache is used more effectively.

Example of speedup: from 1.5h to 30min on Aedes aegypti