### PR TITLE
Adding some division specificity to repeatmasking metakey checks

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
@@ -193,7 +193,7 @@ sub repeat_analysis {
         analysis USING (analysis_id)
       WHERE
         species_id = $species_id
-      $to_skip
+        AND logic_name NOT IN ('$to_skip')
       GROUP BY
         logic_name
       ORDER BY logic_name

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
@@ -184,7 +184,7 @@ sub repeat_analysis {
       @rep_list = qw("repeatmask_repeatmodeler" "repeatdetector");
     }
     my $to_skip="";
-    $to_skip = join " ", map{'AND logic name <>  '. $_} @rep_list;
+    $to_skip = join " ", map{'AND logic_name <>  '. $_} @rep_list;
 
     my $sql = qq/
       SELECT logic_name FROM

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
@@ -181,7 +181,7 @@ sub repeat_analysis {
       @rep_list = qw("repeatmask_repeatmodeler");
     }
     else {
-      @rep_list = qw("repeatmask_repeatmodeler", "repeatdetector");
+      @rep_list = qw("repeatmask_repeatmodeler" "repeatdetector");
     }
     my $to_skip="";
     $to_skip = join " ", map{'AND logic name <>  '. $_} @rep_list;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
@@ -175,6 +175,17 @@ sub repeat_analysis {
     # in order to do a count, use SQL rather than API.
     my $helper = $self->dba->dbc->sql_helper;
     my $species_id = $self->dba->species_id;
+    my $mca = $self->dba->get_adaptor('MetaContainer');
+    my @rep_list = ();
+    if ($mca->get_division eq 'EnsemblPlants') {
+      @rep_list = qw("repeatmask_repeatmodeler");
+    }
+    else {
+      @rep_list = qw("repeatmask_repeatmodeler", "repeatdetector");
+    }
+    my $to_skip="";
+    $to_skip = join " ", map{'AND logic name <>  '. $_} @rep_list;
+
     my $sql = qq/
       SELECT logic_name FROM
         coord_system INNER JOIN
@@ -183,8 +194,7 @@ sub repeat_analysis {
         analysis USING (analysis_id)
       WHERE
         species_id = $species_id
-      AND
-        logic_name <> "repeatmask_repeatmodeler"
+      $to_skip
       GROUP BY
         logic_name
       ORDER BY logic_name
@@ -195,7 +205,6 @@ sub repeat_analysis {
     skip 'No repeat features', 1 unless scalar(@logic_names);
 
     my $desc = "'repeat.analysis' meta_keys exist for appropriate repeat analyses";
-    my $mca = $self->dba->get_adaptor('MetaContainer');
     my @values = sort @{ $mca->list_value_by_key('repeat.analysis') };
     is_deeply(\@values, \@logic_names, $desc);
   }

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
@@ -183,8 +183,7 @@ sub repeat_analysis {
     else {
       @rep_list = qw("repeatmask_repeatmodeler" "repeatdetector");
     }
-    my $to_skip="";
-    $to_skip = join " ", map{'AND logic_name <>  '. $_} @rep_list;
+    my $to_skip = join("', '", @rep_list);
 
     my $sql = qq/
       SELECT logic_name FROM


### PR DESCRIPTION
As per discussions with James and Guy, I've updated the repeat masking conditional metakey checks so that red isn't skipped for the plants division.