### PR TITLE
Fix for caenorhabditis_elegans multiple core db error

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm
@@ -403,18 +403,22 @@ sub find_dbname {
   my ($sql, $params);
   if ($group =~ /(funcgen|variation)/i ||
       $mca->single_value_by_key('schema_type') =~ /(funcgen|variation)/i) {
+      
+    my $division = $mca->single_value_by_key('species.division');  
     $sql = q/
       SELECT DISTINCT gd.dbname FROM
         genome_database gd INNER JOIN
         genome g USING (genome_id) INNER JOIN
         organism o USING (organism_id) INNER JOIN
-        data_release dr USING (data_release_id)
+        data_release dr USING (data_release_id) INNER JOIN
+        division d USING (division_id)
       WHERE
         gd.type = ? AND
         o.name = ? AND
-        dr.ensembl_version = ?
+        dr.ensembl_version = ? AND
+        d.name = ?
     /;
-    $params = [$group, $species, $db_version];
+    $params = [$group, $species, $db_version, $division];
   } else {
     my $division = $mca->get_division;
     # Handle compara case, where division is stored differently:


### PR DESCRIPTION
caenorhabditis_elegans belongs to both divisions EnsemblVertebrates, EnsemblMetazoa   which result datacheck to fail with error 
(Multiple release 106 core databases for caenorhabditis_elegans  )

+----------------------------------------+--------------------+
| dbname                                 | name               |
+----------------------------------------+--------------------+
| caenorhabditis_elegans_core_106_279    | EnsemblVertebrates |
| caenorhabditis_elegans_core_53_106_279 | EnsemblMetazoa     |
+----------------------------------------+--------------------+

new sql with division param will fix this error 