### PR TITLE
Adding repeatdetector as alternative to repeatmask

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
@@ -64,7 +64,7 @@ sub tests {
       is_rows_nonzero($self->dba, $sql_1, $desc_1);
     }
 
-    my $desc_2 = 'Repeat features exist (repeatmask)';
+    my $desc_2 = 'Repeat features exist (repeatmask or repeatdetector)';
     my $sql_2  = qq/
       SELECT COUNT(*) FROM
         repeat_feature INNER JOIN

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
@@ -70,7 +70,8 @@ sub tests {
         repeat_feature INNER JOIN
         analysis USING (analysis_id)
       WHERE
-        logic_name LIKE 'repeatmask%'
+        logic_name LIKE 'repeatmask%' OR
+	logic_name LIKE 'repeatdetector%' 
     /;
     is_rows_nonzero($self->dba, $sql_2, $desc_2);
   }


### PR DESCRIPTION
Following discussion with James, adding repeatdetector as alternative to repeatmask in the analysis/feature check.
Tested.