### PR TITLE
Fix for 'Compare*' datachecks in databases without species_id=1

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
@@ -161,6 +161,7 @@ sub _registry_default {
   $uri->db_params->{dbname} = $self->dba->dbc->dbname;
   $uri->add_param('group', $self->dba->group);
   $uri->add_param('species', $species);
+  $uri->add_param('species_id', $self->dba->species_id);
 
   my $dba_url = $uri->generate_uri;
 


### PR DESCRIPTION
Fix problem arising from the registry assuming that species_id=1 if it is not explicitly specified. This was being supplied in one part of this module (used by most datachecks), but not in another, when the registry is reloaded by a datacheck (as, for example, in a 'Compare*' datacheck that connect to the metadata database).
Further details in JIRA ticket ENSPROD-5471.