### PR TITLE
Making the XrefTypes datacheck critical

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/XrefTypes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/XrefTypes.pm
@@ -30,8 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'XrefTypes',
   DESCRIPTION    => 'Xrefs are only attached to one feature type.',
-  GROUPS         => ['xref', 'xref_mapping'],
-  DATACHECK_TYPE => 'advisory',
+  GROUPS         => ['core', 'xref', 'xref_mapping'],
   DB_TYPES       => ['core'],
   TABLES         => ['external_db', 'object_xref', 'xref'],
   PER_DB         => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2540,9 +2540,10 @@
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::XrefPrefixes"
    },
    "XrefTypes" : {
-      "datacheck_type" : "advisory",
+      "datacheck_type" : "critical",
       "description" : "Xrefs are only attached to one feature type.",
       "groups" : [
+         "core",
          "xref",
          "xref_mapping"
       ],


### PR DESCRIPTION
Making the XrefTypes datacheck critical, and a member of the 'core' group - databases that fail this datacheck can break biomart building, and cause web display problems.