### PR TITLE
Use registry for metadata/production/taxonomy dbs.

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
@@ -326,12 +326,15 @@ sub get_dba {
 
   $self->load_registry();
 
-  # If we have a server_uri and registry, we want to overwrite anything
-  # loaded in the registry with the server_uri.
+  # If we have a server_uri and registry, we want to overwrite
+  # anything loaded in the registry with the server_uri,
+  # unless it's a metadata/production/taxonomy db, which we
+  # always want to come from a registry file.
   if (
     defined $self->registry_file &&
     defined $self->server_uri &&
-    scalar( @{$self->server_uri} )
+    scalar( @{$self->server_uri} ) &&
+    $group !~ /^(metadata|production|taxonomy)$/
   ) {
     SERVER_URI: foreach my $server_uri ( @{$self->server_uri} ) {
       my $uri = parse_uri($server_uri);


### PR DESCRIPTION
In order to force the use of the most up-to-date centrally-managed databases (ensembl_metadata, ensembl-production, ncbi_taxonomy), don't allow those to be overridden by a server_uri parameter.