### PR TITLE
Make Karyotype datacheck critical

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/Karyotype.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/Karyotype.pm
@@ -29,12 +29,11 @@ use List::Util qw/min max/;
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
-  NAME           => 'Karyotype',
-  DESCRIPTION    => 'Karyotype data exists for human, mouse and rat',
-  GROUPS         => ['assembly'],
-  DATACHECK_TYPE => 'advisory',
-  DB_TYPES       => ['core'],
-  TABLES         => ['attrib_type', 'coord_system', 'karyotype', 'seq_region', 'seq_region_attrib']
+  NAME        => 'Karyotype',
+  DESCRIPTION => 'Karyotype data exists for human, mouse and rat',
+  GROUPS      => ['assembly', 'core'],
+  DB_TYPES    => ['core'],
+  TABLES      => ['attrib_type', 'coord_system', 'karyotype', 'seq_region', 'seq_region_attrib']
 };
 
 sub skip_tests {

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1511,10 +1511,11 @@
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::InterProFeatures"
    },
    "Karyotype" : {
-      "datacheck_type" : "advisory",
+      "datacheck_type" : "critical",
       "description" : "Karyotype data exists for human, mouse and rat",
       "groups" : [
-         "assembly"
+         "assembly",
+         "core"
       ],
       "name" : "Karyotype",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::Karyotype"


### PR DESCRIPTION
To detect missing cytogenic bands when assemblies are updated.