### PR TITLE
ControlledTablesCompara taxonomy compatibility with compara pipelines

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
@@ -197,7 +197,7 @@ sub taxonomy_tables {
   my ($self, $helper, $tables) = @_;
   
   my $desc_1 = "Taxonomy database found";
-  my $taxonomy_dba = ($self->registry->alias_exists('multi')) ? $self->get_dba('multi', 'taxonomy') : $self->get_dba('ncbi_taxonomy', 'taxonomy');
+  my $taxonomy_dba = $self->get_dba('multi', 'taxonomy') ? $self->get_dba('multi', 'taxonomy') : $self->get_dba('ncbi_taxonomy', 'taxonomy');
 
   if (ok(defined $taxonomy_dba, $desc_1)) {
     my $taxonomy_helper = $taxonomy_dba->dbc->sql_helper;


### PR DESCRIPTION
At a loss as to why this works and the other does not. For whatever reason, the previous way was incompatible with use in pipeline via `RunDataChecks.pm` and compara style registry, the taxonomy was undetectable. This has now been tested in both compara pipeline and manual datacheck commands, and appears to work. Needs to be merged ASAP to prevent blocking compara production pipelines.
[ENSCOMPARASW-4649](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-4649) 