### PR TITLE
Allow additional special charachters in DisplayNameFormat regex

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayNameFormat.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayNameFormat.pm
@@ -40,7 +40,7 @@ sub tests {
   my $mca = $self->dba->get_adaptor("MetaContainer");
 
   # Check that the format of the display name conforms to expectations.
-  my $format = '[A-Za-z0-9 ]+ \([A-Za-z0-9 ]+\) \- GCA_\d+\.\d+';
+  my $format = '[A-Za-z0-9\ ]+ \([A-Za-z0-9\(\)\/\-\ ]+\) \- GCA_\d+\.\d+';
 
   my $desc = "Display name has correct format";
   my $display_name = $mca->single_value_by_key('species.display_name');


### PR DESCRIPTION
Add `(`, `)`, `-`, `/` as valid characters for meta key `species.display_name` value.
Allowing names like: `Phyllostomus discolor (Pale spear-nosed bat) - GCA_004126475.2`

Note that `DisplayNameFormat` is a Rapid Release only test.