### PR TITLE
Update group script

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSynonym.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSynonym.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CompareSynonym',
   DESCRIPTION    => 'Compare synonym counts between two databases, categorised by external_db',
-  GROUPS         => ['compare_core', 'xref'],
+  GROUPS         => ['compare_core', 'xref', 'xref_mapping'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['core']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareXref.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareXref.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CompareXref',
   DESCRIPTION    => 'Compare xref counts between two databases, categorised by external_db',
-  GROUPS         => ['compare_core', 'xref'],
+  GROUPS         => ['compare_core', 'xref', 'xref_mapping'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['core']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefFormat.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefFormat.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'DisplayXrefFormat',
   DESCRIPTION    => 'Gene names are correctly formatted',
-  GROUPS         => ['core', 'xref'],
+  GROUPS         => ['core', 'xref', 'xref_mapping'],
   TABLES         => ['coord_system', 'external_db', 'gene', 'seq_region', 'xref'],
 };
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DuplicateTranscriptNames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DuplicateTranscriptNames.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'DuplicateTranscriptNames',
   DESCRIPTION    => 'Protein coding Transcript Names are unique',
-  GROUPS         => ['xref'],
+  GROUPS         => ['xref', 'xref_mapping'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['core'],
   TABLES         => ['transcript','xref','seq_region','coord_system']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DuplicateXref.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DuplicateXref.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'DuplicateXref',
   DESCRIPTION    => 'Xrefs have been added twice with different descriptions or versions',
-  GROUPS         => ['xref', 'core'],
+  GROUPS         => ['core', 'xref', 'xref_mapping'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['core'],
   TABLES         => ['xref'],

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GOXrefEvidence.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GOXrefEvidence.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'GOXrefEvidence',
   DESCRIPTION => 'All GO xrefs have an evidence',
-  GROUPS         => ['xref', 'core'],
+  GROUPS         => ['core', 'protein_features', 'xref', 'xref_go_projection'],
   DB_TYPES       => ['core'],
   TABLES         => ['coord_system', 'external_db', 'object_xref', 'ontology_xref', 'seq_region', 'transcript', 'xref']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneDescriptions.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneDescriptions.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'GeneDescriptions',
   DESCRIPTION    => 'Gene descriptions are correctly formatted',
-  GROUPS         => ['core', 'xref'],
+  GROUPS         => ['core', 'xref', 'xref_mapping'],
   DATACHECK_TYPE => 'critical',
   TABLES         => ['coord_system', 'gene', 'seq_region']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/HGNCNumeric.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/HGNCNumeric.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'HGNCNumeric',
   DESCRIPTION    => 'HGNC xrefs do not have the accession as the display_label',
-  GROUPS         => ['core', 'xref'],
+  GROUPS         => ['core', 'xref', 'xref_mapping'],
   TABLES         => ['coord_system', 'external_db', 'gene', 'object_xref', 'seq_region', 'xref'],
 };
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/HGNCTypes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/HGNCTypes.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'HGNCTypes',
   DESCRIPTION    => 'HGNC xrefs are attached to the appropriate object',
-  GROUPS         => ['core', 'xref'],
+  GROUPS         => ['core', 'xref', 'xref_mapping'],
   DATACHECK_TYPE => 'critical',
   TABLES         => ['coord_system', 'external_db', 'gene', 'object_xref', 'seq_region', 'transcript', 'xref'],
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/LRG.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/LRG.pm
@@ -32,7 +32,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'LRG',
   DESCRIPTION => 'LRG features and seq_regions are correctly configured',
-  GROUPS      => ['core', 'brc4_core', 'xref'],
+  GROUPS      => ['brc4_core', 'core'],
   DB_TYPES    => ['core'],
   TABLES      => ['coord_system', 'gene',  'seq_region', 'transcript'],
   PER_DB      => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/StableIdDisplayXref.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/StableIdDisplayXref.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'StableIdDisplayXref',
   DESCRIPTION    => 'Genes/Transcript display_xref does not have display_label set as stable_id',
-  GROUPS         => ['xref', 'core'],
+  GROUPS         => ['core', 'xref', 'xref_mapping'],
   DB_TYPES       => ['core'],
   TABLES         => ['gene','transcript','xref']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/UnreviewedXrefs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/UnreviewedXrefs.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'UnreviewedXrefs',
   DESCRIPTION    => 'Uniprot xrefs do not have Unreviewed as their primary DB accession',
-  GROUPS         => ['xref', 'core'],
+  GROUPS         => ['core', 'xref', 'xref_mapping'],
   DB_TYPES       => ['core'],
   TABLES         => ['xref','external_db'],
   PER_DB         => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/XrefFormat.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/XrefFormat.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'XrefFormat',
   DESCRIPTION    => 'Xref accessions, labels, and descriptions are validly formatted',
-  GROUPS         => ['xref', 'core'],
+  GROUPS         => ['core', 'xref', 'xref_mapping'],
   DB_TYPES       => ['core'],
   TABLES         => ['identity_xref', 'xref'],
   PER_DB         => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/XrefPrefixes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/XrefPrefixes.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'XrefPrefixes',
   DESCRIPTION    => 'Check that xrefs have the correct prefix for their dbprimary_acc',
-  GROUPS         => ['xref'],
+  GROUPS         => ['xref', 'xref_mapping'],
   DB_TYPES       => ['core'],
   TABLES         => ['xref', 'external_db'],
   PER_DB         => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/XrefTypes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/XrefTypes.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'XrefTypes',
   DESCRIPTION    => 'Xrefs are only attached to one feature type.',
-  GROUPS         => ['xref'],
+  GROUPS         => ['xref', 'xref_mapping'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['core'],
   TABLES         => ['external_db', 'object_xref', 'xref'],

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -734,7 +734,8 @@
       "description" : "Compare synonym counts between two databases, categorised by external_db",
       "groups" : [
          "compare_core",
-         "xref"
+         "xref",
+         "xref_mapping"
       ],
       "name" : "CompareSynonym",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareSynonym"
@@ -798,7 +799,8 @@
       "description" : "Compare xref counts between two databases, categorised by external_db",
       "groups" : [
          "compare_core",
-         "xref"
+         "xref",
+         "xref_mapping"
       ],
       "name" : "CompareXref",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareXref"
@@ -999,7 +1001,8 @@
       "description" : "Gene names are correctly formatted",
       "groups" : [
          "core",
-         "xref"
+         "xref",
+         "xref_mapping"
       ],
       "name" : "DisplayXrefFormat",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DisplayXrefFormat"
@@ -1044,7 +1047,8 @@
       "datacheck_type" : "advisory",
       "description" : "Protein coding Transcript Names are unique",
       "groups" : [
-         "xref"
+         "xref",
+         "xref_mapping"
       ],
       "name" : "DuplicateTranscriptNames",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DuplicateTranscriptNames"
@@ -1053,8 +1057,9 @@
       "datacheck_type" : "advisory",
       "description" : "Xrefs have been added twice with different descriptions or versions",
       "groups" : [
+         "core",
          "xref",
-         "core"
+         "xref_mapping"
       ],
       "name" : "DuplicateXref",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DuplicateXref"
@@ -1209,8 +1214,10 @@
       "datacheck_type" : "critical",
       "description" : "All GO xrefs have an evidence",
       "groups" : [
+         "core",
+         "protein_features",
          "xref",
-         "core"
+         "xref_go_projection"
       ],
       "name" : "GOXrefEvidence",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::GOXrefEvidence"
@@ -1254,7 +1261,8 @@
       "description" : "Gene descriptions are correctly formatted",
       "groups" : [
          "core",
-         "xref"
+         "xref",
+         "xref_mapping"
       ],
       "name" : "GeneDescriptions",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::GeneDescriptions"
@@ -1336,7 +1344,8 @@
       "description" : "HGNC xrefs do not have the accession as the display_label",
       "groups" : [
          "core",
-         "xref"
+         "xref",
+         "xref_mapping"
       ],
       "name" : "HGNCNumeric",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::HGNCNumeric"
@@ -1346,7 +1355,8 @@
       "description" : "HGNC xrefs are attached to the appropriate object",
       "groups" : [
          "core",
-         "xref"
+         "xref",
+         "xref_mapping"
       ],
       "name" : "HGNCTypes",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::HGNCTypes"
@@ -1392,9 +1402,8 @@
       "datacheck_type" : "critical",
       "description" : "LRG features and seq_regions are correctly configured",
       "groups" : [
-         "core",
          "brc4_core",
-         "xref"
+         "core"
       ],
       "name" : "LRG",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::LRG"
@@ -1821,6 +1830,15 @@
       "name" : "PublicationDisplay",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::PublicationDisplay"
    },
+   "RNASeqDNAAlignFeatureAnalyses" : {
+      "datacheck_type" : "critical",
+      "description" : "In an RNA-seq database all DNA alignment features and related analyses are linked correctly.",
+      "groups" : [
+         "corelike"
+      ],
+      "name" : "RNASeqDNAAlignFeatureAnalyses",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::RNASeqDNAAlignFeatureAnalyses"
+   },
    "ReadFileNames" : {
       "datacheck_type" : "critical",
       "description" : "Checks that read file names are valid.",
@@ -1862,15 +1880,6 @@
       ],
       "name" : "RepeatFeatures",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::RepeatFeatures"
-   },
-   "RNASeqDNAAlignFeatureAnalyses" : {
-      "datacheck_type" : "critical",
-      "description" : "In an RNA-seq database all DNA alignment features and related analyses are linked correctly.",
-      "groups" : [
-         "corelike"
-      ],
-      "name" : "RNASeqDNAAlignFeatureAnalyses",
-      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::RNASeqDNAAlignFeatureAnalyses"
    },
    "SNPCounts" : {
       "datacheck_type" : "critical",
@@ -2097,8 +2106,9 @@
       "datacheck_type" : "critical",
       "description" : "Genes/Transcript display_xref does not have display_label set as stable_id",
       "groups" : [
+         "core",
          "xref",
-         "core"
+         "xref_mapping"
       ],
       "name" : "StableIdDisplayXref",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::StableIdDisplayXref"
@@ -2189,8 +2199,9 @@
       "datacheck_type" : "critical",
       "description" : "Uniprot xrefs do not have Unreviewed as their primary DB accession",
       "groups" : [
+         "core",
          "xref",
-         "core"
+         "xref_mapping"
       ],
       "name" : "UnreviewedXrefs",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::UnreviewedXrefs"
@@ -2323,8 +2334,9 @@
       "datacheck_type" : "critical",
       "description" : "Xref accessions, labels, and descriptions are validly formatted",
       "groups" : [
+         "core",
          "xref",
-         "core"
+         "xref_mapping"
       ],
       "name" : "XrefFormat",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::XrefFormat"
@@ -2333,7 +2345,8 @@
       "datacheck_type" : "critical",
       "description" : "Check that xrefs have the correct prefix for their dbprimary_acc",
       "groups" : [
-         "xref"
+         "xref",
+         "xref_mapping"
       ],
       "name" : "XrefPrefixes",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::XrefPrefixes"
@@ -2342,7 +2355,8 @@
       "datacheck_type" : "advisory",
       "description" : "Xrefs are only attached to one feature type.",
       "groups" : [
-         "xref"
+         "xref",
+         "xref_mapping"
       ],
       "name" : "XrefTypes",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::XrefTypes"

--- a/scripts/update_group.pl
+++ b/scripts/update_group.pl
@@ -40,13 +40,13 @@ Whether to add or remove the group from the specified datachecks.
 
 =item B<-d[atacheck_dir]> <datacheck_dir>
 
-The directory in which to save the datacheck module. Defaults to the
+The directory in which to find the datacheck module. Defaults to the
 repository's default value (lib/Bio/EnsEMBL/DataCheck/Checks).
 Mandatory if -index_file is specified.
 
 =item B<-i[ndex_file]> <index_file>
 
-The path to the index_file that will be created/updated. Defaults to the
+The path to the index_file that will be updated. Defaults to the
 repository's default value (lib/Bio/EnsEMBL/DataCheck/index.json).
 Mandatory if -datacheck_dir is specified.
 

--- a/scripts/update_group.pl
+++ b/scripts/update_group.pl
@@ -1,0 +1,141 @@
+#!/usr/bin/env perl
+
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 SYNOPSIS
+
+perl create_group.pl [options]
+
+=head1 OPTIONS
+
+=over 8
+
+=item B<-g[roup]> <group>
+
+Mandatory. The new group name, in 'Snake case', e.g. core_handover.
+
+=item B<-n[ames]> <names>
+
+Mandatory. The names of the datachecks to be added to the new group.
+Multiple names can be given as separate -names, or as a single
+comma-separated string.
+
+=item B<-a[ction]> 'add'|'remove'
+
+Whether to add or remove the group from the specified datachecks.
+
+=item B<-d[atacheck_dir]> <datacheck_dir>
+
+The directory in which to save the datacheck module. Defaults to the
+repository's default value (lib/Bio/EnsEMBL/DataCheck/Checks).
+Mandatory if -index_file is specified.
+
+=item B<-i[ndex_file]> <index_file>
+
+The path to the index_file that will be created/updated. Defaults to the
+repository's default value (lib/Bio/EnsEMBL/DataCheck/index.json).
+Mandatory if -datacheck_dir is specified.
+
+=item B<-h[elp]>
+
+Print usage information.
+
+=back
+
+=cut
+
+use warnings;
+use strict;
+use feature 'say';
+
+use Bio::EnsEMBL::DataCheck::Manager;
+
+use File::Copy qw(move);
+use File::Spec::Functions qw(catdir);
+use Getopt::Long qw(:config no_ignore_case);
+use Path::Tiny;
+use Pod::Usage;
+
+my (
+    $help,
+    $group, @names, $action, $datacheck_dir, $index_file,
+);
+
+GetOptions(
+  "help!",           \$help,
+  "group=s",         \$group,
+  "names:s",         \@names,
+  "action=s",        \$action,
+  "datacheck_dir:s", \$datacheck_dir,
+  "index_file:s",    \$index_file,
+);
+
+pod2usage(1) if $help;
+
+die 'group required' unless defined $group;
+die 'names required' unless scalar @names;
+$action = 'add' unless defined $action;
+
+if ($action !~ /^(add|remove)$/) {
+  die "action must be either 'add' or 'remove'";
+}
+
+# It doesn't make sense to update the default index file if a datacheck_dir
+# is specified (and vice versa); one wants the default directory and index
+# to remain in sync.
+if (defined $datacheck_dir && ! defined $index_file) {
+  die "index_file is mandatory if datacheck_dir is specified";
+}
+if (! defined $datacheck_dir && defined $index_file) {
+  die "datacheck_dir is mandatory if index_file is specified";
+}
+
+my %manager_params;
+$manager_params{datacheck_dir} = $datacheck_dir if defined $datacheck_dir;
+$manager_params{index_file}    = $index_file    if defined $index_file;
+
+my $manager = Bio::EnsEMBL::DataCheck::Manager->new(%manager_params);
+
+# Open index to get list of current datacheck groups.
+my $index = $manager->read_index();
+
+@names = sort map { split(/[,\s]+/, $_) } @names;
+
+foreach my $name (@names) {
+  my %groups = map { $_ => 1 } @{$$index{$name}{groups}};
+  if ($action eq 'add') {
+    $groups{$group} = 1;
+  } elsif ($action eq 'remove') {
+    delete $groups{$group};
+  }
+  my $groups_string = "[" . join(", ", map {"'$_'"} sort keys %groups) . "]";
+
+  my $datacheck_file = catdir($manager->datacheck_dir, "$name.pm");
+  my $datacheck = path($datacheck_file)->slurp;
+  $datacheck =~ s/(^\s+GROUPS\s+=>\s+)\[.+\]/$1$groups_string/m;
+
+  path($datacheck_file)->spew($datacheck);
+}
+
+# Update the index to include the added/removed group.
+$manager->write_index();
+
+if ($action eq 'add') {
+  say "Added group '$group' to datachecks: ".join(', ', @names);
+} elsif ($action eq 'remove') {
+  say "Removed group '$group' from datachecks: ".join(', ', @names);
+}

--- a/scripts/update_group.pl
+++ b/scripts/update_group.pl
@@ -64,7 +64,6 @@ use feature 'say';
 
 use Bio::EnsEMBL::DataCheck::Manager;
 
-use File::Copy qw(move);
 use File::Spec::Functions qw(catdir);
 use Getopt::Long qw(:config no_ignore_case);
 use Path::Tiny;


### PR DESCRIPTION
New script to make it easier to add and remove groups from datachecks. Supply a group name to add or remove, and a list of datachecks, and the relevant files will be updated.

And xref groups updated, for more control when executing in a pipeline.

