### PR TITLE
Add check for presence of CCDS for human and mouse

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AttribValuesExist.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AttribValuesExist.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
   NAME           => 'AttribValuesExist',
-  DESCRIPTION    => 'Check that TSL and GENCODE attributes exist',
+  DESCRIPTION    => 'Check for presence of TSL and GENCODE attributes, and CCDS xrefs',
   GROUPS         => ['core', 'geneset_support_level'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['core'],
@@ -40,7 +40,7 @@ sub skip_tests {
   my ($self) = @_;
 
   if ( $self->species !~ /^(homo_sapiens|mus_musculus)$/ ) {
-    return (1, 'GENCODE/TSL attribs are only required for human and mouse');
+    return (1, 'GENCODE/TSL/CCDS are only required for human and mouse');
   }
 }
 
@@ -76,6 +76,16 @@ sub tests {
     WHERE code like 'tsl%'
   /;
   is_rows_nonzero($self->dba, $sql_2, $desc_2);
+
+  my $desc_3 = 'CCDS xrefs exist';
+  my $sql_3  = q/
+    SELECT COUNT(*) FROM
+      object_xref INNER JOIN
+      xref USING (xref_id) INNER JOIN
+      external_db USING (external_db_id)
+    WHERE db_name = 'CCDS';
+  /;
+  is_rows_nonzero($self->dba, $sql_3, $desc_3);
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/TranscriptSupport.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/TranscriptSupport.pm
@@ -16,7 +16,7 @@ limitations under the License.
 
 =cut
 
-package Bio::EnsEMBL::DataCheck::Checks::AttribValuesExist;
+package Bio::EnsEMBL::DataCheck::Checks::TranscriptSupport;
 
 use warnings;
 use strict;
@@ -28,12 +28,12 @@ use Bio::EnsEMBL::DataCheck::Test::DataCheck;
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
-  NAME           => 'AttribValuesExist',
+  NAME           => 'TranscriptSupport',
   DESCRIPTION    => 'Check for presence of TSL and GENCODE attributes, and CCDS xrefs',
   GROUPS         => ['core', 'geneset_support_level'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['core'],
-  TABLES         => ['attrib_type', 'transcript', 'transcript_attrib']
+  TABLES         => ['attrib_type', 'external_db', 'object_xref', 'transcript', 'transcript_attrib', 'xref']
 };
 
 sub skip_tests {

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -151,16 +151,6 @@
       "name" : "AssemblySeqregion",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::AssemblySeqregion"
    },
-   "AttribValuesExist" : {
-      "datacheck_type" : "critical",
-      "description" : "Check for presence of TSL and GENCODE attributes, and CCDS xrefs",
-      "groups" : [
-         "core",
-         "geneset_support_level"
-      ],
-      "name" : "AttribValuesExist",
-      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::AttribValuesExist"
-   },
    "BlankEnums" : {
       "datacheck_type" : "critical",
       "description" : "Enum columns do not have empty string values",
@@ -2362,6 +2352,16 @@
       ],
       "name" : "TranscriptDisplayXrefSuffix",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::TranscriptDisplayXrefSuffix"
+   },
+   "TranscriptSupport" : {
+      "datacheck_type" : "critical",
+      "description" : "Check for presence of TSL and GENCODE attributes, and CCDS xrefs",
+      "groups" : [
+         "core",
+         "geneset_support_level"
+      ],
+      "name" : "TranscriptSupport",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::TranscriptSupport"
    },
    "TranscriptVariation" : {
       "datacheck_type" : "critical",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -153,7 +153,7 @@
    },
    "AttribValuesExist" : {
       "datacheck_type" : "critical",
-      "description" : "Check that TSL and GENCODE attributes exist",
+      "description" : "Check for presence of TSL and GENCODE attributes, and CCDS xrefs",
       "groups" : [
          "core",
          "geneset_support_level"


### PR DESCRIPTION
CCDS xrefs are required for APPRIS annotations, so they need to be in the human and mouse databases at the point of handover (because the data is immediately dumped after handover and passed on to the APPRIS team).