### PR TITLE
Cross-database compara datachecks

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
@@ -91,13 +91,7 @@ sub master_tables {
 sub consistent_data {
   my ($self, $helper, $master_helper, $table) = @_;
 
-  # We need things returned in a consistent order, for which we need
-  # columns names. Easiest way to get them is to return one row.
-  my $row_sql  = "SELECT * FROM $table LIMIT 1";
-  my @row = @{ $helper->execute(-SQL => $row_sql, -use_hashrefs => 1) };
-  my $columns = join(", ", keys %{$row[0]});
-
-  my $sql = "SELECT * FROM $table ORDER BY $columns";
+  my $sql = "SELECT * FROM $table $sql_filter";
   my @data =
     @{ $helper->execute(-SQL => $sql, -use_hashrefs => 1) };
   my @master_data =

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
@@ -33,7 +33,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'ControlledTablesCompara',
   DESCRIPTION    => 'Controlled tables are consistent with compara master database',
-  GROUPS         => ['controlled_tables', 'compara', 'compara_master'],
+  GROUPS         => ['controlled_tables', 'compara', 'compara_genome_alignments', 'compara_gene_trees', 'compara_syntenies', 'compara_master'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['genome_db', 'mapping_session', 'method_link', 'method_link_species_set', 'method_link_species_set_tag', 'ncbi_taxa_node', 'species_set_header', 'species_set', 'species_set_tag']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
@@ -1,0 +1,174 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::ControlledTablesCompara;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+use Bio::EnsEMBL::DataCheck::Utils qw/ hash_diff /;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'ControlledTablesCompara',
+  DESCRIPTION    => 'Controlled tables are consistent with compara master database',
+  GROUPS         => ['controlled_tables', 'compara', 'compara_master'],
+  DATACHECK_TYPE => 'advisory',
+  DB_TYPES       => ['compara'],
+  TABLES         => ['genome_db', 'mapping_session', 'method_link', 'method_link_species_set', 'ncbi_taxa_node', 'species_set']
+};
+
+sub tests {
+  my ($self) = @_;
+
+  my $helper = $self->dba->dbc->sql_helper;
+
+  if ($self->dba->dbc->dbname !~ /master/) {
+    my $master_tables = [
+      'genome_db',
+      'mapping_session',
+      'method_link',
+      'method_link_species_set',
+      'species_set'
+    ];
+    $self->master_tables($helper, $master_tables);
+  }
+
+  # The ncbi_taxa_name table has rows added in the compara db;
+  # so don't check that, ncbi_taxa_node is sufficient to check
+  # whether we're up to date.
+  my $taxonomy_tables = ['ncbi_taxa_node'];
+  $self->taxonomy_tables($helper, $taxonomy_tables);
+}
+
+sub master_tables {
+  my ($self, $helper, $tables) = @_;
+
+  # This test requires a compara_master database in the registry,
+  # where the 'species' parameter is the same as the database name.
+  my $desc_1 = "Compara master database found";
+  my $master_db_name = 'ensembl_compara_master';
+  my $division = $self->dba->get_division;
+  if ($division ne 'vertebrates') {
+    $master_db_name =~ s/ensembl/$division/;
+  }
+  my $master_dba = $self->get_dba($master_db_name, 'compara');
+
+  if (ok(defined $master_dba, $desc_1)) {
+    my $master_helper = $master_dba->dbc->sql_helper;
+
+    foreach my $table (@$tables) {
+      my $count_sql = "SELECT COUNT(*) FROM $table";
+      my $desc_2 = "Table '$table' is populated";
+      my $populated = is_rows_nonzero($self->dba, $count_sql, $desc_2);
+
+      if ($populated) {
+        $self->consistent_data($helper, $master_helper, $table)
+      }
+    }
+  }
+}
+
+sub consistent_data {
+  my ($self, $helper, $master_helper, $table) = @_;
+
+  # We need things returned in a consistent order, for which we need
+  # columns names. Easiest way to get them is to return one row.
+  my $row_sql  = "SELECT * FROM $table LIMIT 1";
+  my @row = @{ $helper->execute(-SQL => $row_sql, -use_hashrefs => 1) };
+  my $columns = join(", ", keys %{$row[0]});
+
+  my $sql = "SELECT * FROM $table ORDER BY $columns";
+  my @data =
+    @{ $helper->execute(-SQL => $sql, -use_hashrefs => 1) };
+  my @master_data =
+    @{ $master_helper->execute(-SQL => $sql, -use_hashrefs => 1) };
+
+  # Create hashes of db rows, indexed on the tables auto-increment ID.
+  my %data;
+  my %master_data;
+
+  my $id_column = "$table\_id";
+
+  foreach (@data) {
+    my $id = $_->{$id_column};
+    $data{$id} = $_;
+  }
+  foreach (@master_data) {
+    my $id = $_->{$id_column};
+    $master_data{$id} = $_;
+  }
+
+  # We do not compare the compara and master hashes in a single test, because
+  # we allow entries in the master db that are not in the compara db. We could
+  # use a Test::Deep method instead, but that module does not provide
+  # adequate diagnostic messages.
+  my @not_in_master;
+  my @not_consistent;
+  foreach my $id (sort {$a <=> $b} keys %data) {
+    if (exists $master_data{$id}) {
+      # Do this rather than 'is_deeply' to avoid an
+      # excessive number of 'ok' messages.
+      my $diff = hash_diff($data{$id}, $master_data{$id});
+      if (
+        keys($$diff{'Different values'}) ||
+        keys($$diff{'In first set only'}) ||
+        keys($$diff{'In second set only'})
+      ) {
+        push @not_consistent, "$table ($id_column: $id)";
+      }
+    } else {
+      push @not_in_master, "$table ($id_column: $id)";
+    }
+  }
+
+  my $desc_3 = "All '$table' data exists in master table";
+  is(scalar(@not_in_master), 0, $desc_3) ||
+    diag explain \@not_in_master;
+
+  my $desc_4 = "All '$table' data is consistent";
+  is(scalar(@not_consistent), 0, $desc_4) ||
+    diag explain \@not_consistent;
+}
+
+sub taxonomy_tables {
+  my ($self, $helper, $tables) = @_;
+  
+  my $desc_1 = "Taxonomy database found";
+  my $taxonomy_dba = $self->get_dba('multi', 'taxonomy');
+
+  if (ok(defined $taxonomy_dba, $desc_1)) {
+    my $taxonomy_helper = $taxonomy_dba->dbc->sql_helper;
+
+    foreach my $table (@$tables) {
+      my $desc = "$table is identical in compara and taxonomy database";
+
+      my $sql = "CHECKSUM TABLE $table";
+
+      my $compara = $helper->execute( -SQL => $sql );
+      my $taxonomy = $taxonomy_helper->execute( -SQL => $sql );
+      is($$compara[0][1], $$taxonomy[0][1], $desc);
+    }
+  }
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
@@ -34,7 +34,7 @@ use constant {
   GROUPS         => ['controlled_tables', 'compara', 'compara_master'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['compara'],
-  TABLES         => ['genome_db', 'mapping_session', 'method_link', 'method_link_species_set', 'ncbi_taxa_node', 'species_set']
+  TABLES         => ['genome_db', 'mapping_session', 'method_link', 'method_link_species_set', 'ncbi_taxa_node', 'species_set_header']
 };
 
 sub tests {
@@ -48,7 +48,7 @@ sub tests {
       'mapping_session',
       'method_link',
       'method_link_species_set',
-      'species_set'
+      'species_set_header',
     ];
     $self->master_tables($helper, $master_tables);
   }
@@ -82,14 +82,15 @@ sub master_tables {
       my $populated = is_rows_nonzero($self->dba, $count_sql, $desc_2);
 
       if ($populated) {
-        $self->consistent_data($helper, $master_helper, $table)
+        my $id_column = $table eq 'species_set_header' ? 'species_set_id' : "${table}_id";
+        $self->consistent_data($helper, $master_helper, $table, $id_column)
       }
     }
   }
 }
 
 sub consistent_data {
-  my ($self, $helper, $master_helper, $table) = @_;
+  my ($self, $helper, $master_helper, $table, $id_column) = @_;
 
   my $sql = "SELECT * FROM $table $sql_filter";
   my @data =
@@ -100,8 +101,6 @@ sub consistent_data {
   # Create hashes of db rows, indexed on the tables auto-increment ID.
   my %data;
   my %master_data;
-
-  my $id_column = "$table\_id";
 
   foreach (@data) {
     my $id = $_->{$id_column};

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
@@ -68,11 +68,7 @@ sub master_tables {
   # This test requires a compara_master database in the registry,
   # where the 'species' parameter is the same as the database name.
   my $desc_1 = "Compara master database found";
-  my $master_db_name = 'ensembl_compara_master';
-  my $division = $self->dba->get_division;
-  if ($division ne 'vertebrates') {
-    $master_db_name =~ s/ensembl/$division/;
-  }
+  my $master_db_name = 'compara_master';
   my $master_dba = $self->get_dba($master_db_name, 'compara');
 
   if (ok(defined $master_dba, $desc_1)) {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
@@ -34,7 +34,7 @@ use constant {
   NAME           => 'ControlledTablesCompara',
   DESCRIPTION    => 'Controlled tables are consistent with compara master database',
   GROUPS         => ['controlled_tables', 'compara', 'compara_master'],
-  DATACHECK_TYPE => 'advisory',
+  DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['genome_db', 'mapping_session', 'method_link', 'method_link_species_set', 'method_link_species_set_tag', 'ncbi_taxa_node', 'species_set_header', 'species_set', 'species_set_tag']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
@@ -130,9 +130,9 @@ sub consistent_data {
       # excessive number of 'ok' messages.
       my $diff = hash_diff($data{$id}, $master_data{$id});
       if (
-        keys($$diff{'Different values'}) ||
-        keys($$diff{'In first set only'}) ||
-        keys($$diff{'In second set only'})
+        keys(%{$diff->{'Different values'}}) ||
+        keys(%{$diff->{'In first set only'}}) ||
+        keys(%{$diff->{'In second set only'}})
       ) {
         push @not_consistent, "$table ($id_column: $id)";
       }

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCore.pm
@@ -53,9 +53,6 @@ sub tests {
       my $row_sql  = "SELECT * FROM $table LIMIT 1";
       my @row = @{ $helper->execute(-SQL => $row_sql, -use_hashrefs => 1) };
       my $columns = join(", ", keys %{$row[0]});
-      if (! defined $columns) {
-        
-      }
 
       my $sql = "SELECT * FROM $table ORDER BY $columns";
       my @data = @{ $helper->execute(-SQL => $sql, -use_hashrefs => 1) };
@@ -96,7 +93,6 @@ sub tests {
           is_deeply($data{$id}, $prod_data{$id}, $desc);
         } else {
           push @not_in_prod, "$table ($id_column: $id)";
-          fail($desc);
         }
       }
       my $desc_exists = "All data exists in master table";

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesVariation.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesVariation.pm
@@ -31,7 +31,7 @@ use constant {
   DESCRIPTION => 'Controlled tables are consistent with production database',
   GROUPS      => ['controlled_tables', 'variation'],
   DB_TYPES    => ['variation'],
-  TABLES      => ['attrib', 'attrib_set'],
+  TABLES      => ['attrib', 'attrib_set', 'attrib_type'],
   PER_DB      => 1
 };
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DNAFragCore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DNAFragCore.pm
@@ -54,6 +54,8 @@ sub tests {
 
     next if $gdb_name eq 'ancestral_sequences';
 
+    next if defined $genome_db->genome_component;
+
     my $core_dba = $self->get_dba($genome_db->name, 'core');
 
     my $desc_1 = "Core database found for $gdb_name";

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DNAFragCore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DNAFragCore.pm
@@ -29,14 +29,83 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'DNAFragCore',
   DESCRIPTION => 'Top-level sequences in the core database match dnafrags in compara database',
-  GROUPS      => ['compara'],
-  DB_TYPES    => ['compara']
+  GROUPS      => ['compara', 'compara_master'],
+  DB_TYPES    => ['compara'],
+  TABLES      => ['dnafrag', 'genome_db']
 };
 
 sub tests {
   my ($self) = @_;
 
+  my $dfa = $self->dba->get_DnaFragAdaptor;
+  my $gdba = $self->dba->get_GenomeDBAdaptor;
+
+  # We get all the information we need in one hit, the cache
+  # will eat up all the memory if we let it...
+  $Bio::EnsEMBL::Utils::SeqRegionCache::SEQ_REGION_CACHE_SIZE = 1;
+
+  my $genome_dbs = $gdba->fetch_all_current();
+
+  my $desc = "Current genome_dbs exist";
+  ok(scalar(@$genome_dbs), $desc);
+
+  foreach my $genome_db (sort { $a->name cmp $b->name } @$genome_dbs) {
+    my $gdb_name = $genome_db->name;
+
+    next if $gdb_name eq 'ancestral_sequences';
+
+    my $core_dba = $self->get_dba($genome_db->name, 'core');
+
+    my $desc_1 = "Core database found for $gdb_name";
+    next unless ok(defined $core_dba, $desc_1);
+
+    my $sa = $core_dba->get_SliceAdaptor;
+    my $slices = $sa->fetch_all('toplevel', undef, 1, 1, 1);
+
+    my $seq_region_count = scalar(@$slices);
+    my $dnafrag_count = $dfa->generic_count('genome_db_id = '.$genome_db->dbID);
+
+    my $desc_2 =
+      "Equal number of top level seq_regions ($seq_region_count) ".
+      "and dnafrags ($dnafrag_count) for $gdb_name";
+    is($seq_region_count, $dnafrag_count, $desc_2);
+
+    # If we have lots of regions, it's time consuming to check them
+    # all - and if the numbers tally, it's very likely that everything
+    # is in sync anyway. Vertebrates take 20 mins with this condition,
+    # 6 hours without it.
+    if ($seq_region_count > 10000) {
+      diag "Too many seq_regions ($seq_region_count) to check individually";
+    } else {
+      my $desc_3 = "Name matches between all seq_regions and dnafrags for $gdb_name";
+      my $desc_4 = "Length matches between all seq_regions and dnafrags for $gdb_name";
+      my $desc_5 = "Reference status matches between all seq_region and dnafrag for $gdb_name";
+
+      my @name_mismatches   = ();
+      my @length_mismatches = ();
+      my @is_ref_mismatches = ();
+
+      foreach my $slice (@$slices) {
+        my $slice_name = $slice->coord_system_name.':'.$slice->seq_region_name;
+
+        my $dnafrag = $dfa->fetch_by_GenomeDB_and_name($genome_db, $slice->seq_region_name);
+        if (! defined $dnafrag) {
+          push @name_mismatches, $slice_name;
+        } else {
+          if ($slice->length != $dnafrag->length) {
+            push @length_mismatches, $slice_name;
+          }
+          if ($slice->is_reference != $dnafrag->is_reference) {
+            push @is_ref_mismatches, $slice_name;
+          }
+        }
+      }
+
+      is(scalar(@name_mismatches),   0, $desc_3) || diag explain \@name_mismatches;
+      is(scalar(@length_mismatches), 0, $desc_4) || diag explain \@length_mismatches;
+      is(scalar(@is_ref_mismatches), 0, $desc_5) || diag explain \@is_ref_mismatches;
+    }
+  }
 }
 
 1;
-

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GenomeDBCore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GenomeDBCore.pm
@@ -30,6 +30,7 @@ use constant {
   NAME        => 'GenomeDBCore',
   DESCRIPTION => 'Species, assembly, and geneset metadata are the same in core and compara databases',
   GROUPS      => ['compara', 'compara_genome_alignments', 'compara_gene_trees', 'compara_syntenies', 'compara_master'],
+  DATACHECK_TYPE => 'critical',
   DB_TYPES    => ['compara']
 };
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GenomeDBCore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GenomeDBCore.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'GenomeDBCore',
   DESCRIPTION => 'Species, assembly, and geneset metadata are the same in core and compara databases',
-  GROUPS      => ['compara', 'compara_master'],
+  GROUPS      => ['compara', 'compara_genome_alignments', 'compara_gene_trees', 'compara_syntenies', 'compara_master'],
   DB_TYPES    => ['compara']
 };
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GenomeDBCore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GenomeDBCore.pm
@@ -29,14 +29,45 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'GenomeDBCore',
   DESCRIPTION => 'Species, assembly, and geneset metadata are the same in core and compara databases',
-  GROUPS      => ['compara'],
+  GROUPS      => ['compara', 'compara_master'],
   DB_TYPES    => ['compara']
 };
 
 sub tests {
   my ($self) = @_;
 
+  my $gdba = $self->dba->get_GenomeDBAdaptor;
+
+  my $genome_dbs = $gdba->fetch_all_current();
+  foreach my $genome_db (sort { $a->name cmp $b->name } @$genome_dbs) {
+    my $gdb_name = $genome_db->name;
+    
+    next if $gdb_name eq 'ancestral_sequences';
+
+    my $core_dba = $self->get_dba($genome_db->name, 'core');
+
+    my $desc_1 = "Core database found for $gdb_name";
+    next unless ok(defined $core_dba, $desc_1);
+
+    my $mca = $core_dba->get_adaptor('MetaContainer');
+
+    my $species   = $mca->single_value_by_key('species.production_name');
+    my $taxon_id  = $mca->single_value_by_key('species.taxonomy_id');
+    my $assembly  = $mca->single_value_by_key('assembly.default');
+    my $genebuild = $mca->single_value_by_key('genebuild.start_date');
+
+    my $desc_2 = "Species name matches for $gdb_name";
+    is($genome_db->name, $species, $desc_1);
+
+    my $desc_3 = "Taxonomy ID matches for $gdb_name";
+    is($genome_db->taxon_id, $taxon_id, $desc_2);
+
+    my $desc_4 = "Assembly matches for $gdb_name";
+    is($genome_db->assembly, $assembly, $desc_3);
+
+    my $desc_5 = "Genebuild matches for $gdb_name";
+    is($genome_db->genebuild, $genebuild, $desc_4);
+  }
 }
 
 1;
-

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GenomeDBCore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GenomeDBCore.pm
@@ -31,7 +31,8 @@ use constant {
   DESCRIPTION => 'Species, assembly, and geneset metadata are the same in core and compara databases',
   GROUPS      => ['compara', 'compara_genome_alignments', 'compara_gene_trees', 'compara_syntenies', 'compara_master'],
   DATACHECK_TYPE => 'critical',
-  DB_TYPES    => ['compara']
+  DB_TYPES    => ['compara'],
+  TABLES      => ['genome_db'],
 };
 
 sub tests {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GenomeDBCore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GenomeDBCore.pm
@@ -49,24 +49,16 @@ sub tests {
     my $desc_1 = "Core database found for $gdb_name";
     next unless ok(defined $core_dba, $desc_1);
 
-    my $mca = $core_dba->get_adaptor('MetaContainer');
+    # Let the API build a fresh object as per the information in the Core database
+    my $expected_genome_db = Bio::EnsEMBL::Compara::GenomeDB->new_from_DBAdaptor($core_dba, $genome_db->genome_component);
 
-    my $species   = $mca->single_value_by_key('species.production_name');
-    my $taxon_id  = $mca->single_value_by_key('species.taxonomy_id');
-    my $assembly  = $mca->single_value_by_key('assembly.default');
-    my $genebuild = $mca->single_value_by_key('genebuild.start_date');
+    # Compare it to the object we have in the Compara database
+    my $diffs = $genome_db->_check_equals($expected_genome_db);
 
-    my $desc_2 = "Species name matches for $gdb_name";
-    is($genome_db->name, $species, $desc_1);
-
-    my $desc_3 = "Taxonomy ID matches for $gdb_name";
-    is($genome_db->taxon_id, $taxon_id, $desc_2);
-
-    my $desc_4 = "Assembly matches for $gdb_name";
-    is($genome_db->assembly, $assembly, $desc_3);
-
-    my $desc_5 = "Genebuild matches for $gdb_name";
-    is($genome_db->genebuild, $genebuild, $desc_4);
+    # Complain if there are any differences
+    my $desc = "The GenomeDB matches the Core database";
+    ok(!$diffs, $desc);
+    diag($diffs) if $diffs;
   }
 }
 

--- a/lib/Bio/EnsEMBL/DataCheck/Utils.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Utils.pm
@@ -187,8 +187,14 @@ sub hash_diff {
 
   foreach my $key (keys %$hash_1) {
     if (exists $$hash_2{$key}) {
-      if ($$hash_1{$key} ne $$hash_2{$key}) {
-        $different_values{$key} = [$$hash_1{$key}, $$hash_2{$key}];
+      if (defined $$hash_1{$key} || defined $$hash_2{$key}) {
+        if (
+          (defined $$hash_1{$key} && ! defined $$hash_2{$key}) ||
+          (defined $$hash_2{$key} && ! defined $$hash_1{$key}) ||
+          ($$hash_1{$key} ne $$hash_2{$key})
+        ) {
+          $different_values{$key} = [$$hash_1{$key}, $$hash_2{$key}];
+        }
       }
     } else {
       $hash_1_only{$key} = $$hash_1{$key};

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1318,6 +1318,9 @@
       "description" : "Species, assembly, and geneset metadata are the same in core and compara databases",
       "groups" : [
          "compara",
+         "compara_genome_alignments",
+         "compara_gene_trees",
+         "compara_syntenies",
          "compara_master"
       ],
       "name" : "GenomeDBCore",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -859,6 +859,9 @@
       "groups" : [
          "controlled_tables",
          "compara",
+         "compara_genome_alignments",
+         "compara_gene_trees",
+         "compara_syntenies",
          "compara_master"
       ],
       "name" : "ControlledTablesCompara",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -854,7 +854,7 @@
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ControlledMetaKeys"
    },
    "ControlledTablesCompara" : {
-      "datacheck_type" : "advisory",
+      "datacheck_type" : "critical",
       "description" : "Controlled tables are consistent with compara master database",
       "groups" : [
          "controlled_tables",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -853,6 +853,17 @@
       "name" : "ControlledMetaKeys",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ControlledMetaKeys"
    },
+   "ControlledTablesCompara" : {
+      "datacheck_type" : "advisory",
+      "description" : "Controlled tables are consistent with compara master database",
+      "groups" : [
+         "controlled_tables",
+         "compara",
+         "compara_master"
+      ],
+      "name" : "ControlledTablesCompara",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ControlledTablesCompara"
+   },
    "ControlledTablesCore" : {
       "datacheck_type" : "critical",
       "description" : "Controlled tables are consistent with production database",
@@ -907,7 +918,8 @@
       "datacheck_type" : "critical",
       "description" : "Top-level sequences in the core database match dnafrags in compara database",
       "groups" : [
-         "compara"
+         "compara",
+         "compara_master"
       ],
       "name" : "DNAFragCore",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DNAFragCore"
@@ -1305,7 +1317,8 @@
       "datacheck_type" : "critical",
       "description" : "Species, assembly, and geneset metadata are the same in core and compara databases",
       "groups" : [
-         "compara"
+         "compara",
+         "compara_master"
       ],
       "name" : "GenomeDBCore",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::GenomeDBCore"


### PR DESCRIPTION
The DNAFragCore datacheck replaces the compara.CheckTopLevelDnaFrag and the eg_compara.ControlledTableDnafrag healthchecks. It checks for consistency between the dnafrag and seq_region tables. If the number of seq_regions is < 10,000, then names, lengths, and reference status are checked - otherwise only the counts are compared. This is for tractability - currently the datacheck takes ~20 mins for vertebrates (300-odd species). Without this condition, it takes ~6 hours. Obviously this constraint could be removed, if necessary; and it could potentially be speeded up with more complicated code, but when a species has half a million toplevel sequences, there's only so much you can do...

The GenomeDBCore datacheck replaces the compara.CheckGenomeDB healthcheck. It checks for consistency between the genome_db and core meta tables.

The ControlledTablesCompara datacheck (mostly) replaces the eg_compara.ControlledTable* healthchecks. It includes tests that compare the compara tables to those in the compara_master; so requires a compara_master database in the registry, with the 'species' parameter the same as the database name. It does not require the tables to be identical, rather the compara should be a subset of the compara_master. It also checks the compara ncbi_taxa_node table against the ncbi_taxonomy database (again, the latter needs to be in the registry) - this is a very large table, so the comparison is done with a checksum, because the expectation is an exact match. (The ncbi_taxa_name table is not checked, because the compara db table has extra rows - but just checking ncbi_taxa_node should be enough to test whether we're up-to-date).

While adding these new datachecks, I found a few minor bugs in ControlledTablesCore, ControlledTablesVariation, and Utils.pm, so I've included them here, to save on a further PR...