### PR TITLE
Force load of core db in GeneBiotypes, when run for core-like dbs

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBiotypes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBiotypes.pm
@@ -94,6 +94,9 @@ sub biotype_groups {
   my @group_mismatch;
   my @pseudogene_mismatch;
 
+  # Force a load of the core database sequences.
+  $self->get_dna_dba();
+
   my $ga = $self->dba->get_adaptor("Gene");
   foreach my $gene ( @{ $ga->fetch_all } ) {
     my $gene_group = $groups{$gene->biotype};


### PR DESCRIPTION
When running this datacheck against a core-like database with the 'run_datachecks.pl' script, we need to force the core database to be loaded into the registry (it's lazy-loaded, but for reasons that aren't clear, loading isn't triggered as expected by the calls to the gene adaptor). This is not an issue when running within a pipeline, because the registry will automatically have been loaded in that case.