### PR TITLE
Check the position of ancestral sequences in the genomic align trees

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignTreeTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignTreeTable.pm
@@ -105,6 +105,30 @@ sub tests {
 
   }
 
+  my $sql_4 = qq/
+    SELECT COUNT(*)
+      FROM genomic_align_tree gat
+        JOIN genomic_align ga USING (node_id)
+        JOIN dnafrag df USING (dnafrag_id)
+      WHERE gat.right_index-gat.left_index!=1
+        AND df.coord_system_name!='ancestralsegment'
+    /;
+
+  my $desc_4 = "All internal nodes are ancestral sequences";
+  is_rows_zero($dbc, $sql_4, $desc_4);
+
+  my $sql_5 = qq/
+    SELECT COUNT(*)
+      FROM genomic_align_tree gat
+        JOIN genomic_align ga USING (node_id)
+        JOIN dnafrag df USING (dnafrag_id)
+      WHERE gat.right_index-gat.left_index=1
+        AND df.coord_system_name='ancestralsegment';
+  /;
+
+  my $desc_5 = "All leaves are from extant species";
+  is_rows_zero($dbc, $sql_5, $desc_5);
+
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignTreeTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignTreeTable.pm
@@ -110,11 +110,11 @@ sub tests {
       FROM genomic_align_tree gat
         JOIN genomic_align ga USING (node_id)
         JOIN dnafrag df USING (dnafrag_id)
-      WHERE gat.right_index-gat.left_index!=1
-        AND df.coord_system_name!='ancestralsegment'
+      WHERE gat.right_index - gat.left_index != 1
+        AND df.coord_system_name != 'ancestralsegment'
     /;
 
-  my $desc_4 = "All internal nodes are ancestral sequences";
+  my $desc_4 = "All internal nodes link to ancestral sequences";
   is_rows_zero($dbc, $sql_4, $desc_4);
 
   my $sql_5 = qq/
@@ -122,14 +122,13 @@ sub tests {
       FROM genomic_align_tree gat
         JOIN genomic_align ga USING (node_id)
         JOIN dnafrag df USING (dnafrag_id)
-      WHERE gat.right_index-gat.left_index=1
-        AND df.coord_system_name='ancestralsegment';
+      WHERE gat.right_index - gat.left_index = 1
+        AND df.coord_system_name = 'ancestralsegment'
   /;
 
-  my $desc_5 = "All leaves are from extant species";
+  my $desc_5 = "All leaves are from current genome sequences";
   is_rows_zero($dbc, $sql_5, $desc_5);
 
 }
 
 1;
-


### PR DESCRIPTION
## Description

Sometimes some leaves in `genomic_align_tree` were ancestral sequences.

The new code checks if all internal nodes are ancestral sequences and all leaves from extant species.

**Related JIRA tickets:**
- ENSCOMPARASW-4084

## Overview of changes

#### Change 1
- `$sql_4` fetches all internal nodes which are not ancestral sequences -> should get 0

#### Change 2
- `$sql_5` fetches all leaves which are ancestral sequences -> should get 0

## Testing
Made a copy of `ensembl_compara_plants_51_104` –` ivana_copy_whole_compara_plants_51_104` on `mysql-ens-compara-prod-1` – and added 1 internal node which is not an ancestral sequence and 1 leaf which is an ancestral sequence. The datachecks failed.

```
INSERT INTO dnafrag VALUES (1, 10, 'TestLeaf', 4, 'ancestralsegment', 'NUC', 1, 5);
INSERT INTO dnafrag VALUES (2, 11, 'TestInternal', 5, 'reftig', 'NUC', 1, 10); 
INSERT INTO genomic_align VALUES (1, 2, 3, 1, 1, 8, 1, '11M', 1, 1);
INSERT INTO genomic_align VALUES (4, 5, 6, 2, 1, 7, 1, '8M', 1, 2);
INSERT INTO genomic_align_tree VALUES (1, 2, 3, 1, 2, 4, 5, 0.6);
INSERT INTO genomic_align_tree VALUES (2, 6, 7, 8, 12, 13, 14, 0.15);
```