### PR TITLE
Exclude the repeatmask_repeatmodeler logic_name from the DC 

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
@@ -194,7 +194,7 @@ sub repeat_analysis {
 
     skip 'No repeat features', 1 unless scalar(@logic_names);
 
-    my $desc = "'repeat.analysis' meta_keys exist for every repeat analysis";
+    my $desc = "'repeat.analysis' meta_keys exist for appropriate repeat analyses";
     my $mca = $self->dba->get_adaptor('MetaContainer');
     my @values = sort @{ $mca->list_value_by_key('repeat.analysis') };
     is_deeply(\@values, \@logic_names, $desc);

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
@@ -184,7 +184,7 @@ sub repeat_analysis {
       WHERE
         species_id = $species_id
       AND
-        logic_name not like "%repeatmodeler%"
+        logic_name <> "repeatmask_repeatmodeler"
       GROUP BY
         logic_name
       ORDER BY logic_name

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
@@ -183,6 +183,8 @@ sub repeat_analysis {
         analysis USING (analysis_id)
       WHERE
         species_id = $species_id
+      AND
+        logic_name not like "%repeatmodeler%"
       GROUP BY
         logic_name
       ORDER BY logic_name


### PR DESCRIPTION
Repeatmodeler is not currently used to mask the genome for subsequent analyses and should not be used to mask the genome for the ftp dumps (discussed in email) - therefore, the key for "repeatmask_repeatmodeler" is not needed in the meta table - skip it in the DC check.