### PR TITLE
Remove inappropriate compara databases

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSchema.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSchema.pm
@@ -32,7 +32,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'CompareSchema',
   DESCRIPTION => 'Compare database schema to definition in SQL file',
-  GROUPS      => ['compara', 'core', 'brc4_core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['compara', 'compara_homology_annotation', 'compara_references', 'core', 'brc4_core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'production', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DatabaseCollation.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DatabaseCollation.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'DatabaseCollation',
   DESCRIPTION => 'All tables have the same collation (latin1_swedish_ci)',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_homology_annotation', 'compara_master', 'compara_references', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MySQLStorageEngine.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MySQLStorageEngine.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'MySQLStorageEngine',
   DESCRIPTION => 'Database schema matches expected MySQL storage engine',
-  GROUPS      => ['compara', 'core', 'brc4_core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['compara', 'compara_homology_annotation', 'core', 'brc4_core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1,
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaPatchesApplied.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaPatchesApplied.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SchemaPatchesApplied',
   DESCRIPTION => 'Schema patches are up-to-date',
-  GROUPS      => ['brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'production', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaVersion.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaVersion.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SchemaVersion',
   DESCRIPTION => 'The schema version meta key matches the DB name',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_homology_annotation', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/WhitespaceCritical.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/WhitespaceCritical.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'WhitespaceCritical',
   DESCRIPTION => 'Fields do not contain carriage returns ("\r")',
-  GROUPS      => ['compara', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['compara', 'compara_homology_annotation', 'compara_references', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2122,8 +2122,6 @@
          "compara_genome_alignments",
          "compara_master",
          "compara_syntenies",
-         "compara_references",
-         "compara_homology_annotation",
          "core",
          "corelike",
          "funcgen",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -826,6 +826,8 @@
       "description" : "Compare database schema to definition in SQL file",
       "groups" : [
          "compara",
+         "compara_homology_annotation",
+         "compara_references",
          "core",
          "brc4_core",
          "corelike",
@@ -1080,7 +1082,9 @@
          "compara",
          "compara_gene_trees",
          "compara_genome_alignments",
+         "compara_homology_annotation",
          "compara_master",
+         "compara_references",
          "compara_syntenies",
          "core",
          "corelike",
@@ -1834,6 +1838,7 @@
       "description" : "Database schema matches expected MySQL storage engine",
       "groups" : [
          "compara",
+         "compara_homology_annotation",
          "core",
          "brc4_core",
          "corelike",
@@ -2159,6 +2164,7 @@
          "ancestral",
          "brc4_core",
          "compara",
+         "compara_homology_annotation",
          "core",
          "corelike",
          "funcgen",
@@ -2596,6 +2602,8 @@
       "description" : "Fields do not contain carriage returns (\"\\r\")",
       "groups" : [
          "compara",
+         "compara_homology_annotation",
+         "compara_references",
          "core",
          "corelike",
          "funcgen",


### PR DESCRIPTION
`SchemaPatchesApplied` DC is not applicable for the rapid release Compara databases (References and Homology annotation at the moment) as they follow a different schema.
After further discussion, some additional DCs have been added for the current Compara RR databases.