### PR TITLE
File dump-related datacheck updates. 

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayNameFormat.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayNameFormat.pm
@@ -1,0 +1,50 @@
+=head1 LICENSE
+
+Copyright [2018-2021] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::DisplayNameFormat;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME        => 'DisplayNameFormat',
+  DESCRIPTION => 'For Rapid Release, the display name must be a specific format',
+  GROUPS      => ['rapid_release'],
+  DB_TYPES    => ['core'],
+  TABLES      => ['meta']
+};
+
+sub tests {
+  my ($self) = @_;
+
+  my $mca = $self->dba->get_adaptor("MetaContainer");
+
+  # Check that the format of the display name conforms to expectations.
+  my $format = '[A-Za-z0-9 ]+ \([A-Za-z0-9 ]+\) \- GCA_\d+\.\d+';
+
+  my $desc = "Display name has correct format";
+  my $display_name = $mca->single_value_by_key('species.display_name');
+  like($display_name, qr/^$format$/, $desc);
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionNamesENA.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionNamesENA.pm
@@ -1,0 +1,86 @@
+=head1 LICENSE
+
+Copyright [2018-2021] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::SeqRegionNamesENA;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'SeqRegionNamesENA',
+  DESCRIPTION    => 'Seq_region contig names from ENA are appropriately formatted and attributed',
+  GROUPS         => ['assembly', 'core'],
+  DATACHECK_TYPE => 'advisory',
+  DB_TYPES       => ['core'],
+  TABLES         => ['attrib_type', 'coord_system', 'seq_region', 'seq_region_attrib']
+};
+
+sub skip_tests {
+  my ($self) = @_;
+  
+  my $gca = $self->dba->get_adaptor("GenomeContainer");
+
+  if (!defined $gca->get_accession) {
+    return (1, 'Not an INSDC assembly.');
+  }
+}
+
+sub tests {
+  my ($self) = @_;
+
+  my $species_id = $self->dba->species_id;
+
+  my $format = '^[A-Z]+_?[0-9]+\.[0-9\.]+$';
+
+  $self->check_ena_attribute('contig', $format, $species_id);
+}
+
+sub check_ena_attribute {
+  my ($self, $cs_name, $format, $species_id) = @_;
+
+  my $desc = "All $cs_name seq_regions have an 'ENA' attribute";
+  my $diag = 'No ENA attribute for seq_region';
+  my $sql  = qq/
+    SELECT sr.name, sra.value, cs.name, cs.version FROM
+      seq_region sr INNER JOIN
+      coord_system cs USING (coord_system_id) LEFT OUTER JOIN
+      (
+        SELECT seq_region_id, value FROM
+          seq_region_attrib INNER JOIN
+          attrib_type USING (attrib_type_id)
+        WHERE
+          code = 'external_db' AND
+          value = 'ENA'
+      ) sra ON sr.seq_region_id = sra.seq_region_id
+    WHERE
+      sra.value IS NULL AND
+      cs.name = '$cs_name' AND
+      sr.name REGEXP '$format' AND
+      sr.name NOT LIKE 'LRG%' AND
+      cs.species_id = $species_id
+  /;
+  is_rows_zero($self->dba, $sql, $desc, $diag);
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionNamesINSDC.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionNamesINSDC.pm
@@ -82,7 +82,7 @@ sub check_name_format {
       a.code = 'toplevel' AND
       sra.value = '1' AND
       sr.name NOT REGEXP '$format' AND
-      srs.synonym NOT REGEXP '$format' AND
+      (srs.synonym NOT REGEXP '$format' OR srs.synonym IS NULL) AND
       sr.name NOT LIKE 'LRG%' AND
       cs.species_id = $species_id
   /;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionNamesINSDC.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionNamesINSDC.pm
@@ -30,45 +30,46 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'SeqRegionNamesINSDC',
   DESCRIPTION    => 'Seq_region names from INSDC are appropriately formatted and attributed',
-  GROUPS         => ['assembly', 'core'],
+  GROUPS         => ['assembly', 'core', 'ena_gff3_format'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['core'],
   TABLES         => ['attrib_type', 'coord_system', 'external_db', 'seq_region', 'seq_region_attrib', 'seq_region_synonym']
 };
 
-sub skip_tests {
-  my ($self) = @_;
-  
-  my $gca = $self->dba->get_adaptor("GenomeContainer");
-
-  if (!defined $gca->get_accession) {
-    return (1, 'Not an INSDC assembly.');
-  }
-}
-
 sub tests {
   my ($self) = @_;
 
-  my $species_id = $self->dba->species_id;
+  if ($self->check_insdc_assembly) {
+    # For an INSDC assembly, we expect INSDC accessions to be synonyms
+    # for top-level sequences; if not, the names might be the accessions,
+    # which is a hard to check rigorously, but a reasonable assumption
+    # is that if it looks like an accession, it probably is. 
 
-  my $format = '^[A-Z]+_?[0-9]+\.[0-9\.]+$';
+    my $species_id = $self->dba->species_id;
+    my $format = '^[A-Z]+_?[0-9]+\.[0-9\.]+$';
+    $self->check_name_format($format, $species_id);
+  }
+}
 
-  $self->check_name_format('clone', $format, $species_id);
-  $self->check_name_format('contig', $format, $species_id);
-  $self->check_name_format('scaffold', $format, $species_id);
-  $self->check_name_format('supercontig', $format, $species_id);
+sub check_insdc_assembly {
+  my ($self) = @_;
 
-  $self->check_ena_attribute('contig', $format, $species_id);
+  my $desc = 'INSDC assembly exists';
+  my $gca = $self->dba->get_adaptor("GenomeContainer");
+
+  return ok(defined $gca->get_accession, $desc);
 }
 
 sub check_name_format {
-  my ($self, $cs_name, $format, $species_id) = @_;
+  my ($self, $format, $species_id) = @_;
 
-  my $desc = "$cs_name seq_region names (or INSDC synonyms) match the expected format";
+  my $desc = "seq_region names (or INSDC synonyms) match the expected format";
   my $diag = 'Unmatched seq_region name';
   my $sql  = qq/
     SELECT sr.name, srs.synonym, cs.name, cs.version FROM
       seq_region sr INNER JOIN
+      seq_region_attrib sra USING (seq_region_id) INNER JOIN
+      attrib_type a USING (attrib_type_id) INNER JOIN
       coord_system cs USING (coord_system_id) LEFT OUTER JOIN
       (
         SELECT seq_region_id, synonym FROM
@@ -78,36 +79,10 @@ sub check_name_format {
           db_name = 'INSDC'
       ) srs ON sr.seq_region_id = srs.seq_region_id
     WHERE
-      cs.name = '$cs_name' AND
+      a.code = 'toplevel' AND
+      sra.value = '1' AND
       sr.name NOT REGEXP '$format' AND
       srs.synonym NOT REGEXP '$format' AND
-      sr.name NOT LIKE 'LRG%' AND
-      cs.species_id = $species_id
-  /;
-  is_rows_zero($self->dba, $sql, $desc, $diag);
-}
-
-sub check_ena_attribute {
-  my ($self, $cs_name, $format, $species_id) = @_;
-
-  my $desc = "All $cs_name seq_regions have an 'ENA' attribute";
-  my $diag = 'No ENA attribute for seq_region';
-  my $sql  = qq/
-    SELECT sr.name, sra.value, cs.name, cs.version FROM
-      seq_region sr INNER JOIN
-      coord_system cs USING (coord_system_id) LEFT OUTER JOIN
-      (
-        SELECT seq_region_id, value FROM
-          seq_region_attrib INNER JOIN
-          attrib_type USING (attrib_type_id)
-        WHERE
-          code = 'external_db' AND
-          value = 'ENA'
-      ) sra ON sr.seq_region_id = sra.seq_region_id
-    WHERE
-      sra.value IS NULL AND
-      cs.name = '$cs_name' AND
-      sr.name REGEXP '$format' AND
       sr.name NOT LIKE 'LRG%' AND
       cs.species_id = $species_id
   /;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionNamesINSDC.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionNamesINSDC.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'SeqRegionNamesINSDC',
   DESCRIPTION    => 'Seq_region names from INSDC are appropriately formatted and attributed',
-  GROUPS         => ['assembly', 'core', 'ena_gff3_format'],
+  GROUPS         => ['assembly', 'core', 'ena_submission'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['core'],
   TABLES         => ['attrib_type', 'coord_system', 'external_db', 'seq_region', 'seq_region_attrib', 'seq_region_synonym']

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2170,12 +2170,23 @@
       "name" : "SeqRegionNames",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SeqRegionNames"
    },
+   "SeqRegionNamesENA" : {
+      "datacheck_type" : "advisory",
+      "description" : "Seq_region contig names from ENA are appropriately formatted and attributed",
+      "groups" : [
+         "assembly",
+         "core"
+      ],
+      "name" : "SeqRegionNamesENA",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SeqRegionNamesENA"
+   },
    "SeqRegionNamesINSDC" : {
       "datacheck_type" : "advisory",
       "description" : "Seq_region names from INSDC are appropriately formatted and attributed",
       "groups" : [
          "assembly",
-         "core"
+         "core",
+         "ena_gff3_format"
       ],
       "name" : "SeqRegionNamesINSDC",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SeqRegionNamesINSDC"

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1113,6 +1113,15 @@
       "name" : "DensitySNPs",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DensitySNPs"
    },
+   "DisplayNameFormat" : {
+      "datacheck_type" : "critical",
+      "description" : "For Rapid Release, the display name must be a specific format",
+      "groups" : [
+         "rapid_release"
+      ],
+      "name" : "DisplayNameFormat",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DisplayNameFormat"
+   },
    "DisplayXrefExists" : {
       "datacheck_type" : "advisory",
       "description" : "At least one gene name exists",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2195,7 +2195,7 @@
       "groups" : [
          "assembly",
          "core",
-         "ena_gff3_format"
+         "ena_submission"
       ],
       "name" : "SeqRegionNamesINSDC",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SeqRegionNamesINSDC"


### PR DESCRIPTION
Added a check for Rapid Release display name.

Split the existing check on INSDC names into two, because only part of it is needed for exporting GFF3 formatted for ENA submission, and we want to be able to run just that bit. The INDSC name check requires all top-level sequences to have an INSDC name/synonym (rather than a set of named coord_systems), which matches the ENA submission use case.

Both of these datachecks are intended to be run within file dump pipelines, to check that the core databases contain all the information required for dumping (https://github.com/Ensembl/ensembl-production/pull/576).