### PR TITLE
Remove analysis db_version check from all groups

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledAnalysisVersion.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledAnalysisVersion.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'ControlledAnalysisVersion',
   DESCRIPTION    => 'Analysis db_verion is consistent with production database',
-  GROUPS         => ['analysis_description', 'core', 'brc4_core', 'corelike'],
+  GROUPS         => [],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['cdna', 'core', 'otherfeatures', 'rnaseq'],
   TABLES         => ['analysis', 'analysis_description'],

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -911,12 +911,7 @@
    "ControlledAnalysisVersion" : {
       "datacheck_type" : "advisory",
       "description" : "Analysis db_verion is consistent with production database",
-      "groups" : [
-         "analysis_description",
-         "core",
-         "brc4_core",
-         "corelike"
-      ],
+      "groups" : [],
       "name" : "ControlledAnalysisVersion",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ControlledAnalysisVersion"
    },


### PR DESCRIPTION
Check on analysis db_version is likely to fail for spurious reasons - too noisy, so remove from all groups for now. It is likely that this datacheck would only be useful for a subset of analyses, because there is little to be gained by updating databases to ensure consistency across the board.