### PR TITLE
Fix compara datacheck retrieval of core dbs.

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
@@ -417,6 +417,11 @@ sub find_dbname {
     $params = [$group, $species, $db_version];
   } else {
     my $division = $mca->get_division;
+    # Handle compara case, where division is stored differently:
+    unless (defined $division) {
+      $division = $mca->db->get_division;
+      $division = 'Ensembl'.ucfirst($division);
+    }
     $sql = q/
       SELECT DISTINCT gd.dbname FROM
         genome_database gd INNER JOIN

--- a/t/test-genome-DBs/multi/compara/meta.txt
+++ b/t/test-genome-DBs/multi/compara/meta.txt
@@ -1,4 +1,5 @@
-2	1	schema_type	compara
+2	\N	schema_type	compara
+3	\N	division	vertebrates
 149	\N	schema_version	105
 5	\N	patch	patch_70_71_a.sql|other_member_sequence_keys
 6	\N	patch	patch_70_71_b.sql|member_xref


### PR DESCRIPTION
The compara datachecks that needed to load core dbs, in order to check data consistency, were not working if both a registry and server_uri were provided. (If only one was provided, then assuming that the core dbs were on the given server, datachecks were fine.)

When registry and server_uri are given, the code looks in the metadata db, to try and work out the name of the requisite core db. This requires a division name (because three species are in two divisions, and we need to only return one of them at a time), but division metadata is formatted differently in compara dbs, compared to all the species-specific dbs.

Once we account for that formatting, everything works as expected.