### PR TITLE
hot_fix/repeatdetector_metakey

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
@@ -185,6 +185,8 @@ sub repeat_analysis {
         species_id = $species_id
       AND
         logic_name <> "repeatmask_repeatmodeler"
+      AND
+        logic_name <> "repeatdetector"
       GROUP BY
         logic_name
       ORDER BY logic_name


### PR DESCRIPTION
Added repeat detector to the list of logic names to be skipped under repeat.analysis meta keys.