### PR TITLE
sort results of geneset_details JOIN query 

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareMetaKeys.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareMetaKeys.pm
@@ -283,6 +283,11 @@ sub geneset_details {
     WHERE
       cs.name <> 'lrg' AND
       cs.species_id = ?
+    ORDER BY
+      gene_stable_id, 
+      transcript_stable_id, 
+      translation_stable_id, 
+      exon_stable_id
   /;
 
   my $geneset_details =


### PR DESCRIPTION
Hi @james-monkeyshines , 
while running 103 critical core datachecks I encountered

not ok 4 - Gene IDs, positions, and biotype groups are the same between theobroma_cacao_criollo_core_50_103_1 and theobroma_cacao_criollo_core_49_102_1

ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/Checks/CompareMetaKeys.pm line 141.
        #     Structures begin differing at:
        #          $got->{Tc01v2_g034470}{exon_stable_id} = 'Tc01v2_t034470.1-E5'
        #     $expected->{Tc01v2_g034470}{exon_stable_id} = 'Tc01v2_t034470.1-E1'

Since these are identical cores (the 1st in pl1, the 2nd in st3) apart from strain metakeys, I went back an ran the SQL query directly. It seems the order of results is not guaranteed, so I added an ORDER BY statement at the end and it seemed to work on my example. Now both databases return the same geneset details. Hope this helps.