### PR TITLE
Test for sequential exon rank

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1193,7 +1193,7 @@
    },
    "ExonRank" : {
       "datacheck_type" : "critical",
-      "description" : "Exon/transcript links are not duplicated, and rank=1 exons exist for every transcript",
+      "description" : "Exon ranks are unique and sequential",
       "groups" : [
          "core",
          "brc4_core",


### PR DESCRIPTION
Some of the file dumps failed, because exon ranks were not sequential - it seems like some API methods for constructing exon lists for a transcript use 'rank - 1' as an array index. So you end up with an 'undef' in the exon list, which makes things fall over. This update checks that ranks are sequential; a pre-exiting test checks that every transcript has a rank 1 exon. Together, these ensure that exon ranks meet the API's assumptions.