### PR TITLE
Missing homology MLSS check from PR #283

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomologyMLSS.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomologyMLSS.pm
@@ -1,0 +1,79 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::CheckHomologyMLSS;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+use Bio::EnsEMBL::Utils::SqlHelper;
+use Data::Dumper;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'CheckHomologyMLSS',
+  DESCRIPTION    => 'The expected number of homologys MLSSs are present',
+  GROUPS         => ['compara', 'compara_gene_trees'],
+  DATACHECK_TYPE => 'critical',
+  DB_TYPES       => ['compara'],
+  TABLES         => ['method_link_species_set', 'homology']
+};
+
+sub tests {
+  my ($self) = @_;
+  my $dba    = $self->dba;
+  my $helper = $dba->dbc->sql_helper;
+  my @method_links = qw(ENSEMBL_ORTHOLOGUES ENSEMBL_PARALOGUES ENSEMBL_HOMOEOLOGUES);
+
+  my $expected_homology_count;
+
+  foreach my $method_link_type ( @method_links ) {
+
+    my $mlsss = $self->dba->get_MethodLinkSpeciesSetAdaptor->fetch_all_by_method_link_type($method_link_type);
+    # Only check from the method_links that have mlsss there are other datachecks to check if mlsss are correct
+    next if scalar(@$mlsss) == 0;
+
+    foreach my $mlss ( @$mlsss ) {
+
+      my $mlss_id   = $mlss->dbID;
+      my $mlss_name = $mlss->name;
+
+      my $sql = qq/
+        SELECT COUNT(*)
+          FROM homology
+        WHERE method_link_species_set_id = $mlss_id
+      /;
+
+      $expected_homology_count += $helper->execute_single_result(-SQL => $sql);
+
+      my $desc_1 = "The homology for $mlss_id ($mlss_name) has rows as expected";
+      is_rows_nonzero($dba, $sql, $desc_1);
+    }
+  }
+
+  # Check that all the homologies correspond to a method_link_species_set that should have homology
+  my $desc_2 = "All the homology rows with corresponding method_link_species_sets are expected";
+  my $row_count_sql = "SELECT COUNT(*) FROM homology";
+  is_rows($dba, $row_count_sql, $expected_homology_count, $desc_2);
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -363,6 +363,16 @@
       "name" : "CheckHomology",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckHomology"
    },
+   "CheckHomologyMLSS" : {
+      "datacheck_type" : "critical",
+      "description" : "The expected number of homologys MLSSs are present",
+      "groups" : [
+         "compara",
+         "compara_gene_trees"
+      ],
+      "name" : "CheckHomologyMLSS",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckHomologyMLSS"
+   },
    "CheckJSONObjects" : {
       "datacheck_type" : "critical",
       "description" : "Check that all JSON objects in gene_tree_object_store are valid",


### PR DESCRIPTION
In PR #283 the ForeignKeysCompara DC was sorted through to remove redundant, duplicate tests and tests with constraints. The tests that were not duplicate or redundant were to be replaced by other DCs. An oversight skipped the replacement of Homology-MLSS checks. This PR replaces that check.