### PR TITLE
Making conversion of output to json more robust

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/ConvertTapToJson.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/ConvertTapToJson.pm
@@ -77,15 +77,21 @@ sub run {
   my $passed      = $self->param('json_passed');
   my $by_species  = $self->param('json_by_species');
 
-  $self->parse_results($tap, $output_file, $by_species, $passed);
+  if (-e $tap) {
+    $self->parse_results($tap, $output_file, $by_species, $passed);
+  }
 }
 
 sub write_output {
   my $self = shift;
 
-  $self->dataflow_output_id(
-    { json_output_file => $self->param('json_output_file') }, 1
-  );
+  my $json_output_file = $self->param('json_output_file');
+
+  if (-e $json_output_file) {
+    $self->dataflow_output_id(
+      { json_output_file => $json_output_file }, 1
+    );
+  }
 }
 
 sub parse_results {


### PR DESCRIPTION
There should always be output from a datacheck run - but, if something has gone wrong, output might not be written. This would get picked up and reported when the run completes - but the jobs for converting to json were failing before then, and the datacheck process was left hanging. So, make that step robust to the absence of output.