### PR TITLE
datacheck added to check meta key species.common name is simillar acr…

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
@@ -23,7 +23,6 @@ use strict;
 
 use Moose;
 use Test::More;
-use Data::Dumper;
 
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
@@ -74,4 +73,3 @@ sub CheckCommonName {
 }
 
 1;
-

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
@@ -70,7 +70,7 @@ sub check_common_name {
         	my $mca = $strain_dba->get_adaptor("MetaContainer");
         	my $dbname =  $genome->dbname();
                 my $common_name = $mca->single_value_by_key('species.common_name') ? $mca->single_value_by_key('species.common_name')  : "No meta_key species.common_name in $dbname";
-                my $desc =  "Meta key species.common_name is similar in DB $dbname for strain group $strain_group";
+                my $desc =  "Meta key species.common_name is the same in DB $dbname for strain group $strain_group";
                 is($species_common_name, $common_name, $desc)
        } 
   }    
@@ -79,4 +79,3 @@ sub check_common_name {
 
 
 1;
-

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
@@ -28,7 +28,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
   NAME        => 'SpeciesCommonName',
-  DESCRIPTION => 'Meta key species.common_name should be same for species form a group of strains or breed',
+  DESCRIPTION => 'Meta key species.common_name should be same for species from a group of strains or breeds',
   GROUPS      => ['core', 'meta'],
   DB_TYPES    => ['core'],
   TABLES      => ['meta'],

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
@@ -69,7 +69,7 @@ sub check_common_name {
 
         	my $mca = $strain_dba->get_adaptor("MetaContainer");
         	my $dbname =  $genome->dbname();
-                my $common_name = $mca->single_value_by_key('species.common_name') ? $mca->single_value_by_key('species.common_name')  : "No meta_key species.common_name in $dbname";
+                my $common_name = $mca->single_value_by_key('species.common_name');
                 my $desc =  "Meta key species.common_name is the same in DB $dbname for strain group $strain_group";
                 is($species_common_name, $common_name, $desc)
        } 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
@@ -53,7 +53,7 @@ sub tests {
 
 sub CheckCommonName {
   my ($self, $division, $reference_species_common_name, $strain_group) = @_;
-  my $gdba = $self->registry->get_DBAdaptor("multi", "metadata")->get_GenomeInfoAdaptor();
+  my $gdba = $self->get_dba("multi", "metadata")->get_GenomeInfoAdaptor();
   my %unique_common_name;
   for my $genome (@{$gdba->fetch_all_by_division($division)}) {
         if($genome->strain() and $genome->reference() and $genome->reference() eq $strain_group){

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
@@ -58,7 +58,7 @@ sub check_common_name {
 
   my ($self, $division, $species_common_name,  $strain_group) = @_;
   my $gdba = $self->get_dba("multi", "metadata")->get_GenomeInfoAdaptor();
-  my %unique_common_name;
+
   for my $genome (@{$gdba->fetch_all_by_division($division)}) {
         if($genome->reference() and $genome->reference() eq $strain_group){
         	my $strain_name = $genome->name;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
@@ -1,0 +1,77 @@
+=head1 LICENSE
+
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::SpeciesCommonName;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Data::Dumper;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'SpeciesCommonName',
+  DESCRIPTION => 'Meta key species.common_name should be same for group of strains or breed',
+  GROUPS      => ['core', 'meta'],
+  DB_TYPES    => ['core'],
+  TABLES      => ['meta'],
+};
+
+sub tests {
+  my ($self) = @_;
+  my $mca = $self->dba->get_adaptor("MetaContainer");
+  my $strain = $mca->single_value_by_key('species.strain');
+  my $strain_group = $mca->single_value_by_key('species.strain_group'); 
+  my $reference_species_common_name = $mca->single_value_by_key('species.common_name');
+  my $division = $mca->single_value_by_key('species.division');
+  if ( $strain && $strain_group ) {
+        
+	$self->CheckCommonName($division, $reference_species_common_name, $strain_group);
+  }
+  else{
+	skip('No Strains or Breeds for Species');
+  }
+
+}
+
+sub CheckCommonName {
+  my ($self, $division, $reference_species_common_name, $strain_group) = @_;
+  my $gdba = $self->registry->get_DBAdaptor("multi", "metadata")->get_GenomeInfoAdaptor();
+  my %unique_common_name;
+  for my $genome (@{$gdba->fetch_all_by_division($division)}) {
+        if($genome->strain() and $genome->reference() and $genome->reference() eq $strain_group){
+        	my $mca = $self->registry->get_adaptor( $genome->name(), 'Core', 'MetaContainer' );
+                my $common_name = $mca->single_value_by_key('species.common_name');
+        	my $dbname =  $genome->dbname();
+                push(@{$unique_common_name{$common_name}} , $dbname); 
+       } 
+  }    
+
+  my $desc='';
+  for my $common_name (keys %unique_common_name){
+  	$desc.= join("\n$common_name: ", @{$unique_common_name{$common_name}});
+  }
+  $desc = " Meta key species.common_name is similar in all DBs for strain group $strain_group \n". $desc   ;
+  is(keys %unique_common_name ,  1 , $desc) ;
+}
+
+1;
+

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
@@ -43,8 +43,7 @@ sub tests {
   if ($species_common_name eq ''){
 	fail("Meta key species.common_name is empty/not set ");
   }
-  elsif ( $strain_group ) {
-        
+  elsif ( $strain_group ) {   
 	$self->check_common_name($division, $species_common_name, $strain_group);
   }
   else{
@@ -54,7 +53,7 @@ sub tests {
 }
 
 sub check_common_name {
-  #This Function checking for common names across all the dbs for specific stain group in a division,
+  #This Function checking for common names across all the dbs for specific strain group in a division,
   #Which deviating from the other Datachecks.
 
   my ($self, $division, $species_common_name,  $strain_group) = @_;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
@@ -57,7 +57,13 @@ sub CheckCommonName {
   my %unique_common_name;
   for my $genome (@{$gdba->fetch_all_by_division($division)}) {
         if($genome->strain() and $genome->reference() and $genome->reference() eq $strain_group){
-        	my $mca = $self->registry->get_adaptor( $genome->name(), 'Core', 'MetaContainer' );
+        	my $strain_name = $genome->name;
+        	my $strain_dba = $self->get_dba($strain_name, 'core');
+        	my $desc_strain_dba = "Core database for $strain_name found";
+        	my $pass = ok(defined $strain_dba, $desc_strain_dba);
+        	next unless $pass;
+
+        	my $mca = $strain_dba->get_adaptor("MetaContainer");
         	my $dbname =  $genome->dbname();
                 my $common_name = $mca->single_value_by_key('species.common_name') ? $mca->single_value_by_key('species.common_name')  : "No meta_key species.common_name in $dbname";
                 push(@{$unique_common_name{$common_name}} , $dbname); 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2018-2020] EMBL-European Bioinformatics Institute
+Copyright [2018-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the 'License');
 you may not use this file except in compliance with the License.
@@ -59,18 +59,18 @@ sub CheckCommonName {
   for my $genome (@{$gdba->fetch_all_by_division($division)}) {
         if($genome->strain() and $genome->reference() and $genome->reference() eq $strain_group){
         	my $mca = $self->registry->get_adaptor( $genome->name(), 'Core', 'MetaContainer' );
-                my $common_name = $mca->single_value_by_key('species.common_name');
         	my $dbname =  $genome->dbname();
+                my $common_name = $mca->single_value_by_key('species.common_name') ? $mca->single_value_by_key('species.common_name')  : "No meta_key species.common_name in $dbname";
                 push(@{$unique_common_name{$common_name}} , $dbname); 
        } 
   }    
 
-  my $desc='';
+  my $report='';
   for my $common_name (keys %unique_common_name){
-  	$desc.= join("\n$common_name: ", @{$unique_common_name{$common_name}});
+  	$report.= join("\n$common_name: ", @{$unique_common_name{$common_name}});
   }
-  $desc = " Meta key species.common_name is similar in all DBs for strain group $strain_group \n". $desc   ;
-  is(keys %unique_common_name ,  1 , $desc) ;
+  my $desc = " Meta key species.common_name is similar in all DBs for strain group $strain_group \n". $report;
+  is(keys %unique_common_name ,  1 , $desc) or diag('Meta key species.common name is  not similar in dbs : ' . $report);
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2232,7 +2232,7 @@
       "namCommonName" : " ",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SpeciesCommonName"
    },
-   "speciesNameUnique" : {
+   "SpeciesNameUnique" : {
       "datacheck_type" : "critical",
       "description" : "Species production_name and alias are unique across all databases in the registry",
       "groups" : [

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2221,7 +2221,18 @@
       "name" : "SourceAdvisory",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SourceAdvisory"
    },
-   "SpeciesNameUnique" : {
+   "SpeciesCommonName":{
+      "datacheck_type" : "critical",
+      "description" : "Meta key species.common_name should be same for species from a group of strains or breed",
+      "groups" : [
+         "core",
+         "meta"
+      ],
+      "name" : "SpeciesCommonName",
+      "namCommonName" : " ",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SpeciesCommonName"
+   },
+   "speciesNameUnique" : {
       "datacheck_type" : "critical",
       "description" : "Species production_name and alias are unique across all databases in the registry",
       "groups" : [

--- a/scripts/create_datacheck.pl
+++ b/scripts/create_datacheck.pl
@@ -244,7 +244,7 @@ sub copyright {
 return <<'END_COPYRIGHT';
 =head1 LICENSE
 
-Copyright [2018-2020] EMBL-European Bioinformatics Institute
+Copyright [2018-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the 'License');
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
All V species that form a group of strains or breeds need to have the same value for species.common_name; if they don't then they are not grouped together in Search. If the metadata DB knows which species are grouped in this way, we could have a DC to make sure the species.common_names match

Test case: 
perl scripts/run_datachecks.pl  $(${ST1} details script)   -config_file  datachecks/config/${ST1}.json -name SpeciesCommonName  -dbname mus_musculus_lpj_core_104_1  -r datachecks/registry/sta-1.pm -history_file history.json
