### PR TITLE
Add common name check to core_sync group.

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesCommonName.pm
@@ -29,8 +29,8 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'SpeciesCommonName',
   DESCRIPTION    => 'Meta key species.common_name should be same for species from a group of strains or breeds',
-  GROUPS         => ['core', 'meta'],
-  DATACHECK_TYPE => 'advisory',
+  GROUPS         => ['core_sync'],
+  DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['core'],
   TABLES         => ['meta'],
 };

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2327,11 +2327,10 @@
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SourceAdvisory"
    },
    "SpeciesCommonName" : {
-      "datacheck_type" : "advisory",
+      "datacheck_type" : "critical",
       "description" : "Meta key species.common_name should be same for species from a group of strains or breeds",
       "groups" : [
-         "core",
-         "meta"
+         "core_sync"
       ],
       "name" : "SpeciesCommonName",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SpeciesCommonName"


### PR DESCRIPTION
Checking common names across a range of databases is awkward to do at handover, but things break if there are discrepancies, so we certainly want it as a critical datacheck.

The datacheck logically fits in the existing 'core_sync' group, which is convenient because we already run that as a post-handover pipeline, so don't need any additional process or config to incorporate the check.