### PR TITLE
Move test out of ForeignKeysCompara to new DC

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesTrees.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesTrees.pm
@@ -83,7 +83,7 @@ sub tests {
         (class LIKE 'GenomicAlignTree%' OR class LIKE '%multiple_alignment')
     )
   /;
-  fk($self->dba, 'species_tree_root',       'method_link_species_set_id', 'method_link_species_set', 'method_link_species_set_id', $species_tree_root_constraint);
+  fk($dba, 'species_tree_root', 'method_link_species_set_id', 'method_link_species_set', 'method_link_species_set_id', $species_tree_root_constraint);
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesTrees.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesTrees.pm
@@ -73,7 +73,7 @@ sub tests {
   # Check that all the species_trees correspond to a method_link_species_set that should have a species tree
   my $desc_2 = "All the species_trees with corresponding method_link_species_sets are expected";
   my $row_count_sql = "SELECT COUNT(*) FROM species_tree_root";
-  cmp_rows($dba, $row_count_sql, "==", $expected_tree_count, $desc_2);
+  is_rows($dba, $row_count_sql, $expected_tree_count, $desc_2);
 
   my $species_tree_root_constraint = q/
     method_link_id IN (
@@ -87,4 +87,3 @@ sub tests {
 }
 
 1;
-

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesTrees.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesTrees.pm
@@ -1,0 +1,90 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::CheckSpeciesTrees;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+use Bio::EnsEMBL::Utils::SqlHelper;
+use Data::Dumper;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'CheckSpeciesTrees',
+  DESCRIPTION    => 'The expected number of species trees have been merged',
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments'],
+  DATACHECK_TYPE => 'critical',
+  DB_TYPES       => ['compara'],
+  TABLES         => ['method_link_species_set', 'species_set', 'species_tree_root']
+};
+
+sub tests {
+  my ($self) = @_;
+  my $dba    = $self->dba;
+  my $helper = $dba->dbc->sql_helper;
+  my @method_links = qw(CACTUS_HAL EPO EPO_EXTENDED PECAN PROTEIN_TREES NC_TREES SPECIES_TREE);
+
+  my $expected_tree_count;
+
+  foreach my $method_link_type ( @method_links ) {
+
+    my $mlsss = $self->dba->get_MethodLinkSpeciesSetAdaptor->fetch_all_by_method_link_type($method_link_type);
+    # Only check from the method_links that have mlsss there are other datachecks to check if mlsss are correct
+    next if scalar(@$mlsss) == 0;
+
+    foreach my $mlss ( @$mlsss ) {
+
+      my $mlss_id   = $mlss->dbID;
+      my $mlss_name = $mlss->name;
+
+      my $sql = qq/
+        SELECT COUNT(*)
+          FROM species_tree_root
+        WHERE method_link_species_set_id = $mlss_id
+      /;
+
+      $expected_tree_count += $helper->execute_single_result(-SQL => $sql);
+
+      my $desc_1 = "The species tree for $mlss_id ($mlss_name) is present as expected";
+      is_rows_nonzero($dba, $sql, $desc_1);
+    }
+  }
+
+  # Check that all the species_trees correspond to a method_link_species_set that should have a species tree
+  my $desc_2 = "All the species_trees with corresponding method_link_species_sets are expected";
+  my $row_count_sql = "SELECT COUNT(*) FROM species_tree_root";
+  cmp_rows($dba, $row_count_sql, "==", $expected_tree_count, $desc_2);
+
+  my $species_tree_root_constraint = q/
+    method_link_id IN (
+      SELECT method_link_id FROM method_link
+      WHERE
+        method_link_id < 100 AND
+        (class LIKE 'GenomicAlignTree%' OR class LIKE '%multiple_alignment')
+    )
+  /;
+  fk($self->dba, 'species_tree_root',       'method_link_species_set_id', 'method_link_species_set', 'method_link_species_set_id', $species_tree_root_constraint);
+}
+
+1;
+

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesTrees.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesTrees.pm
@@ -75,15 +75,6 @@ sub tests {
   my $row_count_sql = "SELECT COUNT(*) FROM species_tree_root";
   is_rows($dba, $row_count_sql, $expected_tree_count, $desc_2);
 
-  my $species_tree_root_constraint = q/
-    method_link_id IN (
-      SELECT method_link_id FROM method_link
-      WHERE
-        method_link_id < 100 AND
-        (class LIKE 'GenomicAlignTree%' OR class LIKE '%multiple_alignment')
-    )
-  /;
-  fk($dba, 'species_tree_root', 'method_link_species_set_id', 'method_link_species_set', 'method_link_species_set_id', $species_tree_root_constraint);
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
@@ -25,7 +25,7 @@ use Moose;
 use Path::Tiny;
 use Test::More;
 use Bio::EnsEMBL::DataCheck::Test::DataCheck;
-use Bio::EnsEMBL::DataCheck::Utils qw/repo_location is_ehive_db/;
+use Bio::EnsEMBL::DataCheck::Utils qw/repo_location is_compara_ehive_db/;
 
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
@@ -111,7 +111,7 @@ sub compara_fk {
   fk($self->dba, 'genomic_align_block', 'genomic_align_block_id', 'genomic_align');
 
   # Reverse direction FK constraint, but not applicable to compara_master or pipeline dbs
-  if ($self->dba->dbc->dbname !~ /_master/ && is_ehive_db($self->dba) != 1) {
+  if ($self->dba->dbc->dbname !~ /_master/ && is_compara_ehive_db($self->dba) != 1) {
     fk($self->dba, 'method_link', 'method_link_id', 'method_link_species_set');
     fk($self->dba, 'species_set', 'species_set_id', 'method_link_species_set');
     fk($self->dba, 'genome_db',   'genome_db_id',   'species_set',             undef, 'name != "ancestral_sequences"' );

--- a/lib/Bio/EnsEMBL/DataCheck/Utils.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Utils.pm
@@ -31,7 +31,7 @@ use feature 'say';
 
 require Exporter;
 our @ISA       = qw( Exporter );
-our @EXPORT_OK = qw( repo_location sql_count array_diff hash_diff );
+our @EXPORT_OK = qw( repo_location sql_count array_diff hash_diff is_ehive_db );
 
 use File::Spec::Functions qw/catdir splitdir/;
 
@@ -210,6 +210,31 @@ sub hash_diff {
   );
 
   return (\%diff);
+}
+
+=item B<is_ehive_db>
+
+is_ehive_db($dba);
+
+Takes the database adaptor and returns 1 if the database is an ehive
+pipeline database.
+
+=back
+
+=cut
+sub is_ehive_db {
+  my $dba = shift;
+  my $helper = $dba->dbc->sql_helper;
+
+  my $dbname = $dba->dbc->dbname;
+  my $sql = qq/
+    SELECT COUNT(*)
+      FROM information_schema.tables
+    WHERE table_name = "job"
+      AND table_schema = "$dbname"
+  /;
+
+  return $helper->execute_single_result(-SQL =>$sql);
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Utils.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Utils.pm
@@ -31,7 +31,7 @@ use feature 'say';
 
 require Exporter;
 our @ISA       = qw( Exporter );
-our @EXPORT_OK = qw( repo_location sql_count array_diff hash_diff is_ehive_db );
+our @EXPORT_OK = qw( repo_location sql_count array_diff hash_diff is_compara_ehive_db );
 
 use File::Spec::Functions qw/catdir splitdir/;
 
@@ -212,9 +212,9 @@ sub hash_diff {
   return (\%diff);
 }
 
-=item B<is_ehive_db>
+=item B<is_compara_ehive_db>
 
-is_ehive_db($dba);
+is_compara_ehive_db($dba);
 
 Takes the database adaptor and returns 1 if the database is an ehive
 pipeline database.
@@ -222,7 +222,7 @@ pipeline database.
 =back
 
 =cut
-sub is_ehive_db {
+sub is_compara_ehive_db {
   my $dba = shift;
   my $helper = $dba->dbc->sql_helper;
 

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -506,6 +506,17 @@
       "name" : "CheckSpeciesTreeNodeAttr",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckSpeciesTreeNodeAttr"
    },
+   "CheckSpeciesTrees" : {
+      "datacheck_type" : "critical",
+      "description" : "The expected number of species trees have been merged",
+      "groups" : [
+         "compara",
+         "compara_gene_trees",
+         "compara_genome_alignments"
+      ],
+      "name" : "CheckSpeciesTrees",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckSpeciesTrees"
+   },
    "CheckSynteny" : {
       "datacheck_type" : "critical",
       "description" : "Every synteny_region_id should be seen more than once",

--- a/t/Utils.t
+++ b/t/Utils.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::DataCheck::Utils qw( repo_location sql_count array_diff hash_diff );
+use Bio::EnsEMBL::DataCheck::Utils qw( repo_location sql_count array_diff hash_diff is_ehive_db );
 use Bio::EnsEMBL::Test::MultiTestDB;
 
 use FindBin; FindBin::again();
@@ -90,6 +90,17 @@ subtest 'Hash diff', sub {
   $diff = hash_diff(\%primate_names, \%nocturnal_names, 'primates', 'nocturnal');
   is_deeply($$diff{'In primates only'},  {'siamang' => 'elizabeth'},   'Named first set');
   is_deeply($$diff{'In nocturnal only'}, {'vampire bat' => 'harriet'}, 'Named second set');
+};
+
+subtest 'E-hive check', sub {
+  my $testdb = Bio::EnsEMBL::Test::MultiTestDB->new('multi');
+  my $dba    = $testdb->get_DBAdaptor('metadata');
+
+  my $ehive_check = is_ehive_db($dba);
+  is($ehive_check, 0, 'Correct assignment - not an ehive db');
+  $dba->dbc->db_handle->do("CREATE TABLE job ( column1 int )");
+  $ehive_check    = is_ehive_db($dba);
+  is($ehive_check, 1, 'Correct assignment - is an ehive db');
 };
 
 done_testing();

--- a/t/Utils.t
+++ b/t/Utils.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::DataCheck::Utils qw( repo_location sql_count array_diff hash_diff is_ehive_db );
+use Bio::EnsEMBL::DataCheck::Utils qw( repo_location sql_count array_diff hash_diff is_compara_ehive_db );
 use Bio::EnsEMBL::Test::MultiTestDB;
 
 use FindBin; FindBin::again();
@@ -92,14 +92,14 @@ subtest 'Hash diff', sub {
   is_deeply($$diff{'In nocturnal only'}, {'vampire bat' => 'harriet'}, 'Named second set');
 };
 
-subtest 'E-hive check', sub {
+subtest 'Compara e-hive check', sub {
   my $testdb = Bio::EnsEMBL::Test::MultiTestDB->new('multi');
   my $dba    = $testdb->get_DBAdaptor('metadata');
 
-  my $ehive_check = is_ehive_db($dba);
+  my $ehive_check = is_compara_ehive_db($dba);
   is($ehive_check, 0, 'Correct assignment - not an ehive db');
   $dba->dbc->db_handle->do("CREATE TABLE job ( column1 int )");
-  $ehive_check    = is_ehive_db($dba);
+  $ehive_check    = is_compara_ehive_db($dba);
   is($ehive_check, 1, 'Correct assignment - is an ehive db');
 };
 


### PR DESCRIPTION
## CheckSpeciesTrees

We only detected in `e101` that the species tree in vertebrates had not been merged when the `ForeignKeysCompara` datacheck was run prior to handover. Here we have a species tree specific DC that checks that all expected species trees with linked mlsss are present in the release database. The FK check for the species tree has been moved here too, so that it is not duplicated.

There is some overlap in the tests within `CheckSpeciesTree`, happy to discuss. Was aiming to provide more specific descriptions in the non-fk derived tests to make failures easier to understand.

### Jira ticket linked:
- [Add a datacheck to check that all species-tree are present in the database](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-3602)

## ForeignKeysCompara

`ForeignKeysCompara` was not quite compatible with embedding in our pipelines because it expects all species_sets must be used by an mlss, this is not the case in our production pipeline databases. A new method to detect if a database is an ehive pipeline database or not was placed in `Utils` provisionally, if there is somewhere better to do this or an equal and already implemented method, open to those suggestions. Will add test for coverage if agreed on.

### Jira ticket linked:
- [Update the ForeignKey datacheck to make it pass on production databases](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-3606)