### PR TITLE
Prevent empty strings in 'SET' fields

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankSets.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankSets.pm
@@ -43,7 +43,7 @@ sub tests {
     WHERE
       TABLE_SCHEMA = database() AND
       DATA_TYPE = 'set' AND 
-      COLUMN_DEFAULT <> ''
+      (COLUMN_DEFAULT <> '' OR COLUMN_DEFAULT IS NULL)
   /;
 
   my $sets = $self->dba->dbc->sql_helper->execute(-SQL => $set_sql);

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankSets.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankSets.pm
@@ -30,8 +30,8 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'BlankSets',
   DESCRIPTION => 'Set columns do not have empty string values (unless default)',
-  GROUPS      => ['variation'],
-  DB_TYPES    => ['variation']
+  GROUPS      => ['core', 'corelike', 'variation'],
+  DB_TYPES    => ['cdna', 'core', 'otherfeatures', 'rnaseq', 'variation']
 };
 
 sub tests {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyAssembly.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyAssembly.pm
@@ -127,9 +127,25 @@ sub mapping_test {
   
   my $condition = '';
   if ($mapping_type eq 'assembly') {
-    $condition = 'cs1.attrib rlike "default_version" AND cs2.attrib rlike "default_version" AND';
+    $condition .=
+      '('.
+        '(cs1.version = cs2.version) OR '.
+        '(cs1.version IS NULL) OR '.
+        '(cs2.version IS NULL)'.
+      ') AND';
+    $condition .=
+      '('.
+        '(cs1.attrib rlike "default_version" OR cs2.attrib rlike "default_version") OR '.
+        '(cs1.attrib IS NULL AND cs2.attrib IS NULL)'.
+      ') AND';
   } elsif ($mapping_type eq 'liftover') {
-    $condition = '(cs1.attrib IS NULL OR cs2.attrib IS NULL) AND';
+    $condition .= 'cs1.version <> cs2.version AND';
+    $condition .=
+      '('.
+        '(cs1.attrib IS NULL AND cs2.attrib = "default_version") OR '.
+        '(cs1.attrib = "default_version" AND cs2.attrib IS NULL) OR '.
+        '(cs1.attrib IS NULL AND cs2.attrib IS NULL)'.
+      ') AND';
   }
 
   my $sql_implicit_mappings = qq/

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -194,6 +194,8 @@
       "datacheck_type" : "critical",
       "description" : "Set columns do not have empty string values (unless default)",
       "groups" : [
+         "core",
+         "corelike",
          "variation"
       ],
       "name" : "BlankSets",


### PR DESCRIPTION
For all VARCHAR and ENUM type fields, we prevent empty strings, as long as the fields are NULLable. For variation dbs, SET type fields are also checked - but it makes sense to extend this to dbs with the core schema. There are only two such fields, `coord_system.attrib` and `biotype.db_type`. In the current set of core and core-like dbs, the latter never has an empty string, and it occurs in the former for only a few vertebrates. But those few vertebrates are important, because those rows deal with mappings between assemblies, and our datacheck for verifying those assumes NULL values. We could make the assembly mapping datacheck more complicated to handle empty strings, but we've already got a complicated set of conditions to deal with all the different permutations. And it seems sensible and consistent to disallow empty strings. All non-vertebrates have NULLs, and assembly mapping works fine there, and the Infrastructure team do not foresee any problems enforcing this.
A staging patch will accompany this PR, to remove empty strings on the current set of core dbs.

The BlankSets datacheck is altered slightly, to have an explicit 'is null' condition - otherwise 'SET' columns which have NULL default values are not included when checking for empty strings. This changes the behaviour of the datacheck on variation databases, adding about half a dozen columns to the checking - I ran the updated datacheck against the current set of staging dbs, and got a single empty string, in the pig `variation_feature.flags` field, which has 64 million NULL values, so I don't think it'll be a problem to change that value. A staging patch will be submitted for that.

