### PR TITLE
Speed up SQL query on INFORMATION_SCHEMA.COLUMNS and INFORMATION_SCHEMA.TABLES

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
@@ -40,13 +40,18 @@ sub tests {
 
   my $nullable_sql = q/
     SELECT TABLE_NAME, COLUMN_NAME FROM
-      INFORMATION_SCHEMA.COLUMNS INNER JOIN
-      INFORMATION_SCHEMA.TABLES USING (TABLE_SCHEMA, TABLE_NAME)
+      INFORMATION_SCHEMA.COLUMNS
     WHERE
-      TABLE_SCHEMA = database() AND
+      TABLE_NAME IN (
+        SELECT TABLE_NAME FROM
+          INFORMATION_SCHEMA.TABLES
+        WHERE
+          TABLE_SCHEMA = database() AND
+          TABLE_TYPE = 'BASE TABLE'
+        ) AND
       DATA_TYPE = 'varchar' AND
-      IS_NULLABLE = 'YES' AND
-      TABLE_TYPE = 'BASE TABLE'
+     IS_NULLABLE = 'YES'
+     AND TABLE_SCHEMA = database()
   /;
   my $nullables = $self->dba->dbc->sql_helper->execute(-SQL => $nullable_sql);
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
@@ -50,8 +50,8 @@ sub tests {
           TABLE_TYPE = 'BASE TABLE'
         ) AND
       DATA_TYPE = 'varchar' AND
-     IS_NULLABLE = 'YES'
-     AND TABLE_SCHEMA = database()
+      IS_NULLABLE = 'YES'
+      AND TABLE_SCHEMA = database()
   /;
   my $nullables = $self->dba->dbc->sql_helper->execute(-SQL => $nullable_sql);
 


### PR DESCRIPTION
I don't like when people use SELECT inside SELECT statement when it can be done with JOINs but the query with JOINs is taking forever on a server with ~2000 databases whereas the new query is taking 0.02s