### PR TITLE
Make old_dba retrieval more robust

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareVariationFeatures.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareVariationFeatures.pm
@@ -47,10 +47,10 @@ sub tests {
     my $curr_dna_dba = $self->get_dna_dba();
     my $old_core_dba = $self->get_old_dba(undef, 'core');
 
-    my $desc_curr_core = 'Current core database found';
+    my $desc_curr_core = 'Current core database found: '.$curr_dna_dba->dbc->dbname;
     my $curr_core_pass = ok(defined $curr_dna_dba, $desc_curr_core);
 
-    my $desc_old_core = 'Old core database found';
+    my $desc_old_core = 'Old core database found: '.$old_core_dba->dbc->dbname;
     my $old_core_pass = ok(defined $old_core_dba, $desc_old_core);
 
     if ($curr_core_pass && $old_core_pass) {

--- a/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
@@ -446,7 +446,10 @@ sub find_old_dbname {
     die "No metadata database found in the registry" unless defined $meta_dba;
 
     my ($sql, $params);
-    if ($group =~ /(funcgen|variation)/i) {
+    if (
+      $group =~ /(funcgen|variation)/i ||
+      $mca->single_value_by_key('schema_type') =~ /(funcgen|variation)/i
+    ) {
       $sql = q/
         SELECT DISTINCT gd.dbname FROM
           genome_database gd INNER JOIN


### PR DESCRIPTION
Include additional condition to catch cases where old versions of both core and variation dbs are needed within a datacheck. And add the database names to the test descriptions, to make debugging easier.