### PR TITLE
Fixes for two seq_region-related datachecks

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionTopLevel.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionTopLevel.pm
@@ -86,9 +86,11 @@ sub tests_with_assembly {
       coord_system cs USING (coord_system_id) INNER JOIN
       seq_region_attrib sra USING (seq_region_id) INNER JOIN
       attrib_type at USING (attrib_type_id) INNER JOIN
-      assembly a ON sr.seq_region_id = a.cmp_seq_region_id
+      assembly a ON sr.seq_region_id = a.cmp_seq_region_id LEFT OUTER JOIN
+      assembly a2 ON sr.seq_region_id = a2.asm_seq_region_id
     WHERE
       at.code = 'toplevel' AND
+      a2.asm_seq_region_id IS NULL AND
       cs.species_id = $species_id
   /;
   is_rows_zero($self->dba, $sql_2, $desc_2, $diag_2);

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionTopLevel.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionTopLevel.pm
@@ -85,10 +85,9 @@ sub tests_with_assembly {
       seq_region sr INNER JOIN
       coord_system cs USING (coord_system_id) INNER JOIN
       seq_region_attrib sra USING (seq_region_id) INNER JOIN
-      attrib_type at USING (attrib_type_id) LEFT OUTER JOIN
-      assembly a ON sr.seq_region_id = a.asm_seq_region_id
+      attrib_type at USING (attrib_type_id) INNER JOIN
+      assembly a ON sr.seq_region_id = a.cmp_seq_region_id
     WHERE
-      a.asm_seq_region_id IS NULL AND
       at.code = 'toplevel' AND
       cs.species_id = $species_id
   /;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SequenceLevel.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SequenceLevel.pm
@@ -83,16 +83,18 @@ sub tests {
   my $desc_4 = 'Contigs shared between assemblies have null versions';
   my $diag_4 = 'Versioned contig in multiple assemblies';
   my $sql_4  = qq/
-    SELECT sr.name FROM
+    SELECT cs2.version FROM
       assembly a INNER JOIN
       seq_region sr on a.cmp_seq_region_id = sr.seq_region_id INNER JOIN
-      coord_system cs on sr.coord_system_id = cs.coord_system_id
+      coord_system cs on sr.coord_system_id = cs.coord_system_id INNER JOIN
+      seq_region sr2 on a.asm_seq_region_id = sr2.seq_region_id INNER JOIN
+      coord_system cs2 on sr2.coord_system_id = cs2.coord_system_id
     WHERE
       cs.name = 'contig' AND
       cs.version IS NOT NULL AND
-      species_id = $species_id
-    GROUP BY sr.name
-    HAVING COUNT(*) > 1
+      cs.species_id = $species_id
+    GROUP BY cs2.version
+    HAVING COUNT(DISTINCT cs2.version) > 1
   /;
   is_rows_zero($self->dba, $sql_4, $desc_4, $diag_4);
 }


### PR DESCRIPTION
Two datachecks were incorrectly reporting failures, because they did not account for edge cases.

- SequenceLevel: To account for assembly mappings that involve old contig-only assemblies, the SQL in one test was updated to count distinct versions, not seq_region names.
- SeqRegionTopLevel: Handle partial population of the assembly table, where some seq_regions of a particular coord_system are components, and others are unassembled top-level regions.



