### PR TITLE
GeneBounds: fixing out-of-bound feature reports for circular seq_regions

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBounds.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBounds.pm
@@ -73,7 +73,8 @@ sub bounds_check {
         t.seq_region_start = 0 OR
         t.seq_region_end > sr.length
       ) AND
-      cs.species_id = $species_id
+      cs.species_id = $species_id AND
+      at.code IS NULL
   /;
   is_rows_zero($self->dba, $sql, $desc, $diag);
 }


### PR DESCRIPTION
tested on me1:premz_bombyx_mori_core_53_105_2
gene with stable_id "GeneID_4266952"

Just in case.

original gff
```
##sequence-region NC_002355.1 1 15643
NC_002355.1     RefSeq  gene    15095   15883   .       +       .       ID=gene-COX3;Dbxref=GeneID:4266952;Name=COX3;gbkey=Gene;gene=COX3;gene_biotype=protein_coding
NC_002355.1     RefSeq  CDS     15095   15883   .       +       0       ID=cds-NP_059480.1;Parent=gene-COX3;Dbxref=Genbank:NP_059480.1,GeneID:4266952;Name=NP_059480.1;gbkey=CDS;gene=COX3;product=cytochrome c oxidase subunit III;protein_id=NP_059480.1;transl_table=5
```

original gbff
```
CDS             1..262
/gene="COX3"
/locus_tag="KEF65_p01"
/coded_by="join(NC_002355.1:15095..15643,NC_002355.1:1..240)"
/transl_table=5
/db_xref="GeneID:4266952"
```