### PR TITLE
Add optional miminum_count parameter to row_totals & row_subtotals

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareGOXref.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareGOXref.pm
@@ -74,11 +74,10 @@ sub go_xref_counts {
       ox.ensembl_object_type = 'Transcript' AND
       cs.species_id = %d
     GROUP BY edb2.db_name
-    HAVING COUNT(*) > $minimum_count
   /;
   my $sql1 = sprintf($sql, $self->dba->species_id);
   my $sql2 = sprintf($sql, $old_dba->species_id);
-  row_subtotals($self->dba, $old_dba, $sql1, $sql2, $threshold, $desc);
+  row_subtotals($self->dba, $old_dba, $sql1, $sql2, $threshold, $desc, $minimum_count);
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareProjectedGOXrefs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareProjectedGOXrefs.pm
@@ -78,11 +78,10 @@ sub go_xref_counts {
       info_type not in ('UNMAPPED', 'DEPENDENT') AND
       species_id = %d
     GROUP BY proj_source
-    HAVING COUNT(*) > $minimum_count
   /;
   my $sql1 = sprintf($sql, $self->dba->species_id);
   my $sql2 = sprintf($sql, $old_dba->species_id);
-  row_subtotals($self->dba, $old_dba, $sql1, $sql2, $threshold, $desc);
+  row_subtotals($self->dba, $old_dba, $sql1, $sql2, $threshold, $desc, $minimum_count);
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSynonym.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSynonym.pm
@@ -79,11 +79,10 @@ sub synonym_counts {
       ensembl_object_type = '$table_obj' AND
       species_id = %d
     GROUP BY db_name
-    HAVING COUNT(*) > $minimum_count
   /;
   my $sql1 = sprintf($sql, $self->dba->species_id);
   my $sql2 = sprintf($sql, $old_dba->species_id);
-  row_subtotals($self->dba, $old_dba, $sql1, $sql2, 0.70, $desc);
+  row_subtotals($self->dba, $old_dba, $sql1, $sql2, 0.70, $desc, $minimum_count);
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareXref.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareXref.pm
@@ -79,11 +79,10 @@ sub xref_counts {
       ensembl_object_type = '$table_obj' AND
       species_id = %d
     GROUP BY db_name
-    HAVING COUNT(*) > $minimum_count
   /;
   my $sql1 = sprintf($sql, $self->dba->species_id);
   my $sql2 = sprintf($sql, $old_dba->species_id);
-  row_subtotals($self->dba, $old_dba, $sql1, $sql2, 0.66, $desc);
+  row_subtotals($self->dba, $old_dba, $sql1, $sql2, 0.66, $desc, $minimum_count);
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Test/DataCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Test/DataCheck.pm
@@ -237,12 +237,11 @@ C<$sql1> must not be less than 75% of the count for C<$sql2>.
 C<$test_name> is a very short description of the test that will be printed
 out; it is optional, but we B<very> strongly encourage its use.
 
-C<$minimum_count> is an optional parameter that sets the minimum number of rows
-that have to be returned by the SQL statemets for the test to be performed. For
-example if C<$minimum_count> is 500 and B<both> SQL evaluations on C<$dbc1> and
-C<$dbc2> return less than 500 rows, then the test is automatically passed; if
-at least one evaluation returns more than 500 then the test is performed.
-Default value is 0.
+C<$minimum_count> is an optional parameter that sets the minimum count that have
+to be returned by the SQL statemets for the test to be performed. For example if
+C<$minimum_count> is 500 and B<both> SQL evaluations on C<$dbc1> and C<$dbc2>
+return less than 500, then the test is automatically passed; if at least one
+evaluation returns more than 500 then the test is performed. Default value is 0.
 
 A slightly more complex case is when you want to compare counts within
 categories, i.e. with an SQL query that uses a GROUP BY statement.

--- a/t/TestDataCheck.t
+++ b/t/TestDataCheck.t
@@ -128,8 +128,6 @@ subtest 'Comparing Database Rows', sub {
   my $sql_4 = 'SELECT biotype, COUNT(*) FROM gene WHERE biotype <> "protein_coding" GROUP BY biotype';
   my $sql_5 = 'SELECT COUNT(*) FROM gene';
   my $sql_6 = 'SELECT * FROM gene GROUP BY biotype';
-  my $sql_7 = 'SELECT stable_id, COUNT(*) FROM gene';
-  my $sql_8 = 'SELECT stable_id, COUNT(*) FROM gene LIMIT 250';
 
   subtest 'row_totals', sub {
     check_tests(
@@ -167,8 +165,8 @@ subtest 'Comparing Database Rows', sub {
         row_subtotals($dba, undef, $sql_3, $sql_4, 1,   'pass: Row subtotals with min_proportion');
         row_subtotals($dba, undef, $sql_4, $sql_3, 0,   'pass: Row subtotals with min_proportion');
         row_subtotals($dba, undef, $sql_4, $sql_3, 1,   'fail: Row subtotals with min_proportion');
-        row_subtotals($dba, undef, $sql_8, $sql_8, 0.9, 'pass: Row totals below minimum_count', 500);
-        row_subtotals($dba, undef, $sql_8, $sql_7, 0.5, 'fail: Row totals below minimum_count', 250);
+        row_subtotals($dba, undef, $sql_4, $sql_3, 1, 'pass: Row totals below minimum_count', 500);
+        row_subtotals($dba, undef, $sql_4, $sql_3, 1, 'fail: Row totals below minimum_count', 3);
       },
       [
         { ok => 1, depth => undef, name => 'pass: Row subtotals identical' },

--- a/t/TestDataCheck.t
+++ b/t/TestDataCheck.t
@@ -128,6 +128,8 @@ subtest 'Comparing Database Rows', sub {
   my $sql_4 = 'SELECT biotype, COUNT(*) FROM gene WHERE biotype <> "protein_coding" GROUP BY biotype';
   my $sql_5 = 'SELECT COUNT(*) FROM gene';
   my $sql_6 = 'SELECT * FROM gene GROUP BY biotype';
+  my $sql_7 = 'SELECT stable_id, COUNT(*) FROM gene';
+  my $sql_8 = 'SELECT stable_id, COUNT(*) FROM gene LIMIT 250';
 
   subtest 'row_totals', sub {
     check_tests(
@@ -138,12 +140,16 @@ subtest 'Comparing Database Rows', sub {
         row_totals($dba, undef, $sql_1, $sql_2, 0.9, 'pass: Row totals with min_proportion');
         row_totals($dba, undef, $sql_2, $sql_1, 0.5, 'pass: Row totals with min_proportion');
         row_totals($dba, undef, $sql_2, $sql_1, 0.9, 'fail: Row totals with min_proportion');
+        row_totals($dba, undef, $sql_2, $sql_2, 0.9, 'pass: Row totals below minimum_count', 500);
+        row_totals($dba, undef, $sql_2, $sql_1, 0.9, 'fail: Row totals below minimum_count', 500);
       },
       [
         { ok => 1, depth => undef, name => 'pass: Exact row totals' },
         { ok => 0, depth => undef },
         { ok => 1, depth => undef },
         { ok => 1, depth => undef },
+        { ok => 1, depth => undef },
+        { ok => 0, depth => undef },
         { ok => 1, depth => undef },
         { ok => 0, depth => undef },
       ],
@@ -161,6 +167,8 @@ subtest 'Comparing Database Rows', sub {
         row_subtotals($dba, undef, $sql_3, $sql_4, 1,   'pass: Row subtotals with min_proportion');
         row_subtotals($dba, undef, $sql_4, $sql_3, 0,   'pass: Row subtotals with min_proportion');
         row_subtotals($dba, undef, $sql_4, $sql_3, 1,   'fail: Row subtotals with min_proportion');
+        row_subtotals($dba, undef, $sql_8, $sql_8, 0.9, 'pass: Row totals below minimum_count', 500);
+        row_subtotals($dba, undef, $sql_8, $sql_7, 0.9, 'fail: Row totals below minimum_count', 500);
       },
       [
         { ok => 1, depth => undef, name => 'pass: Row subtotals identical' },
@@ -168,6 +176,8 @@ subtest 'Comparing Database Rows', sub {
         { ok => 0, depth => undef },
         { ok => 1, depth => undef },
         { ok => 1, depth => undef },
+        { ok => 1, depth => undef },
+        { ok => 0, depth => undef },
         { ok => 1, depth => undef },
         { ok => 0, depth => undef },
       ],

--- a/t/TestDataCheck.t
+++ b/t/TestDataCheck.t
@@ -141,7 +141,7 @@ subtest 'Comparing Database Rows', sub {
         row_totals($dba, undef, $sql_2, $sql_1, 0.5, 'pass: Row totals with min_proportion');
         row_totals($dba, undef, $sql_2, $sql_1, 0.9, 'fail: Row totals with min_proportion');
         row_totals($dba, undef, $sql_2, $sql_2, 0.9, 'pass: Row totals below minimum_count', 500);
-        row_totals($dba, undef, $sql_2, $sql_1, 0.9, 'fail: Row totals below minimum_count', 500);
+        row_totals($dba, undef, $sql_2, $sql_1, 0.9, 'fail: Row totals below minimum_count', 250);
       },
       [
         { ok => 1, depth => undef, name => 'pass: Exact row totals' },
@@ -168,7 +168,7 @@ subtest 'Comparing Database Rows', sub {
         row_subtotals($dba, undef, $sql_4, $sql_3, 0,   'pass: Row subtotals with min_proportion');
         row_subtotals($dba, undef, $sql_4, $sql_3, 1,   'fail: Row subtotals with min_proportion');
         row_subtotals($dba, undef, $sql_8, $sql_8, 0.9, 'pass: Row totals below minimum_count', 500);
-        row_subtotals($dba, undef, $sql_8, $sql_7, 0.9, 'fail: Row totals below minimum_count', 500);
+        row_subtotals($dba, undef, $sql_8, $sql_7, 0.9, 'fail: Row totals below minimum_count', 250);
       },
       [
         { ok => 1, depth => undef, name => 'pass: Row subtotals identical' },

--- a/t/TestDataCheck.t
+++ b/t/TestDataCheck.t
@@ -168,7 +168,7 @@ subtest 'Comparing Database Rows', sub {
         row_subtotals($dba, undef, $sql_4, $sql_3, 0,   'pass: Row subtotals with min_proportion');
         row_subtotals($dba, undef, $sql_4, $sql_3, 1,   'fail: Row subtotals with min_proportion');
         row_subtotals($dba, undef, $sql_8, $sql_8, 0.9, 'pass: Row totals below minimum_count', 500);
-        row_subtotals($dba, undef, $sql_8, $sql_7, 0.9, 'fail: Row totals below minimum_count', 250);
+        row_subtotals($dba, undef, $sql_8, $sql_7, 0.5, 'fail: Row totals below minimum_count', 250);
       },
       [
         { ok => 1, depth => undef, name => 'pass: Row subtotals identical' },


### PR DESCRIPTION
Passing `minimum_count` to `row_totals` or `row_subtotals` sets the minimum number of rows that have to be returned by the SQL statemets for the test to be performed.
The test passes automatically if **both** counts returned by the compared databases are below `minimum_count`.
