### PR TITLE
ExonBounds fix for circular chromosomes

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ExonBounds.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ExonBounds.pm
@@ -152,7 +152,7 @@ sub tests {
 
     if (defined $last_transcript_id && $last_transcript_id == $transcript_id) {
       if ($strand == 1) {
-        if ($last_end > $start && $last_start < $start) {
+        if ($last_start < $start && $start < $last_end) {
           push(@exon_overlaps, "Exons $last_exon_id and $exon_id overlap ($last_end > $start)");
         }
       } else {


### PR DESCRIPTION
Datacheck was relying on the assumption of linear regions, in order to make the queries a bit simpler. But it was failing to handle origin-spanning genes in bacterial circular regions; so need to be a bit more long-winded, to account for those. Introduce four separate queries, one for transcript start and one for transcript end, for each strand.