### PR TITLE
Fix: should fail if not all translations have attribs

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/PepstatsAttributes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/PepstatsAttributes.pm
@@ -71,7 +71,7 @@ sub tests {
         species_id = $species_id AND
         attrib_type_id = $attrib_type_id
     /;
-    row_totals($self->dba, undef, $sql_2a, $sql_2b, 1, $desc_2);
+    row_totals($self->dba, undef, $sql_2a, $sql_2b, undef, $desc_2);
   }
 }
 


### PR DESCRIPTION
Change the min_proportion to undef, because we need the number of
translations to be the number of attribs of each type. The value 1
basically meant that any number of attribs would work, as long as it
wasn't more than the number of translations.