### PR TITLE
New Compara Groups for RR

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankEnums.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankEnums.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'BlankEnums',
   DESCRIPTION => 'Enum columns do not have empty string values',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_gene_trees', 'compara_master', 'compara_syntenies', 'compara_references', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_gene_trees', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankEnums.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankEnums.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'BlankEnums',
   DESCRIPTION => 'Enum columns do not have empty string values',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_gene_trees', 'compara_master', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_gene_trees', 'compara_master', 'compara_syntenies', 'compara_references', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'BlankNulls',
   DESCRIPTION => 'Nullable columns do not have empty string values',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_referenes', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'BlankNulls',
   DESCRIPTION => 'Nullable columns do not have empty string values',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_referenes', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckComparaStableIDs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckComparaStableIDs.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckComparaStableIDs',
   DESCRIPTION    => 'gene trees in gene_tree_root and family all have stable_ids generated',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_references'],
+  GROUPS         => ['compara', 'compara_gene_trees'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['family', 'gene_tree_root']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckComparaStableIDs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckComparaStableIDs.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckComparaStableIDs',
   DESCRIPTION    => 'gene trees in gene_tree_root and family all have stable_ids generated',
-  GROUPS         => ['compara', 'compara_gene_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_references'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['family', 'gene_tree_root']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckDuplicatedTaxaNames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckDuplicatedTaxaNames.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckDuplicatedTaxaNames',
   DESCRIPTION    => 'Check that the ncbi_taxa_name contains only unique rows',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['ncbi_taxa_name']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckDuplicatedTaxaNames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckDuplicatedTaxaNames.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckDuplicatedTaxaNames',
   DESCRIPTION    => 'Check that the ncbi_taxa_name contains only unique rows',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['ncbi_taxa_name']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomology.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomology.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckHomology',
   DESCRIPTION    => 'Check homology_id are all one-to-many for homology_members',
-  GROUPS         => ['compara', 'compara_gene_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_homology_annotation'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['homology', 'homology_member']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomologyMLSS.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomologyMLSS.pm
@@ -32,7 +32,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckHomologyMLSS',
   DESCRIPTION    => 'The expected number of homologys MLSSs are present',
-  GROUPS         => ['compara', 'compara_gene_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_homology_annotation'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['method_link_species_set', 'homology']
@@ -43,6 +43,9 @@ sub tests {
   my $dba    = $self->dba;
   my $helper = $dba->dbc->sql_helper;
   my @method_links = qw(ENSEMBL_ORTHOLOGUES ENSEMBL_PARALOGUES ENSEMBL_HOMOEOLOGUES ENSEMBL_PROJECTIONS);
+  if ($dba->dbc->dbname !~ /[ensembl_compara|protein_trees|ncrna_trees]/) {
+    @method_links = qw(ENSEMBL_HOMOLOGUES);
+  }
 
   my $expected_homology_count;
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckReleaseConsistency.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckReleaseConsistency.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckReleaseConsistency',
   DESCRIPTION    => 'Check for consistency between retired genomes and species_sets',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_master', 'compara_syntenies'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_master', 'compara_syntenies', 'compara_references'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['genome_db', 'method_link_species_set', 'species_set_header']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckReleaseNulls.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckReleaseNulls.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckReleaseNulls',
   DESCRIPTION    => 'For release DB the last_release must be NULL but cannot have a NULL first_release',
-  GROUPS         => ['compara', 'compara_master', 'compara_syntenies'],
+  GROUPS         => ['compara', 'compara_master', 'compara_syntenies', 'compara_references'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['genome_db', 'method_link_species_set', 'species_set_header']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSequenceTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSequenceTable.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckSequenceTable',
   DESCRIPTION    => 'Check for sequence length and availability',
-  GROUPS         => ['compara', 'compara_gene_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_references'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['sequence']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSequenceTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSequenceTable.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckSequenceTable',
   DESCRIPTION    => 'Check for sequence length and availability',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_references'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_references', 'compara_homology_annotation'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['sequence']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetTable.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckSpeciesSetTable',
   DESCRIPTION    => 'Check species_set_tags have no orphans and species_sets are unique',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['species_set']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetTable.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckSpeciesSetTable',
   DESCRIPTION    => 'Check species_set_tags have no orphans and species_sets are unique',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['species_set']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CigarCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CigarCheck.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CigarCheck',
   DESCRIPTION    => 'The cigar_line must not have negative numbers or zeros in it',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_homology_annotation'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['family_member', 'gene_align_member', 'genomic_align', 'homology_member', 'peptide_align_feature'],

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'ForeignKeysCompara',
   DESCRIPTION => 'Foreign key relationships are not violated',
-  GROUPS      => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references'],
+  GROUPS      => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation'],
   DB_TYPES    => ['compara'],
   PER_DB      => 1
 };
@@ -45,6 +45,10 @@ sub tests {
     # Because the master database may have old genomes linked to deprecated taxon_ids
     if ($self->dba->dbc->dbname =~ /master/) {
       next if join(" ", @$relationship) eq 'genome_db taxon_id ncbi_taxa_node taxon_id';
+    }
+    if ($self->dba->dbc->dbname !~ /[ensembl_compara|protein_trees|ncrna_trees]/) {
+      next if join(" ", @$relationship) =~ /homology_member.*[gene_member_id|seq_member_id]/;
+      next if join(" ", @$relationship) =~ /peptide_align_feature.*[gene_member_id|seq_member_id]/;
     }
     fk($self->dba, @$relationship);
   }

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'ForeignKeysCompara',
   DESCRIPTION => 'Foreign key relationships are not violated',
-  GROUPS      => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies'],
+  GROUPS      => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references'],
   DB_TYPES    => ['compara'],
   PER_DB      => 1
 };
@@ -73,7 +73,7 @@ sub compara_fk {
   fk($self->dba, 'genomic_align_block', 'genomic_align_block_id', 'genomic_align');
 
   # Reverse direction FK constraint, but not applicable to compara_master or pipeline dbs
-  if ($self->dba->dbc->dbname !~ /_master/ && is_compara_ehive_db($self->dba) != 1) {
+  if ($self->dba->dbc->dbname !~ /[_master|_reference]/ && is_compara_ehive_db($self->dba) != 1) {
     fk($self->dba, 'method_link', 'method_link_id', 'method_link_species_set');
     fk($self->dba, 'species_set', 'species_set_id', 'method_link_species_set');
     fk($self->dba, 'genome_db',   'genome_db_id',   'species_set',             undef, 'name != "ancestral_sequences"' );

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/NoDataOnGenomeComponents.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/NoDataOnGenomeComponents.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'NoDataOnGenomeComponents',
   DESCRIPTION    => 'Data is only allowed on principle genomes and not components',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_syntenies'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_syntenies', 'compara_homology_annotation'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['constrained_element', 'dnafrag', 'dnafrag_region', 'gene_member', 'genome_db', 'genomic_align', 'seq_member']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaPatchesApplied.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaPatchesApplied.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SchemaPatchesApplied',
   DESCRIPTION => 'Schema patches are up-to-date',
-  GROUPS      => ['brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'production', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaPatchesApplied.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaPatchesApplied.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SchemaPatchesApplied',
   DESCRIPTION => 'Schema patches are up-to-date',
-  GROUPS      => ['brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'production', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaType.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaType.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SchemaType',
   DESCRIPTION => 'The schema type meta key matches the DB name',
-  GROUPS      => ['brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaType.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaType.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SchemaType',
   DESCRIPTION => 'The schema type meta key matches the DB name',
-  GROUPS      => ['brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaVersion.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaVersion.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SchemaVersion',
   DESCRIPTION => 'The schema version meta key matches the DB name',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'core', 'corelike', 'funcgen', 'schema', 'variation', 'compara_references'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -162,6 +162,7 @@
          "compara_master",
          "compara_syntenies",
          "compara_references",
+         "compara_homology_annotation",
          "core",
          "corelike",
          "funcgen",
@@ -182,7 +183,8 @@
          "compara_genome_alignments",
          "compara_master",
          "compara_syntenies",
-         "compara_referenes",
+         "compara_references",
+         "compara_homology_annotation",
          "core",
          "corelike",
          "funcgen",
@@ -229,8 +231,7 @@
       "description" : "gene trees in gene_tree_root and family all have stable_ids generated",
       "groups" : [
          "compara",
-         "compara_gene_trees",
-         "compara_references"
+         "compara_gene_trees"
       ],
       "name" : "CheckComparaStableIDs",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckComparaStableIDs"
@@ -274,7 +275,8 @@
          "compara_genome_alignments",
          "compara_master",
          "compara_syntenies",
-         "compara_references"
+         "compara_references",
+         "compara_homology_annotation"
       ],
       "name" : "CheckDuplicatedTaxaNames",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckDuplicatedTaxaNames"
@@ -384,7 +386,8 @@
       "description" : "Check homology_id are all one-to-many for homology_members",
       "groups" : [
          "compara",
-         "compara_gene_trees"
+         "compara_gene_trees",
+         "compara_homology_annotation"
       ],
       "name" : "CheckHomology",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckHomology"
@@ -394,7 +397,8 @@
       "description" : "The expected number of homologys MLSSs are present",
       "groups" : [
          "compara",
-         "compara_gene_trees"
+         "compara_gene_trees",
+         "compara_homology_annotation"
       ],
       "name" : "CheckHomologyMLSS",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckHomologyMLSS"
@@ -523,7 +527,8 @@
       "groups" : [
          "compara",
          "compara_gene_trees",
-         "compara_references"
+         "compara_references",
+         "compara_homology_annotation"
       ],
       "name" : "CheckSequenceTable",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckSequenceTable"
@@ -550,7 +555,8 @@
          "compara_genome_alignments",
          "compara_master",
          "compara_syntenies",
-         "compara_references"
+         "compara_references",
+         "compara_homology_annotation"
       ],
       "name" : "CheckSpeciesSetTable",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckSpeciesSetTable"
@@ -632,7 +638,8 @@
       "groups" : [
          "compara",
          "compara_gene_trees",
-         "compara_genome_alignments"
+         "compara_genome_alignments",
+         "compara_homology_annotation"
       ],
       "name" : "CigarCheck",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CigarCheck"
@@ -1296,7 +1303,8 @@
          "compara_genome_alignments",
          "compara_master",
          "compara_syntenies",
-         "compara_references"
+         "compara_references",
+         "compara_homology_annotation"
       ],
       "name" : "ForeignKeysCompara",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ForeignKeysCompara"
@@ -1818,7 +1826,8 @@
          "compara",
          "compara_gene_trees",
          "compara_genome_alignments",
-         "compara_syntenies"
+         "compara_syntenies",
+         "compara_homology_annotation"
       ],
       "name" : "NoDataOnGenomeComponents",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::NoDataOnGenomeComponents"
@@ -2079,6 +2088,7 @@
          "compara_master",
          "compara_syntenies",
          "compara_references",
+         "compara_homology_annotation",
          "core",
          "corelike",
          "funcgen",
@@ -2099,6 +2109,7 @@
          "compara_master",
          "compara_syntenies",
          "compara_references",
+         "compara_homology_annotation",
          "core",
          "corelike",
          "funcgen",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -161,6 +161,7 @@
          "compara_gene_trees",
          "compara_master",
          "compara_syntenies",
+         "compara_references",
          "core",
          "corelike",
          "funcgen",
@@ -181,6 +182,7 @@
          "compara_genome_alignments",
          "compara_master",
          "compara_syntenies",
+         "compara_referenes",
          "core",
          "corelike",
          "funcgen",
@@ -227,7 +229,8 @@
       "description" : "gene trees in gene_tree_root and family all have stable_ids generated",
       "groups" : [
          "compara",
-         "compara_gene_trees"
+         "compara_gene_trees",
+         "compara_references"
       ],
       "name" : "CheckComparaStableIDs",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckComparaStableIDs"
@@ -270,7 +273,8 @@
          "compara_gene_trees",
          "compara_genome_alignments",
          "compara_master",
-         "compara_syntenies"
+         "compara_syntenies",
+         "compara_references"
       ],
       "name" : "CheckDuplicatedTaxaNames",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckDuplicatedTaxaNames"
@@ -495,7 +499,8 @@
          "compara",
          "compara_gene_trees",
          "compara_master",
-         "compara_syntenies"
+         "compara_syntenies",
+         "compara_references"
       ],
       "name" : "CheckReleaseConsistency",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckReleaseConsistency"
@@ -506,7 +511,8 @@
       "groups" : [
          "compara",
          "compara_master",
-         "compara_syntenies"
+         "compara_syntenies",
+         "compara_references"
       ],
       "name" : "CheckReleaseNulls",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckReleaseNulls"
@@ -516,7 +522,8 @@
       "description" : "Check for sequence length and availability",
       "groups" : [
          "compara",
-         "compara_gene_trees"
+         "compara_gene_trees",
+         "compara_references"
       ],
       "name" : "CheckSequenceTable",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckSequenceTable"
@@ -542,7 +549,8 @@
          "compara_gene_trees",
          "compara_genome_alignments",
          "compara_master",
-         "compara_syntenies"
+         "compara_syntenies",
+         "compara_references"
       ],
       "name" : "CheckSpeciesSetTable",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckSpeciesSetTable"
@@ -1287,7 +1295,8 @@
          "compara_gene_trees",
          "compara_genome_alignments",
          "compara_master",
-         "compara_syntenies"
+         "compara_syntenies",
+         "compara_references"
       ],
       "name" : "ForeignKeysCompara",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ForeignKeysCompara"
@@ -2069,6 +2078,7 @@
          "compara_genome_alignments",
          "compara_master",
          "compara_syntenies",
+         "compara_references",
          "core",
          "corelike",
          "funcgen",
@@ -2088,6 +2098,7 @@
          "compara_genome_alignments",
          "compara_master",
          "compara_syntenies",
+         "compara_references",
          "core",
          "corelike",
          "funcgen",
@@ -2108,7 +2119,8 @@
          "corelike",
          "funcgen",
          "schema",
-         "variation"
+         "variation",
+         "compara_references"
       ],
       "name" : "SchemaVersion",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SchemaVersion"


### PR DESCRIPTION
## Rapid Release in Compara requires a new group for two new database types.

- Most changes simply involve adding new group to existing checks.

- Some minor exceptions included into `ForeignKeysCompara` for both `compara_references` and `compara_homology_annotation`.

- Minor alteration in `CheckHomologyMLSS` to search for specific `ENSEMBL_HOMOLOGUES` `method.type` for `compara_homology_annotation`.

### Note: Basing against `master` branch because this is not release specific