### PR TITLE
Add compatibility with Compara's registry config file

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
@@ -197,7 +197,7 @@ sub taxonomy_tables {
   my ($self, $helper, $tables) = @_;
   
   my $desc_1 = "Taxonomy database found";
-  my $taxonomy_dba = $self->get_dba('multi', 'taxonomy');
+  my $taxonomy_dba = $self->get_dba('multi', 'taxonomy') || $self->get_dba('ncbi_taxonomy', 'taxonomy');
 
   if (ok(defined $taxonomy_dba, $desc_1)) {
     my $taxonomy_helper = $taxonomy_dba->dbc->sql_helper;


### PR DESCRIPTION
In case the `multi` "formula" is not found, use our standard alias as the species name for the taxonomy database.