### PR TITLE
add MD5 so that string comparison is case sensitive

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyAssembly.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyAssembly.pm
@@ -53,7 +53,7 @@ sub tests {
       cs.attrib RLIKE 'default_version' AND
       at.code = 'toplevel' AND
       m.meta_key = 'assembly.default' AND
-      MD5(cs.version) <> MD5(m.meta_value) AND
+      BINARY(cs.version) <> BINARY(m.meta_value) AND
       m.species_id = $species_id AND
       cs.species_id = $species_id
     GROUP BY

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyAssembly.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyAssembly.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2018-2020] EMBL-European Bioinformatics Institute
+Copyright [2018-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the 'License');
 you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ sub tests {
       cs.attrib RLIKE 'default_version' AND
       at.code = 'toplevel' AND
       m.meta_key = 'assembly.default' AND
-      cs.version <> m.meta_value AND
+      MD5(cs.version) <> MD5(m.meta_value) AND
       m.species_id = $species_id AND
       cs.species_id = $species_id
     GROUP BY


### PR DESCRIPTION
This patch makes core critical check MetaKeyAssembly case-sensitive @james-monkeyshines 

This was tested on pl1 with musa_acuminata_core_51_104_2 while fixing https://github.com/Ensembl/staging-patches/pull/443