### PR TITLE
Enforce INSDC accessions as seq_region names or synonyms.

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionNamesINSDCAdvisory.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionNamesINSDCAdvisory.pm
@@ -16,7 +16,7 @@ limitations under the License.
 
 =cut
 
-package Bio::EnsEMBL::DataCheck::Checks::SeqRegionNamesINSDC;
+package Bio::EnsEMBL::DataCheck::Checks::SeqRegionNamesINSDCAdvisory;
 
 use warnings;
 use strict;
@@ -28,9 +28,9 @@ use Bio::EnsEMBL::DataCheck::Test::DataCheck;
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
-  NAME           => 'SeqRegionNamesINSDC',
+  NAME           => 'SeqRegionNamesINSDCAdvisory',
   DESCRIPTION    => 'Seq_region names from INSDC are appropriately formatted and attributed',
-  GROUPS         => ['assembly', 'core', 'ena_submission'],
+  GROUPS         => ['assembly', 'core'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['core'],
   TABLES         => ['attrib_type', 'coord_system', 'external_db', 'seq_region', 'seq_region_attrib', 'seq_region_synonym']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionNamesINSDCCritical.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionNamesINSDCCritical.pm
@@ -1,0 +1,39 @@
+=head1 LICENSE
+
+Copyright [2018-2021] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::SeqRegionNamesINSDCCritical;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
+extends 'Bio::EnsEMBL::DataCheck::Checks::SeqRegionNamesINSDCAdvisory';
+
+use constant {
+  NAME           => 'SeqRegionNamesINSDCCritical',
+  DESCRIPTION    => 'Seq_region names from INSDC are appropriately formatted and attributed',
+  GROUPS         => ['ena_submission', 'rapid_release'],
+  DATACHECK_TYPE => 'critical',
+  DB_TYPES       => ['core'],
+  TABLES         => ['attrib_type', 'coord_system', 'external_db', 'seq_region', 'seq_region_attrib', 'seq_region_synonym']
+};
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2220,6 +2220,26 @@
       "name" : "SeqRegionNamesINSDC",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SeqRegionNamesINSDC"
    },
+   "SeqRegionNamesINSDCAdvisory" : {
+      "datacheck_type" : "advisory",
+      "description" : "Seq_region names from INSDC are appropriately formatted and attributed",
+      "groups" : [
+         "assembly",
+         "core"
+      ],
+      "name" : "SeqRegionNamesINSDCAdvisory",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SeqRegionNamesINSDCAdvisory"
+   },
+   "SeqRegionNamesINSDCCritical" : {
+      "datacheck_type" : "critical",
+      "description" : "Seq_region names from INSDC are appropriately formatted and attributed",
+      "groups" : [
+         "ena_submission",
+         "rapid_release"
+      ],
+      "name" : "SeqRegionNamesINSDCCritical",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SeqRegionNamesINSDCCritical"
+   },
    "SeqRegionRank" : {
       "datacheck_type" : "critical",
       "description" : "Chromosomes have rank 1",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2209,17 +2209,6 @@
       "name" : "SeqRegionNamesENA",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SeqRegionNamesENA"
    },
-   "SeqRegionNamesINSDC" : {
-      "datacheck_type" : "advisory",
-      "description" : "Seq_region names from INSDC are appropriately formatted and attributed",
-      "groups" : [
-         "assembly",
-         "core",
-         "ena_submission"
-      ],
-      "name" : "SeqRegionNamesINSDC",
-      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SeqRegionNamesINSDC"
-   },
    "SeqRegionNamesINSDCAdvisory" : {
       "datacheck_type" : "advisory",
       "description" : "Seq_region names from INSDC are appropriately formatted and attributed",


### PR DESCRIPTION
For new species, and most old ones, we have INSDC accessions for all of our sequences - this is really useful for users. Due to exceptional cases on the main Ensembl site, however, we don't enforce INSDC accessions, and the relevant datacheck was advisory.

For Rapid Release, however, this data should always be available, and we are introducing processes which depend on this (ENA-format GFF3 dumps, and the new metadata schema).

This PR makes the datacheck critical for RR, remaining advisory for the main site.