### PR TITLE
Missing alignment method

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignments.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignments.pm
@@ -41,7 +41,7 @@ sub skip_tests {
   my ($self) = @_;
   my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
 
-  my @method_links = qw(LASTZ_NET LASTZ_PATCH EPO EPO_EXTENDED PECAN);
+  my @method_links = qw(LASTZ_NET LASTZ_PATCH EPO EPO_EXTENDED PECAN POLYPLOID);
   my @mlsss;
   foreach my $method (@method_links) {
     my $mlss = $mlss_adap->fetch_all_by_method_link_type($method);


### PR DESCRIPTION
`POLYPLOID` comprehends the polyploid self-alignments we compute in Compara. I have noticed it was missing when this DC has failed for plants handover.