### PR TITLE
Sundry fixes

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DatabaseSpeciesName.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DatabaseSpeciesName.pm
@@ -29,7 +29,6 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'DatabaseSpeciesName',
   DESCRIPTION    => 'The species.production_name meta key matches the DB name',
-  DATACHECK_TYPE => 'advisory',
   GROUPS         => ['core', 'corelike', 'funcgen', 'meta', 'variation'],
   DB_TYPES       => ['cdna', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   TABLES         => ['meta'],

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
@@ -44,6 +44,11 @@ sub tests {
       skip "Repeat features not mandatory for species in collection dbs", 1;
     }
 
+    my $mca = $self->dba->get_adaptor('MetaContainer');
+    if ($mca->get_division eq 'EnsemblViruses') {
+      skip "Repeat features not mandatory for viruses", 1;
+    }
+
     # Don't need to worry about species_id, because we don't do this
     # query for collection dbs...
     my @logic_names = ('dust', 'trf');

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/VersionedGenes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/VersionedGenes.pm
@@ -40,14 +40,16 @@ sub tests {
   my $species_id = $self->dba->species_id;
 
   my $mca = $self->dba->get_adaptor('MetaContainer');
-  my $method = $mca->single_value_by_key('genebuild.method');
+  my $methods = $mca->list_value_by_key('genebuild.method');
 
   # If the geneset has been produced in-house, the 'method' meta_key
   # will have one of the following values:
   # full_genebuild, projection_build, mixed_strategy_build, maker_genebuild
   my $version_expected = 0;
-  if ($method =~ /build/) {
-    $version_expected = 1;
+  foreach my $method (@$methods) {
+    if ($method =~ /build/) {
+      $version_expected = 1;
+    }
   }
 
   $self->version_check('gene',       $version_expected, $species_id);

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1041,7 +1041,7 @@
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DatabaseCollation"
    },
    "DatabaseSpeciesName" : {
-      "datacheck_type" : "advisory",
+      "datacheck_type" : "critical",
       "description" : "The species.production_name meta key matches the DB name",
       "groups" : [
          "core",


### PR DESCRIPTION
- VersionedGenes: Handle databases with multiple 'genebuild.methods'
- RepeatFeatures: Repeat features are not mandatory for virus databases.
- DatabaseSpeciesName: It has become apparent that it is necessary for the database name to match the 'species.production_name' meta_key - change the datacheck for this from advisory to critical.

