### PR TITLE
Set SpeciesCommonName datacheck to be advisory.

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
@@ -27,11 +27,12 @@ use Test::More;
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
-  NAME        => 'SpeciesCommonName',
-  DESCRIPTION => 'Meta key species.common_name should be same for species from a group of strains or breeds',
-  GROUPS      => ['core', 'meta'],
-  DB_TYPES    => ['core'],
-  TABLES      => ['meta'],
+  NAME           => 'SpeciesCommonName',
+  DESCRIPTION    => 'Meta key species.common_name should be same for species from a group of strains or breeds',
+  GROUPS         => ['core', 'meta'],
+  DATACHECK_TYPE => 'advisory',
+  DB_TYPES       => ['core'],
+  TABLES         => ['meta'],
 };
 
 sub skip_tests {

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2266,7 +2266,7 @@
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SourceAdvisory"
    },
    "SpeciesCommonName" : {
-      "datacheck_type" : "critical",
+      "datacheck_type" : "advisory",
       "description" : "Meta key species.common_name should be same for species from a group of strains or breeds",
       "groups" : [
          "core",


### PR DESCRIPTION
The configuration requirements for this style of datacheck turn out to be too onerous - it is working across multiple core databases, and being able to locate all the relevant dbs is a pain. This requires further thought as to how it can best be integrated into our release processes, but for now, set it as advisory, so that it is not a blocker.