### PR TITLE
Check for mitochondrial attribute

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ChromosomesAnnotated.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ChromosomesAnnotated.pm
@@ -59,12 +59,6 @@ sub tests {
       my $sr_name = $_->seq_region_name;
       my $desc = "$cs_name $sr_name has 'karyotype_rank' attribute";
       ok($_->has_karyotype, $desc);
-
-      if ($sr_name =~ /^(chrM|chrMT|MT|Mito|mitochondrion_genome)$/) {
-        my $desc_mt = "$cs_name $sr_name has mitochondrial 'sequence_location' attribute";
-        my %seq_locs = map { $_->value => 1 } @{$_->get_all_Attributes('sequence_location')};
-        ok(exists $seq_locs{'mitochondrial_chromosome'}, $desc_mt);
-      }
     }
   }
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MitochondriaAnnotated.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MitochondriaAnnotated.pm
@@ -72,7 +72,7 @@ sub tests {
     my $slice = $sa->fetch_by_region('toplevel', $name);
     if (defined $slice) {
       my $desc_mt = "$name has mitochondrial 'sequence_location' attribute";
-      my %seq_locs = map { $_->value => 1 } @{$_->get_all_Attributes('sequence_location')};
+      my %seq_locs = map { $_->value => 1 } @{$slice->get_all_Attributes('sequence_location')};
       ok(exists $seq_locs{'mitochondrial_chromosome'}, $desc_mt);
     }
   }

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MitochondriaAnnotated.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MitochondriaAnnotated.pm
@@ -1,0 +1,81 @@
+=head1 LICENSE
+
+Copyright [2018-2021] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::MitochondriaAnnotated;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Utils qw/sql_count/;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'MitochondriaAnnotated',
+  DESCRIPTION    => 'Mitochondrial seq_regions have appropriate attribute',
+  GROUPS         => ['assembly', 'core', 'brc4_core'],
+  DB_TYPES       => ['core'],
+  TABLES         => ['attrib_type', 'coord_system', 'seq_region', 'seq_region_attrib']
+};
+
+sub skip_tests {
+  my ($self) = @_;
+
+  my $sa = $self->dba->get_adaptor('Slice');
+
+  my %mt_names = map { lc($_) => 1 } ('chrM', 'chrMT', 'MT', 'Mito', 'mitochondrion_genome');
+        
+  my $mt = 0;
+  foreach my $mt_name (keys %mt_names) {
+    my $slice = $sa->fetch_by_region('toplevel', $mt_name);
+    # Need to iterate over names due to unavoidable fuzzy matching of synonyms.
+    if (defined $slice && $slice->is_toplevel) {
+      my @synonyms = map { $_->name } @{$slice->get_all_synonyms};
+      my @names = ($slice->seq_region_name, @synonyms);
+      foreach my $name (@names) {
+        if (exists $mt_names{lc($name)}) {
+          $mt = 1;
+        }
+      }
+    }
+  }
+
+  if ( !$mt ) {
+    return (1, 'No apparent mitochondrial seq_regions.');
+  }
+}
+
+sub tests {
+  my ($self) = @_;
+
+  my $sa = $self->dba->get_adaptor('Slice');
+
+  my @names = ('chrM', 'chrMT', 'MT', 'Mito', 'mitochondrion_genome');
+  foreach my $name (@names) {
+    my $slice = $sa->fetch_by_region('toplevel', $name);
+    if (defined $slice) {
+      my $desc_mt = "$name has mitochondrial 'sequence_location' attribute";
+      my %seq_locs = map { $_->value => 1 } @{$_->get_all_Attributes('sequence_location')};
+      ok(exists $seq_locs{'mitochondrial_chromosome'}, $desc_mt);
+    }
+  }
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1798,6 +1798,17 @@
       "name" : "MetaKeyOptional",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MetaKeyOptional"
    },
+   "MitochondriaAnnotated" : {
+      "datacheck_type" : "critical",
+      "description" : "Mitochondrial seq_regions have appropriate attribute",
+      "groups" : [
+         "assembly",
+         "core",
+         "brc4_core"
+      ],
+      "name" : "MitochondriaAnnotated",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MitochondriaAnnotated"
+   },
    "MultipleGenomicAlignBlockIds" : {
       "datacheck_type" : "critical",
       "description" : "Check that every genomic_align_block_id has more than one genomic_align_id",


### PR DESCRIPTION
We expect MT seq_regions to have a 'sequence_location' attrib, with a value of 'mitochondrial_chromosome'. This was only being checked if the coord_system name was 'chromosome' - but most new core dbs do not use that name, they have 'primary_assembly' instead.

This update splits out the MT stuff to a new datacheck, so that it does not depend on the coord_system name.