### PR TITLE
Better configuration of available servers/databases

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysMultiDB.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysMultiDB.pm
@@ -51,44 +51,48 @@ sub variation_core_fk {
   # Core <-> Variation database relationships. We cannot assume that the dbs
   # are on the same server, so need to compare in Perl rather than SQL.
 
+  my $desc_dna_dba = 'Core database found';
   my $dna_dba = $self->get_dna_dba();
+  my $pass = ok(defined $dna_dba, $desc_dna_dba);
 
-  my ($stable_ids) = $self->col_array($dna_dba, 'transcript', 'stable_id');
-  my @stable_id_tables = qw/
-    transcript_variation
-  /;
-  foreach my $table (@stable_id_tables) {
-    my $desc = "All stable IDs in $table exist in core database";
+  if ($pass) {
+    my ($stable_ids) = $self->col_array($dna_dba, 'transcript', 'stable_id');
+    my @stable_id_tables = qw/
+      transcript_variation
+    /;
+    foreach my $table (@stable_id_tables) {
+      my $desc = "All stable IDs in $table exist in core database";
 
-    my ($ids, $label) = $self->col_array($self->dba, $table, 'feature_stable_id');
-    my $diff = array_diff($ids, $stable_ids, $label);
-    my @diffs = @{$$diff{"In $label only"}};
-    is(scalar(@diffs), 0, $desc) || diag explain \@diffs;
-  }
+      my ($ids, $label) = $self->col_array($self->dba, $table, 'feature_stable_id');
+      my $diff = array_diff($ids, $stable_ids, $label);
+      my @diffs = @{$$diff{"In $label only"}};
+      is(scalar(@diffs), 0, $desc) || diag explain \@diffs;
+    }
 
-  my ($seq_region_ids) = $self->col_array($dna_dba, 'seq_region', 'seq_region_id');
-  my @seq_region_id_tables = qw/
-    variation_feature
-    structural_variation_feature
-  /;
-  foreach my $table (@seq_region_id_tables) {
-    my $desc = "All seq_region IDs in $table exist in core database";
+    my ($seq_region_ids) = $self->col_array($dna_dba, 'seq_region', 'seq_region_id');
+    my @seq_region_id_tables = qw/
+      variation_feature
+      structural_variation_feature
+    /;
+    foreach my $table (@seq_region_id_tables) {
+      my $desc = "All seq_region IDs in $table exist in core database";
 
-    my ($ids, $label) = $self->col_array($self->dba, $table, 'seq_region_id');
-    my $diff = array_diff($ids, $seq_region_ids, $label);
-    my @diffs = @{$$diff{"In $label only"}};
-    is(scalar(@diffs), 0, $desc) || diag explain \@diffs;
-  }
+      my ($ids, $label) = $self->col_array($self->dba, $table, 'seq_region_id');
+      my $diff = array_diff($ids, $seq_region_ids, $label);
+      my @diffs = @{$$diff{"In $label only"}};
+      is(scalar(@diffs), 0, $desc) || diag explain \@diffs;
+    }
 
-  {
-    my $desc = "seq_region IDs and names are consistent with the core database";
-    my ($sr_variation, $label) = $self->col_hash($self->dba, 'seq_region', 'seq_region_id', 'name');
-    my ($sr_core) = $self->col_hash($dna_dba, 'seq_region', 'seq_region_id', 'name');
-    my $diff = hash_diff($sr_variation, $sr_core, $label);
-    my @diffs = keys %{$$diff{"In $label only"}};
-    is(scalar(@diffs), 0, $desc) || diag explain \@diffs;
-    @diffs = keys %{$$diff{"Different values"}};
-    is(scalar(@diffs), 0, $desc) || diag explain \@diffs;
+    {
+      my $desc = "seq_region IDs and names are consistent with the core database";
+      my ($sr_variation, $label) = $self->col_hash($self->dba, 'seq_region', 'seq_region_id', 'name');
+      my ($sr_core) = $self->col_hash($dna_dba, 'seq_region', 'seq_region_id', 'name');
+      my $diff = hash_diff($sr_variation, $sr_core, $label);
+      my @diffs = keys %{$$diff{"In $label only"}};
+      is(scalar(@diffs), 0, $desc) || diag explain \@diffs;
+      @diffs = keys %{$$diff{"Different values"}};
+      is(scalar(@diffs), 0, $desc) || diag explain \@diffs;
+    }
   }
 }
 
@@ -130,50 +134,54 @@ sub funcgen_core_fk {
   # Core <-> Funcgen database relationships. We cannot assume that the dbs
   # are on the same server, so need to compare in Perl rather than SQL.
 
+  my $desc_dna_dba = 'Core database found';
   my $dna_dba = $self->get_dna_dba();
+  my $pass = ok(defined $dna_dba, $desc_dna_dba);
 
-  my ($stable_ids) = $self->col_array($dna_dba, 'transcript', 'stable_id');
-  my @stable_id_tables = qw/
-    probe_feature_transcript
-    probe_set_transcript
-    probe_transcript
-  /;
-  foreach my $table (@stable_id_tables) {
-    my $desc = "All stable IDs in $table exist in core database";
+  if ($pass) {
+    my ($stable_ids) = $self->col_array($dna_dba, 'transcript', 'stable_id');
+    my @stable_id_tables = qw/
+      probe_feature_transcript
+      probe_set_transcript
+      probe_transcript
+    /;
+    foreach my $table (@stable_id_tables) {
+      my $desc = "All stable IDs in $table exist in core database";
 
-    my ($ids, $label) = $self->col_array($self->dba, $table, 'stable_id');
-    my $diff = array_diff($ids, $stable_ids, $label);
-    my @diffs = @{$$diff{"In $label only"}};
-    is(scalar(@diffs), 0, $desc) || diag explain \@diffs;
-  }
+      my ($ids, $label) = $self->col_array($self->dba, $table, 'stable_id');
+      my $diff = array_diff($ids, $stable_ids, $label);
+      my @diffs = @{$$diff{"In $label only"}};
+      is(scalar(@diffs), 0, $desc) || diag explain \@diffs;
+    }
 
-  my ($gene_stable_ids) = $self->col_array($dna_dba, 'gene', 'stable_id');
-  my @gene_stable_id_tables = ('mirna_target_feature');
+    my ($gene_stable_ids) = $self->col_array($dna_dba, 'gene', 'stable_id');
+    my @gene_stable_id_tables = ('mirna_target_feature');
 
-  for my $table (@gene_stable_id_tables){
-    my $desc = "All gene stable IDs in $table exist in core database";
-    my ($ids, $label) = $self->col_array($self->dba, $table, 'gene_stable_id');
-    my $diff = array_diff($ids, $gene_stable_ids, $label);
-    my @diffs = @{$$diff{"In $label only"}};
-    is(scalar(@diffs), 0, $desc) || diag explain \@diffs;
-  }
+    for my $table (@gene_stable_id_tables){
+      my $desc = "All gene stable IDs in $table exist in core database";
+      my ($ids, $label) = $self->col_array($self->dba, $table, 'gene_stable_id');
+      my $diff = array_diff($ids, $gene_stable_ids, $label);
+      my @diffs = @{$$diff{"In $label only"}};
+      is(scalar(@diffs), 0, $desc) || diag explain \@diffs;
+    }
 
-  my ($seq_region_ids) = $self->col_array($dna_dba, 'seq_region', 'seq_region_id');
-  my @seq_region_id_tables = qw/
-    external_feature
-    mirna_target_feature
-    motif_feature
-    peak
-    probe_feature
-    regulatory_feature
-  /;
-  foreach my $table (@seq_region_id_tables) {
-    my $desc = "All seq_region IDs in $table exist in core database";
+    my ($seq_region_ids) = $self->col_array($dna_dba, 'seq_region', 'seq_region_id');
+    my @seq_region_id_tables = qw/
+      external_feature
+      mirna_target_feature
+      motif_feature
+      peak
+      probe_feature
+      regulatory_feature
+    /;
+    foreach my $table (@seq_region_id_tables) {
+      my $desc = "All seq_region IDs in $table exist in core database";
 
-    my ($ids, $label) = $self->col_array($self->dba, $table, 'seq_region_id');
-    my $diff = array_diff($ids, $seq_region_ids, $label);
-    my @diffs = @{$$diff{"In $label only"}};
-    is(scalar(@diffs), 0, $desc) || diag explain \@diffs;
+      my ($ids, $label) = $self->col_array($self->dba, $table, 'seq_region_id');
+      my $diff = array_diff($ids, $seq_region_ids, $label);
+      my @diffs = @{$$diff{"In $label only"}};
+      is(scalar(@diffs), 0, $desc) || diag explain \@diffs;
+    }
   }
 }
 

--- a/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
@@ -129,7 +129,6 @@ has 'registry_file' => (
 has 'server_uri' => (
   is      => 'ro',
   isa     => 'ArrayRef[Str] | Undef',
-  default => sub { [] }
 );
 
 =head2 registry
@@ -225,7 +224,6 @@ sub _registry_default {
 has 'old_server_uri' => (
   is      => 'ro',
   isa     => 'ArrayRef[Str] | Undef',
-  default => sub { [] }
 );
 
 =head2 data_file_path

--- a/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
@@ -358,13 +358,12 @@ sub get_dba {
       }
 
       $uri->db_params->{dbname} = $dbname;
-      $uri->{params}->{group} = [$group];
-      $uri->{params}->{species} = [$species];
+      my $db_uri = $uri->generate_uri."?species=$species;group=$group";
 
       my $dbh = $self->test_db_connection($uri, $dbname, undef, 0);
       if (defined $dbh) {
         $self->registry->remove_DBAdaptor($species, $group);
-        $self->registry->load_registry_from_url($uri->generate_uri);
+        $self->registry->load_registry_from_url($db_uri);
         last SERVER_URI;
       }
     }
@@ -398,7 +397,8 @@ sub find_dbname {
   die "No metadata database found in the registry" unless defined $meta_dba;
 
   my ($sql, $params);
-  if ($group =~ /(funcgen|variation)/i) {
+  if ($group =~ /(funcgen|variation)/i ||
+      $mca->single_value_by_key('schema_type') =~ /(funcgen|variation)/i) {
     $sql = q/
       SELECT DISTINCT gd.dbname FROM
         genome_database gd INNER JOIN

--- a/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
@@ -173,6 +173,8 @@ sub _registry_default {
     $registry->clear;
     $registry->load_all($self->registry_file);
   } elsif (defined $self->server_uri && scalar(@{$self->server_uri}) ) {
+    my @uris = ();
+
     foreach my $server_uri ( @{$self->server_uri} ) {
       # We need species and group if dbname is given, to make sure
       # the registry manipulations we're about to do are valid.
@@ -182,7 +184,13 @@ sub _registry_default {
           die "species and group parameters are required if the URI includes a database name";
         }
       }
-      $registry->load_registry_from_url($server_uri);
+      push @uris, $server_uri;
+    }
+
+    $registry->disconnect_all;
+    $registry->clear;
+    foreach (@uris) {
+      $registry->load_registry_from_url($_);
     }
   } else {
     die "The '".$self->name."' datacheck needs data from another database, ".
@@ -365,8 +373,6 @@ sub get_dba {
   my $dba = $self->registry->get_DBAdaptor($species, $group);
 
   push @{$self->dba_list}, $dba if defined $dba;
-
-  $dba->dbc && $dba->dbc->disconnect_if_idle();
 
   return $dba;
 }

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/DataCheckSubmission.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/DataCheckSubmission.pm
@@ -103,6 +103,7 @@ sub write_output {
     datacheck_groups   => $self->param('datacheck_groups'),
     datacheck_types    => $self->param('datacheck_types'),
     registry_file      => $self->param('registry_file'),
+    server_uri         => $self->param('server_uri'),
     old_server_uri     => $self->param('old_server_uri'),
     data_file_path     => $self->param('data_file_path'),
 

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/DbDataChecks_conf.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/DbDataChecks_conf.pm
@@ -59,7 +59,8 @@ sub default_options {
     datacheck_groups   => [],
     datacheck_types    => [],
     registry_file      => undef,
-    old_server_uri     => undef,
+    server_uri         => [],
+    old_server_uri     => [],
     data_file_path     => undef,
 
     failures_fatal => 0,
@@ -169,6 +170,7 @@ sub pipeline_analyses {
                               datacheck_groups   => $self->o('datacheck_groups'),
                               datacheck_types    => $self->o('datacheck_types'),
                               registry_file      => $self->o('registry_file'),
+                              server_uri         => $self->o('server_uri'),
                               old_server_uri     => $self->o('old_server_uri'),
                               data_file_path     => $self->o('data_file_path'),
 

--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/DbDataChecks_conf.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/DbDataChecks_conf.pm
@@ -59,8 +59,8 @@ sub default_options {
     datacheck_groups   => [],
     datacheck_types    => [],
     registry_file      => undef,
-    server_uri         => [],
-    old_server_uri     => [],
+    server_uri         => undef,
+    old_server_uri     => undef,
     data_file_path     => undef,
 
     failures_fatal => 0,

--- a/scripts/run_datachecks.pl
+++ b/scripts/run_datachecks.pl
@@ -51,6 +51,9 @@ is needed so that they know _where_ to look.
 
 As an alternative to providing a registry file (see above), a URI can be
 given, e.g. mysql://a_user@some_host:port_number/
+If given in addition to a registry file, the server_uri takes precedence.
+Multiple uris can be given as separate -s[erver_uri] parameters, 
+or as a single comma-separated string.
 
 =item B<-ol[d_server_uri]> <old_server_uri>
 
@@ -58,6 +61,8 @@ For comparisons with an analogous database from a previous release it is
 not possible to load them via the registry_file.
 A URI must be specified with the location of the previous release's databases,
 e.g. mysql://a_user@some_host:port_number/[old_db_name|old_release_number]
+Multiple uris can be given as separate -ol[d_server_uri] parameters, 
+or as a single comma-separated string.
 
 =item B<-data_f[ile_path]> <data_file_path>
 
@@ -147,7 +152,7 @@ use Pod::Usage;
 my (
     $help,
     $host, $port, $user, $pass, $dbname, $dbtype,
-    $registry_file, $server_uri, $old_server_uri, $data_file_path, $config_file,
+    $registry_file, @server_uri, @old_server_uri, $data_file_path, $config_file,
     @names, @patterns, @groups, @datacheck_types,
     $datacheck_dir, $index_file, $history_file, $output_file,
 );
@@ -161,8 +166,8 @@ GetOptions(
   "dbname=s",          \$dbname,
   "dbtype=s",          \$dbtype,
   "registry_file=s",   \$registry_file,
-  "server_uri=s",      \$server_uri,
-  "old_server_uri=s",  \$old_server_uri,
+  "server_uri=s",      \@server_uri,
+  "old_server_uri=s",  \@old_server_uri,
   "data_file_path=s",  \$data_file_path,
   "config_file=s",     \$config_file,
   "names|n:s",         \@names,
@@ -245,6 +250,8 @@ if (! defined $datacheck_dir && defined $index_file) {
 @patterns = map { split(/[,\s]+/, $_) } @patterns if scalar @patterns;
 @groups = map { split(/[,\s]+/, $_) } @groups if scalar @groups;
 @datacheck_types = map { split(/[,\s]+/, $_) } @datacheck_types if scalar @datacheck_types;
+@server_uri = map { split(/[,\s]+/, $_) } @server_uri if scalar @server_uri;
+@old_server_uri = map { split(/[,\s]+/, $_) } @old_server_uri if scalar @old_server_uri;
 
 my %manager_params;
 $manager_params{names}           = \@names           if scalar @names;
@@ -258,11 +265,11 @@ $manager_params{output_file}     = $output_file      if defined $output_file;
 $manager_params{config_file}     = $config_file      if defined $config_file;
 
 my %datacheck_params;
-$datacheck_params{dba}            = $dba            if defined $dba;
-$datacheck_params{registry_file}  = $registry_file  if defined $registry_file;
-$datacheck_params{server_uri}     = $server_uri     if defined $server_uri;
-$datacheck_params{old_server_uri} = $old_server_uri if defined $old_server_uri;
-$datacheck_params{data_file_path} = $data_file_path if defined $data_file_path;
+$datacheck_params{dba}            = $dba             if defined $dba;
+$datacheck_params{registry_file}  = $registry_file   if defined $registry_file;
+$datacheck_params{server_uri}     = \@server_uri     if scalar @server_uri;
+$datacheck_params{old_server_uri} = \@old_server_uri if scalar @old_server_uri;
+$datacheck_params{data_file_path} = $data_file_path  if defined $data_file_path;
 
 my $manager = Bio::EnsEMBL::DataCheck::Manager->new(%manager_params);
 

--- a/scripts/run_pipeline.pl
+++ b/scripts/run_pipeline.pl
@@ -379,8 +379,8 @@ my %input_id = (
   registry_file => $registry_file,
   timestamp     => localtime->cdate,
 );
-$input_id{server_uri} = $server_uri if scalar $server_uri;
-$input_id{old_server_uri} = $old_server_uri if scalar $old_server_uri;
+$input_id{server_uri} = \@server_uri if scalar @server_uri;
+$input_id{old_server_uri} = \@old_server_uri if scalar @old_server_uri;
 $input_id{data_file_path} = $data_file_path if defined $data_file_path;
 $input_id{db_type} = $dbtype if defined $dbtype;
 $input_id{species} = \@species if scalar @species;

--- a/scripts/run_pipeline.pl
+++ b/scripts/run_pipeline.pl
@@ -49,12 +49,22 @@ is required in order to locate those databases. If the databases being
 checked require connections to other databases, those also need to be
 in the registry (e.g. funcgen datachecks need access to core databases).
 
+=item B<-s[erver_uri]> <server_uri>
+
+In addition to a registry file (see above), a URI can be given,
+e.g. mysql://a_user@some_host:port_number/
+This either augments or overrides databases loaded by the registry file.
+Multiple uris can be given as separate -s[erver_uri] parameters, 
+or as a single comma-separated string.
+
 =item B<-old_server_uri> <old_server_uri>
 
 For comparisons with an analogous database from a previous release it is
 not possible to load them via the registry_file.
 A URI must be specified with the location of the previous release's databases,
 e.g. mysql://a_user@some_host:port_number/[old_db_name|old_release_number]
+Multiple uris can be given as separate -ol[d_server_uri] parameters, 
+or as a single comma-separated string.
 
 =item B<-data_f[ile_path]> <data_file_path>
 
@@ -224,7 +234,8 @@ use Time::Piece;
 my (
     $help,
     $host, $port, $user, $pass, $dbname, $drop_db,
-    $registry_file, $old_server_uri, $data_file_path, $config_file, $dbtype,
+    $registry_file, @server_uri, @old_server_uri, $data_file_path,
+    $config_file, $dbtype,
     @species, @taxons, @divisions, $run_all, @antispecies, @antitaxons, @dbnames,
     @names, @patterns, @groups, @datacheck_types,
     $datacheck_dir, $index_file, $history_file, $output_dir, $json_passed,
@@ -243,7 +254,8 @@ GetOptions(
   "drop_pipeline_db",                \$drop_db,
 
   "registry_file=s",  \$registry_file,
-  "old_server_uri:s", \$old_server_uri,
+  "server_uri:s",     \@server_uri,
+  "old_server_uri:s", \@old_server_uri,
   "data_file_path:s", \$data_file_path,
   "config_file:s",    \$config_file,
   "dbtype|db_type:s", \$dbtype,
@@ -328,6 +340,8 @@ if (! defined $datacheck_dir && defined $index_file) {
 @patterns = map { split(/[,\s]+/, $_) } @patterns if scalar @patterns;
 @groups = map { split(/[,\s]+/, $_) } @groups if scalar @groups;
 @datacheck_types = map { split(/[,\s]+/, $_) } @datacheck_types if scalar @datacheck_types;
+@server_uri = map { split(/[,\s]+/, $_) } @server_uri if scalar @server_uri;
+@old_server_uri = map { split(/[,\s]+/, $_) } @old_server_uri if scalar @old_server_uri;
 
 # Only initialise the hive pipeline db if we have to.
 my $initialise = 0;
@@ -365,7 +379,8 @@ my %input_id = (
   registry_file => $registry_file,
   timestamp     => localtime->cdate,
 );
-$input_id{old_server_uri} = $old_server_uri if defined $old_server_uri;
+$input_id{server_uri} = $server_uri if scalar $server_uri;
+$input_id{old_server_uri} = $old_server_uri if scalar $old_server_uri;
 $input_id{data_file_path} = $data_file_path if defined $data_file_path;
 $input_id{db_type} = $dbtype if defined $dbtype;
 $input_id{species} = \@species if scalar @species;

--- a/t/DbCheck.t
+++ b/t/DbCheck.t
@@ -372,7 +372,7 @@ subtest 'Registry instantiation', sub {
 
   $check = TestChecks::DbCheck_1->new(
     dba        => $dba,
-    server_uri => $server_uri,
+    server_uri => [$server_uri],
   );
 
   # The registry object is a bit weird, the return value is a string,
@@ -383,7 +383,7 @@ subtest 'Registry instantiation', sub {
 
   $check = TestChecks::DbCheck_1->new(
     dba        => $dba,
-    server_uri => $server_uri.$dba->dbc->dbname,
+    server_uri => [$server_uri.$dba->dbc->dbname],
   );
 
   throws_ok(
@@ -392,13 +392,11 @@ subtest 'Registry instantiation', sub {
     'DbCheck->registry fails if uri has dbname but no species attrib');
 
   $server_uri .=
-	$dba->dbc->dbname.
-	'?species='.$dba->species.
-	';group='.$dba->group;
+    $dba->dbc->dbname.'?species='.$dba->species.';group='.$dba->group;
 
   $check = TestChecks::DbCheck_1->new(
     dba        => $dba,
-    server_uri => $server_uri,
+    server_uri => [$server_uri],
   );
 
   is($check->registry, 'Bio::EnsEMBL::Registry', 'registry attribute set via server_uri with dbname');
@@ -409,7 +407,7 @@ subtest 'Registry instantiation', sub {
   # and that it has precedence over server_uri.
   $check = TestChecks::DbCheck_1->new(
     dba           => $dba,
-    server_uri    => 'unconnectable rubbish',
+    server_uri    => ['unconnectable rubbish'],
     registry_file => $registry_file->stringify,
   );
 
@@ -430,7 +428,7 @@ subtest 'Fetch DBA from registry', sub {
 
   my $check = TestChecks::DbCheck_1->new(
     dba        => $dba,
-    server_uri => $server_uri,
+    server_uri => [$server_uri],
   );
 
   my $dba2 = $check->get_dba();

--- a/t/DbCheck_noncore.t
+++ b/t/DbCheck_noncore.t
@@ -69,7 +69,7 @@ subtest 'Fetch DNA DBA from registry', sub {
 
   my $check = TestChecks::DbCheck_1->new(
     dba        => $dba,
-    server_uri => $server_uri,
+    server_uri => [$server_uri],
   );
 
   # The test databases are added to the registry via MultiTestDB; but
@@ -89,7 +89,7 @@ subtest 'Fetch DNA DBA from registry', sub {
   $server_uri .= $dba->dbc->dbname."?species=$species;group=variation";
   $check = TestChecks::DbCheck_1->new(
     dba        => $dba,
-    server_uri => $server_uri,
+    server_uri => [$server_uri],
   );
 };
 

--- a/t/DbCheck_noncore.t
+++ b/t/DbCheck_noncore.t
@@ -278,7 +278,7 @@ subtest '(Fail to) fetch core-like db from server_uri', sub {
   my $server_uri = "$driver://$user:$pass\@$host:$port/";
 
   my $check = TestChecks::DbCheck_1->new(
-    dba           => $variation_dba,
+    dba           => $core_dba,
     registry_file => $registry_file->stringify,
     server_uri    => [$server_uri],
   );
@@ -287,8 +287,8 @@ subtest '(Fail to) fetch core-like db from server_uri', sub {
   # we can determine the name of the ancillary db.
   $check->load_registry();
   my $reg = $check->load_registry();
+  $reg->add_DBAdaptor($species, 'core', $core_dba);
   $reg->add_DBAdaptor('multi', 'metadata', $metadata_dba);
-  $reg->add_DBAdaptor($species, 'variation', $variation_dba);
 
   my $of_dba = $check->get_dba($species, 'otherfeatures');
 

--- a/t/DbCheck_old.t
+++ b/t/DbCheck_old.t
@@ -55,8 +55,8 @@ my $test_db_dir = $FindBin::Bin;
 
       my $check = TestChecks::DbCheck_1->new(
         dba            => $dba,
-        server_uri     => $server_uri,
-        old_server_uri => $server_uri.$dba->dbc->dbname,
+        server_uri     => [$server_uri],
+        old_server_uri => [$server_uri.$dba->dbc->dbname],
       );
       my $old_dba = $check->get_old_dba();
       isa_ok($old_dba, $dba_type, 'Return value of "get_old_dba"');
@@ -64,7 +64,7 @@ my $test_db_dir = $FindBin::Bin;
 
       $check = TestChecks::DbCheck_1->new(
         dba        => $dba,
-        server_uri => $server_uri,
+        server_uri => [$server_uri],
       );
       throws_ok(
         sub { $check->get_old_dba },
@@ -73,8 +73,8 @@ my $test_db_dir = $FindBin::Bin;
 
       $check = TestChecks::DbCheck_1->new(
         dba            => $dba,
-        server_uri     => $server_uri,
-        old_server_uri => $server_uri.'rhubarb_and_custard',
+        server_uri     => [$server_uri],
+        old_server_uri => [$server_uri.'rhubarb_and_custard'],
       );
       throws_ok(
         sub { $check->get_old_dba },
@@ -83,8 +83,8 @@ my $test_db_dir = $FindBin::Bin;
 
       $check = TestChecks::DbCheck_1->new(
         dba            => $dba,
-        server_uri     => $server_uri,
-        old_server_uri => $server_uri,
+        server_uri     => [$server_uri],
+        old_server_uri => [$server_uri],
       );
       $check->load_registry();
       throws_ok(
@@ -94,8 +94,8 @@ my $test_db_dir = $FindBin::Bin;
 
       $check = TestChecks::DbCheck_1->new(
         dba            => $dba,
-        server_uri     => $server_uri,
-        old_server_uri => $server_uri.'95',
+        server_uri     => [$server_uri],
+        old_server_uri => [$server_uri.'95'],
       );
       $check->load_registry();
       $check->registry->add_DBAdaptor('multi', 'metadata', $metadata_dba);
@@ -125,8 +125,8 @@ my $test_db_dir = $FindBin::Bin;
 
     my $check = TestChecks::DbCheck_1->new(
       dba            => $dba,
-      server_uri     => $server_uri,
-      old_server_uri => $server_uri.$dba->dbc->dbname,
+      server_uri     => [$server_uri],
+      old_server_uri => [$server_uri.$dba->dbc->dbname],
     );
     my $old_dba = $check->get_old_dba();
     isa_ok($old_dba, $dba_type, 'Return value of "get_old_dba"');
@@ -134,8 +134,8 @@ my $test_db_dir = $FindBin::Bin;
 
     $check = TestChecks::DbCheck_1->new(
       dba            => $dba,
-      server_uri     => $server_uri,
-      old_server_uri => $server_uri.'95',
+      server_uri     => [$server_uri],
+      old_server_uri => [$server_uri.'95'],
     );
     $check->load_registry();
     $check->registry->add_DBAdaptor('multi', 'metadata', $metadata_dba);
@@ -165,8 +165,8 @@ my $test_db_dir = $FindBin::Bin;
 
     my $check = TestChecks::DbCheck_1->new(
       dba            => $dba,
-      server_uri     => $server_uri,
-      old_server_uri => $server_uri.$dba->dbc->dbname,
+      server_uri     => [$server_uri],
+      old_server_uri => [$server_uri.$dba->dbc->dbname],
     );
     my $old_dba = $check->get_old_dba();
     isa_ok($old_dba, $dba_type, 'Return value of "get_old_dba"');
@@ -174,8 +174,8 @@ my $test_db_dir = $FindBin::Bin;
 
     $check = TestChecks::DbCheck_1->new(
       dba            => $dba,
-      server_uri     => $server_uri,
-      old_server_uri => $server_uri.'95',
+      server_uri     => [$server_uri],
+      old_server_uri => [$server_uri.'95'],
     );
     my $mca = $dba->get_adaptor("MetaContainer");
     my $uri = parse_uri($server_uri.'95');

--- a/t/Manager.t
+++ b/t/Manager.t
@@ -98,14 +98,16 @@ subtest 'Config file', sub {
 
   my %params = (
     registry_file  => 'registry_file_from_param',
+    server_uri     => 'server_uri_from_param',
     old_server_uri => 'old_server_uri_from_param',
   );
 
   my %loaded = $manager->load_config(%params);
 
   is($loaded{data_file_path}, 'data_file_path_from_config', 'Parameter loaded from config file');
-  is($loaded{old_server_uri}, 'old_server_uri_from_param', 'Explicit parameter loaded');
   is($loaded{registry_file},  'registry_file_from_param', 'Explicit parameters overwrite config file');
+  is($loaded{server_uri},     'server_uri_from_param', 'Explicit parameter loaded');
+  is($loaded{old_server_uri}, 'old_server_uri_from_param', 'Explicit parameter loaded');
   is($manager->history_file,  'history_file_from_config', 'File parameter loaded from config file');
   is($manager->output_file,   'output_file_from_param', 'Explicit file parameter loaded');
 };

--- a/t/RunDataChecks.t
+++ b/t/RunDataChecks.t
@@ -177,16 +177,16 @@ foreach my $species (@species) {
 
   subtest 'Parameter instantiation: DbCheck non-DBA parameters', sub {
     $obj->param('registry_file', '/path/to/registry');
-    $obj->param('server_uri', 'mysql_uri_1');
-    $obj->param('old_server_uri', 'mysql_uri_2');
+    $obj->param('server_uri', ['mysql_uri_1']);
+    $obj->param('old_server_uri', ['mysql_uri_2']);
     $obj->param('data_file_path', '/path/to/data_files');
 
     $obj->fetch_input();
     my $datacheck_params = $obj->param('datacheck_params');
 
     is($$datacheck_params{registry_file}, '/path/to/registry', 'Registry file is set correctly');
-    is($$datacheck_params{server_uri}, 'mysql_uri_1', 'Server URI is set correctly');
-    is($$datacheck_params{old_server_uri}, 'mysql_uri_2', 'Old server URI is set correctly');
+    is($$datacheck_params{server_uri}->[0], 'mysql_uri_1', 'Server URI is set correctly');
+    is($$datacheck_params{old_server_uri}->[0], 'mysql_uri_2', 'Old server URI is set correctly');
     is($$datacheck_params{data_file_path}, '/path/to/data_files', 'Data file path is set correctly');
 
     $obj->param('registry_file', undef);


### PR DESCRIPTION
Make server_uri and old_server_uri multi-valued.

For old_server_uri, we simply loop through the list, looking for the old version of the relevant db, stopping when we find it.

For server_uri, it remains as an alternative to specifying a registry_file, and in this case we loop through all values, adding them to the registry. There is some additional functionality, however - if both registry_file and server_uri are given, then only the registry is loaded by default. But, if an ancillary database (e.g. a core db needed for a corelike datacheck) is required, we first loop through the server_uri values, stopping when we find it; if not found there, we look in the registry. This functionality allows us to have a generic all-purpose registry file, which we can override for specific use cases, for example: genebuild create an rnaseq db, and test it against a copy of the core db on the same server (they only need to specify a registry that covers that server); at handover, we add the target server at the front of the server_uri list, so that testing can be done aginst the core db there (and ignoring the genebuild core db since it may be a slightly different version).

See https://www.ebi.ac.uk/panda/jira/browse/ENSPROD-6710 for more details on the use cases.
