### PR TITLE
Allow for differing clustersets/additional trees in homology relationships

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomology.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomology.pm
@@ -44,16 +44,22 @@ sub tests {
   is_one_to_many($dbc, "homology_member", "homology_id", $desc_1);
   ### Hoping for a better idea than this query (below)
   my $hideous_sql = q/
-    SELECT hm1.gene_member_id gene_member_id1, hm2.gene_member_id gene_member_id2, COUNT(*) num, 
-      GROUP_CONCAT(h1.description order by h1.description) descs 
-        FROM homology h1 
-          CROSS JOIN homology_member hm1 
-            USING (homology_id)
-          CROSS JOIN homology_member hm2 
-            USING (homology_id)
-    WHERE hm1.gene_member_id < hm2.gene_member_id
-      GROUP BY hm1.gene_member_id, hm2.gene_member_id 
-        HAVING COUNT(*) > 1
+    SELECT
+      hm1.gene_member_id gene_member_id1,
+      hm2.gene_member_id gene_member_id2,
+      COUNT(*) num,
+      GROUP_CONCAT(h1.description
+          ORDER BY h1.description) descs
+    FROM
+      homology h1
+          CROSS JOIN
+      homology_member hm1 USING (homology_id)
+          CROSS JOIN
+      homology_member hm2 USING (homology_id)
+    WHERE
+      hm1.gene_member_id < hm2.gene_member_id
+    GROUP BY h1.gene_tree_root_id, hm1.gene_member_id, hm2.gene_member_id
+    HAVING COUNT(*) > 1
   /;
 
   my $desc_2 = "There is no redundancy in homology";


### PR DESCRIPTION
### CheckHomology

:bangbang: | This needs to be merged to handover compara vertebrates
:---: | :---

This compara DC checks for redundancy in homology relationships - duplicate relationships for a pair of `gene_members`.
But it does not take into account the possibility that a homology relationship can be identical and inferred from two different trees.
This flexibility has been checked on the staging sites and in the compara API, and causes no issues.

* Non default clustersets with overlapping mlsss in
  in the strains/breeds and default can cause `gene_members`
  to have duplicated relationships in different trees

* These "redundant" or duplicate relationships are actually
  a sign of consistency between trees

* Whilst overlapping mlsss should be avoided in the future,
  the data is not at fault, not technically redundant and
  should be allowed

* Check now groups by gene_tree_root_id as well as
  gene_members