### PR TITLE
Bugfix for ControlledTablesCompara DC

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
@@ -197,7 +197,7 @@ sub taxonomy_tables {
   my ($self, $helper, $tables) = @_;
   
   my $desc_1 = "Taxonomy database found";
-  my $taxonomy_dba = $self->get_dba('multi', 'taxonomy') || $self->get_dba('ncbi_taxonomy', 'taxonomy');
+  my $taxonomy_dba = ($self->registry->alias_exists('multi')) ? $self->get_dba('multi', 'taxonomy') : $self->get_dba('ncbi_taxonomy', 'taxonomy');
 
   if (ok(defined $taxonomy_dba, $desc_1)) {
     my $taxonomy_helper = $taxonomy_dba->dbc->sql_helper;


### PR DESCRIPTION
When the registry includes the method `Bio::EnsEMBL::Registry->load_registry_from_url()`, several aliases are loaded by default (including `multi`, it seems). If only specific cores are loaded using `Bio::EnsEMBL::DBSQL::DBAdaptor->new()`, this alias is not added, making the DC fail. This is because `get_DBAdaptor()`, called from `get_dba()`, throws an error when the species/alias passed as an argument does not exist. Checking if it is there first fixes the issue, preserving the previous behaviour.

_Note:_ This has not been spotted earlier, neither is relevant for production e105, because it has been spotted doing a new "usage" of Compara's registry for a new Genebuild project (see [pan_genome registry](https://github.com/Ensembl/ensembl-compara/blob/feature/pan_genome_cmp/conf/pan_genome/production_reg_conf.pl)).