### PR TITLE
Fix/compara dcs for e102

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomologyMLSS.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomologyMLSS.pm
@@ -42,7 +42,7 @@ sub tests {
   my ($self) = @_;
   my $dba    = $self->dba;
   my $helper = $dba->dbc->sql_helper;
-  my @method_links = qw(ENSEMBL_ORTHOLOGUES ENSEMBL_PARALOGUES ENSEMBL_HOMOEOLOGUES);
+  my @method_links = qw(ENSEMBL_ORTHOLOGUES ENSEMBL_PARALOGUES ENSEMBL_HOMOEOLOGUES ENSEMBL_PROJECTIONS);
 
   my $expected_homology_count;
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MemberProductionCounts.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MemberProductionCounts.pm
@@ -116,15 +116,17 @@ sub tests {
     
     my @counts = ($family_count, $genetree_count, $cafetrees_count, $genetree_count, $genetree_count, $polyploid_count);
 
-    if ( $division =~ /vertebrates/ && $collection =~ /default/ ) {
-      my $desc_5 = "The sum of entries for families in gene_member_hom_stats > 0 for the $collection collection";
-      cmp_ok( $sums->[0]->{sum_families}, ">", 0, $desc_5 );
-      my $desc_6 = "There are entries in the family table";
-      cmp_ok( $counts[0], ">", 0, $desc_6 );
-      my $desc_7 = "Found expected entries in gene_member_hom_stats with families > 0 for the $collection collection";
-      my $desc_8 = "There were no unexpected entries in gene_member_hom_stats with families > 0 for the $collection collection";
-      is( $sums->[0]->{sum_families} > 0, $counts[0] > 0, $desc_7 );
-    }
+    #Test for families commented out for duration of compara production freeze, this may return in the future
+
+    # if ( $division =~ /vertebrates/ && $collection =~ /default/ ) {
+    #   my $desc_5 = "The sum of entries for families in gene_member_hom_stats > 0 for the $collection collection";
+    #   cmp_ok( $sums->[0]->{sum_families}, ">", 0, $desc_5 );
+    #   my $desc_6 = "There are entries in the family table";
+    #   cmp_ok( $counts[0], ">", 0, $desc_6 );
+    #   my $desc_7 = "Found expected entries in gene_member_hom_stats with families > 0 for the $collection collection";
+    #   my $desc_8 = "There were no unexpected entries in gene_member_hom_stats with families > 0 for the $collection collection";
+    #   is( $sums->[0]->{sum_families} > 0, $counts[0] > 0, $desc_7 );
+    # }
     if ( $division =~ /vertebrates/ || $collection =~ /default/ ) {
       my $desc_5 = "The sum of entries for gene_trees in gene_member_hom_stats > 0 for the $collection collection";
       cmp_ok( $sums->[0]->{sum_gene_trees}, ">", 0, $desc_5 );


### PR DESCRIPTION
No longer running Families pipeline during the production "freeze" in Compara - so the check for families entries in vertebrates is currently redundant and will fail.

`CheckHomologyMLSS` should have been checking the `ENSEMBL_PROJECTIONS` `method_link.type` too, and will fail on the `$expected_homology_count` without it.