### PR TITLE
Check that seq_region synonyms are not names of other seq_regions

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionSynonyms.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionSynonyms.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SeqRegionSynonyms',
   DESCRIPTION => 'Seq_region synonyms do not clash with seq region names',
-  GROUPS      => ['ancestral', 'assembly', 'brc4_core', 'core'],
+  GROUPS      => ['assembly', 'brc4_core', 'core'],
   DB_TYPES    => ['core'],
   TABLES      => ['attrib_type', 'coord_system', 'seq_region', 'seq_region_synonym']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionSynonyms.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionSynonyms.pm
@@ -52,8 +52,8 @@ sub tests {
       INNER JOIN coord_system cs2 ON sr2.coord_system_id = cs2.coord_system_id
     WHERE
       sr1.name = ss2.synonym
-      AND sr1.coord_system_id = sr2.coord_system_id
       AND sr1.seq_region_id != sr2.seq_region_id
+      AND cs1.version = cs2.version
       AND cs1.species_id = $species_id
       AND cs2.species_id = $species_id
     GROUP BY sr1.name, sr2.name

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionSynonyms.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionSynonyms.pm
@@ -1,0 +1,64 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::SeqRegionSynonyms;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'SeqRegionSynonyms',
+  DESCRIPTION => 'Seq_region synonyms do not clash with seq region names',
+  GROUPS      => ['ancestral', 'assembly', 'brc4_core', 'core'],
+  DB_TYPES    => ['core'],
+  TABLES      => ['attrib_type', 'coord_system', 'seq_region', 'seq_region_synonym']
+};
+
+sub tests {
+  my ($self) = @_;
+
+  my $species_id = $self->dba->species_id;
+
+  my $desc_1 = 'Seq_region synonyms are not the same as the name of other seq_regions';
+  my $diag_1 = 'Clashing seq_region synonym';
+  my $sql_1  = qq/
+    SELECT sr1.name, sr2.name
+      FROM seq_region sr1
+      INNER JOIN seq_region_synonym ss1 ON sr1.seq_region_id = ss1.seq_region_id
+      INNER JOIN coord_system cs1 ON sr1.coord_system_id = cs1.coord_system_id
+      , seq_region sr2
+      INNER JOIN seq_region_synonym ss2 ON sr2.seq_region_id = ss2.seq_region_id
+      INNER JOIN coord_system cs2 ON sr2.coord_system_id = cs2.coord_system_id
+    WHERE
+      sr1.name = ss2.synonym
+      AND sr1.coord_system_id = sr2.coord_system_id
+      AND sr1.seq_region_id != sr2.seq_region_id
+      AND cs1.species_id = $species_id
+      AND cs2.species_id = $species_id
+    GROUP BY sr1.name, sr2.name
+  /;
+  is_rows_zero($self->dba, $sql_1, $desc_1, $diag_1);
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1979,6 +1979,18 @@
       "name" : "SeqRegionRank",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SeqRegionRank"
    },
+   "SeqRegionSynonyms" : {
+      "datacheck_type" : "critical",
+      "description" : "Seq_region synonyms do not clash with seq region names",
+      "groups" : [
+         "ancestral",
+         "assembly",
+         "brc4_core",
+         "core"
+      ],
+      "name" : "SeqRegionSynonyms",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SeqRegionSynonyms"
+   },
    "SeqRegionTopLevel" : {
       "datacheck_type" : "critical",
       "description" : "Top-level seq_regions are appropriately configured",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1983,7 +1983,6 @@
       "datacheck_type" : "critical",
       "description" : "Seq_region synonyms do not clash with seq region names",
       "groups" : [
-         "ancestral",
          "assembly",
          "brc4_core",
          "core"


### PR DESCRIPTION
(in the same coord system, for a given species)

If a seq_region synonym happens to be the name of a different
seq_region, then the API will prioritize the synonym over the name of
the seq_region, and so will be using the wrong sequence.

This happened in Phlebotomus papatasi, where the name of the scaffolds
were from a version of the assembly prior to its submission to INSDC
(the sequences ended up identical, but with different names in the final
version, hence the clash).