### PR TITLE
Bugfixes/fix query check previous db

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
@@ -448,7 +448,7 @@ sub find_old_dbname {
     my ($sql, $params);
     if ($group =~ /(funcgen|variation)/i) {
       $sql = q/
-        SELECT gd.dbname FROM
+        SELECT DISTINCT gd.dbname FROM
           genome_database gd INNER JOIN
           genome g USING (genome_id) INNER JOIN
           organism o USING (organism_id) INNER JOIN
@@ -462,7 +462,7 @@ sub find_old_dbname {
     } else {
       my $division = $mca->get_division;
       $sql = q/
-        SELECT gd.dbname FROM
+        SELECT DISTINCT gd.dbname FROM
           genome_database gd INNER JOIN
           genome g USING (genome_id) INNER JOIN
           organism o USING (organism_id) INNER JOIN


### PR DESCRIPTION
In the context of the Rapid Release, we have multiple releases sharing the same ENS_VERSION number.
The query checking for previous release DB is therefore failing because for a given ens_version, all RR species may have same database name. 
Adding DISTINCT in the query should fix the issue, because 
- for main site, ens_version is still unique and we won't have the same use case, since db name would have change anyway.
- for RR, it ensure to return the only DB name as expected. 