### PR TITLE
Production DB-specific foreign key datachecks

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledAnalysis.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledAnalysis.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'ControlledAnalysis',
   DESCRIPTION => 'Analysis descriptions and display settings are consistent with production database',
-  GROUPS      => ['analysis_description', 'controlled_tables', 'core', 'brc4_core', 'corelike'],
+  GROUPS      => ['analysis_description', 'core', 'brc4_core', 'corelike'],
   DB_TYPES    => ['cdna', 'core', 'otherfeatures', 'rnaseq'],
   TABLES      => ['analysis', 'analysis_description'],
   PER_DB      => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledAnalysisVersion.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledAnalysisVersion.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'ControlledAnalysisVersion',
   DESCRIPTION    => 'Analysis db_verion is consistent with production database',
-  GROUPS         => ['controlled_tables', 'core', 'brc4_core', 'corelike'],
+  GROUPS         => ['analysis_description', 'core', 'brc4_core', 'corelike'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['cdna', 'core', 'otherfeatures', 'rnaseq'],
   TABLES         => ['analysis', 'analysis_description'],

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledMetaKeys.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledMetaKeys.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'ControlledMetaKeys',
   DESCRIPTION => 'Meta keys are consistent with production database',
-  GROUPS      => ['controlled_tables', 'core', 'corelike', 'meta', 'funcgen', 'variation'],
+  GROUPS      => ['core', 'corelike', 'meta', 'funcgen', 'variation'],
   DB_TYPES    => ['cdna', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   TABLES      => ['meta']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysControlledTablesCore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysControlledTablesCore.pm
@@ -1,0 +1,58 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::ForeignKeysControlledTablesCore;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+use Bio::EnsEMBL::DataCheck::Utils qw/foreign_keys/;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'ForeignKeysControlledTablesCore',
+  DESCRIPTION => 'Foreign key relationships for tables imported from the production database',
+  GROUPS      => ['controlled_tables'],
+  DB_TYPES    => ['cdna', 'core', 'otherfeatures', 'rnaseq'],
+  TABLES      => ['attrib_type', 'biotype', 'external_db', 'misc_set', 'unmapped_reason'],
+  PER_DB      => 1
+};
+
+sub tests {
+  my ($self) = @_;
+
+  my ($foreign_keys, $failed_to_parse) = foreign_keys($self->dba->group);
+
+  my %tables = map { $_ => 1 } @{$self->tables};
+  foreach my $relationship (@$foreign_keys) {
+    my ($table1, $col1, $table2, $col2) = @$relationship;
+    if (exists $tables{$table2}) {
+      fk($self->dba, @$relationship);
+    }
+  }
+
+  my $desc_parsed = "Parsed all foreign key relationships from file";
+  is(scalar(@$failed_to_parse), 0, $desc_parsed) ||
+    diag explain @$failed_to_parse;
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysControlledTablesVariation.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysControlledTablesVariation.pm
@@ -1,0 +1,38 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::ForeignKeysControlledTablesVariation;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+
+extends 'Bio::EnsEMBL::DataCheck::Checks::ForeignKeysControlledTablesCore';
+
+use constant {
+  NAME        => 'ForeignKeysControlledTablesVariation',
+  DESCRIPTION => 'Foreign key relationships for tables imported from the production database',
+  GROUPS      => ['controlled_tables'],
+  DB_TYPES    => ['variation'],
+  TABLES      => ['attrib', 'attrib_set', 'attrib_type'],
+  PER_DB      => 1
+};
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBiotypes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBiotypes.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'GeneBiotypes',
   DESCRIPTION => 'Genes and transcripts have valid biotypes',
-  GROUPS      => ['core', 'brc4_core', 'corelike', 'geneset'],
+  GROUPS      => ['controlled_tables', 'core', 'brc4_core', 'corelike', 'geneset'],
   DB_TYPES    => ['core', 'otherfeatures'],
   TABLES      => ['biotype', 'coord_system', 'gene', 'seq_region', 'transcript']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Manager.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Manager.pm
@@ -334,7 +334,7 @@ sub write_index {
 
   my @datacheck_files = $dir->children( qr/\.pm$/ );
 
-  foreach (@datacheck_files) {
+  foreach (sort @datacheck_files) {
     eval { require $_ };
     die $@ if $@;
 

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -900,7 +900,6 @@
       "description" : "Analysis descriptions and display settings are consistent with production database",
       "groups" : [
          "analysis_description",
-         "controlled_tables",
          "core",
          "brc4_core",
          "corelike"
@@ -912,7 +911,7 @@
       "datacheck_type" : "advisory",
       "description" : "Analysis db_verion is consistent with production database",
       "groups" : [
-         "controlled_tables",
+         "analysis_description",
          "core",
          "brc4_core",
          "corelike"
@@ -924,7 +923,6 @@
       "datacheck_type" : "critical",
       "description" : "Meta keys are consistent with production database",
       "groups" : [
-         "controlled_tables",
          "core",
          "corelike",
          "meta",
@@ -1287,6 +1285,24 @@
       "name" : "ForeignKeysCompara",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ForeignKeysCompara"
    },
+   "ForeignKeysControlledTablesCore" : {
+      "datacheck_type" : "critical",
+      "description" : "Foreign key relationships for tables imported from the production database",
+      "groups" : [
+         "controlled_tables"
+      ],
+      "name" : "ForeignKeysControlledTablesCore",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ForeignKeysControlledTablesCore"
+   },
+   "ForeignKeysControlledTablesVariation" : {
+      "datacheck_type" : "critical",
+      "description" : "Foreign key relationships for tables imported from the production database",
+      "groups" : [
+         "controlled_tables"
+      ],
+      "name" : "ForeignKeysControlledTablesVariation",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ForeignKeysControlledTablesVariation"
+   },
    "ForeignKeysMultiDB" : {
       "datacheck_type" : "critical",
       "description" : "Foreign key relationships between tables from different databases are not violated",
@@ -1322,6 +1338,7 @@
       "datacheck_type" : "critical",
       "description" : "Genes and transcripts have valid biotypes",
       "groups" : [
+         "controlled_tables",
          "core",
          "brc4_core",
          "corelike",

--- a/t/Utils.t
+++ b/t/Utils.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::DataCheck::Utils qw( repo_location sql_count array_diff hash_diff is_compara_ehive_db );
+use Bio::EnsEMBL::DataCheck::Utils qw( repo_location foreign_keys sql_count array_diff hash_diff is_compara_ehive_db );
 use Bio::EnsEMBL::Test::MultiTestDB;
 
 use FindBin; FindBin::again();
@@ -43,6 +43,21 @@ subtest 'Repository Location', sub {
   throws_ok(
     sub { repo_location('ensembl-bananas') },
     qr/was not found/, 'non-existent repository not located');
+};
+
+subtest 'Foreign Keys', sub {
+  my @db_types = qw(core funcgen variation compara); 
+
+  foreach my $db_type (@db_types) {
+    my ($foreign_keys, $failed_to_parse) = foreign_keys($db_type);
+    ok(scalar(@$foreign_keys), "Retrieved $db_type db foreign keys");
+    is(scalar(@{$$foreign_keys[0]}), 4, "Relationships have four elements");
+    is(scalar(@$failed_to_parse), 0, "No $db_type db parsing failures");
+  }
+
+  throws_ok(
+    sub { foreign_keys('ensembl-datacheck') },
+    qr/file does not exist/, 'fail on invalid repository');
 };
 
 foreach my $species (@species) {


### PR DESCRIPTION
Running the complete foreign key check in the Production DB Sync pipeline was taking way too long, and was largely redundant, so introduce new datachecks which only test the foreign keys that are affected by the sync. This involved a little bit of refactoring of the code for parsing the relationships from a file, in order to prevent code duplication. Also tweaked group membership a little, so that the pipeline can refer to the 'controlled_tables' group.

