### PR TITLE
Add disconnect_if_idle to GeneBiotypes datacheck

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBiotypes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBiotypes.pm
@@ -101,6 +101,8 @@ sub biotype_groups {
 
   my $ga = $self->dba->get_adaptor("Gene");
   my $genes = $ga->fetch_all();
+  $self->dba->dbc && $self->dba->dbc->disconnect_if_idle();
+
   while (my $gene = shift @$genes) {
     my $gene_group = $groups{$gene->biotype};
 


### PR DESCRIPTION
With very large numbers of genes, the datacheck loses connection to the database; an explicit disconnect solves this.
However, further optimisations may be required to account for the millions of genes that may be in otherfeatures databases, in order to reduce the memory footprint.