### PR TITLE
Remove SchemaVersion from compara_references and update Compara schema

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaVersion.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaVersion.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SchemaVersion',
   DESCRIPTION => 'The schema version meta key matches the DB name',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'core', 'corelike', 'funcgen', 'schema', 'variation', 'compara_references'],
+  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Utils.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Utils.pm
@@ -145,6 +145,9 @@ sub foreign_keys {
         next if $line =~ /^\-\-/;
         next unless $line =~ /FOREIGN KEY/;
 
+        if ($line =~ /ALTER TABLE/) {
+          ($table1) = $line =~ /ALTER\s+TABLE\s+(\S+)\s+ADD\s+/i;
+        }
         my ($col1, $table2, $col2) = $line =~
           /\s*FOREIGN\s+KEY\s+\((\S+)\)\s+REFERENCES\s+(\S+)\s*\((\S+)\)/i;
         if (defined $col1 && defined $table2 && defined $col2) {

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2139,8 +2139,7 @@
          "corelike",
          "funcgen",
          "schema",
-         "variation",
-         "compara_references"
+         "variation"
       ],
       "name" : "SchemaVersion",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SchemaVersion"


### PR DESCRIPTION
`SchemaVersion` was working in our previous `compara_references` pipeline because we were using release numbers in the same fashion as the release databases, but we have decided to create a master-like database instead (names `ensembl_compara_references`), so the release number as been removed and this DC is no longer applicable.

For the homology annotation pipeline, we have modified our schema to make things easier for us internally: since we use `InnoDB`, we are taking advantage of the `ON UPDATE CASCADE` option to automatically update some keys, so `ALTER TABLE` is now part of our schema. Thus, `Utils::foreign_keys()` method has been updated.

Both edits have been tested in the [latest run of our `UpdateReferencesDB` pipeline](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-compara-prod-3&port=4523&dbname=jalvarez_update_references_103_fresh).