### PR TITLE
Changes to account for per-species compara databases

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
@@ -49,6 +49,10 @@ sub tests {
     if ($self->dba->dbc->dbname !~ /ensembl_compara|protein_trees|ncrna_trees/) {
       next if join(" ", @$relationship) =~ /homology_member.*[gene_member_id|seq_member_id]/;
       next if join(" ", @$relationship) =~ /peptide_align_feature.*[gene_member_id|seq_member_id]/;
+      # Because the rapid release per-species compara database does not hold the reference genomes
+      if ($self->dba->dbc->dbname =~ /_compara_/) {
+          next if join(" ", @$relationship) =~ /species_set.genome_db_id/;
+      }
     }
     fk($self->dba, @$relationship);
   }


### PR DESCRIPTION
## Description

Additional changes for rapid release in Compara, in particular the per-species compara databases. 

- The homology MLSS may not be retrievable using the traditional compara API, so a more simple check is reverted to. This should be fine because the same data is already tested in the pipeline, where the API does work.
- The reference genomes are not retained in the per-species compara database, so a reduced `ForeignKeysCompara` check is necessary, although again, the data is checked in the pipeline first, so this should be enough.

## Related EPIC in compara

[ENSCOMPARASW-3545](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-3545)

## Testing

Tested in homology annotation pipeline database, main release database and per-species compara database