### PR TITLE
Remove '_old' species DBAdaptor after running DbCheck

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
@@ -282,6 +282,9 @@ after 'run' => sub {
 
   foreach my $dba (@{ $self->dba_list }) {
     $dba->dbc && $dba->dbc->disconnect_if_idle();
+    if ($dba->species =~ m/_old$/) {
+      $self->registry->remove_DBAdaptor($dba->species, $dba->group);
+    }
   }
 };
 


### PR DESCRIPTION
Fix for EP-6693 where some pipelines receive species names postfixed with `_old` introduced by Datachecks when comparing previous databases releases.