### PR TITLE
New compara_blastocyst group for RR pipeline_db checks

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankEnums.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankEnums.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'BlankEnums',
   DESCRIPTION => 'Enum columns do not have empty string values',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_gene_trees', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_blastocyst', 'compara_gene_trees', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'BlankNulls',
   DESCRIPTION => 'Nullable columns do not have empty string values',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_blastocyst', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckDuplicatedTaxaNames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckDuplicatedTaxaNames.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckDuplicatedTaxaNames',
   DESCRIPTION    => 'Check that the ncbi_taxa_name contains only unique rows',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'compara_blastocyst'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['ncbi_taxa_name']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomology.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomology.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckHomology',
   DESCRIPTION    => 'Check homology_id are all one-to-many for homology_members',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_homology_annotation'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_homology_annotation', 'compara_blastocyst'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['homology', 'homology_member']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomologyMLSS.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomologyMLSS.pm
@@ -32,7 +32,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckHomologyMLSS',
   DESCRIPTION    => 'The expected number of homologys MLSSs are present',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_homology_annotation'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_homology_annotation', 'compara_blastocyst'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['method_link_species_set', 'homology']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSequenceTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSequenceTable.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckSequenceTable',
   DESCRIPTION    => 'Check for sequence length and availability',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_references', 'compara_homology_annotation'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_references', 'compara_homology_annotation', 'compara_blastocyst'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['sequence']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesSetTable.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckSpeciesSetTable',
   DESCRIPTION    => 'Check species_set_tags have no orphans and species_sets are unique',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'compara_blastocyst'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['species_set']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CigarCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CigarCheck.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CigarCheck',
   DESCRIPTION    => 'The cigar_line must not have negative numbers or zeros in it',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_homology_annotation'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_homology_annotation', 'compara_blastocyst'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['family_member', 'gene_align_member', 'genomic_align', 'homology_member', 'peptide_align_feature'],

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DatabaseCollation.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DatabaseCollation.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'DatabaseCollation',
   DESCRIPTION => 'All tables have the same collation (latin1_swedish_ci)',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_homology_annotation', 'compara_master', 'compara_references', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_blastocyst', 'compara_gene_trees', 'compara_genome_alignments', 'compara_homology_annotation', 'compara_master', 'compara_references', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeysCompara.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'ForeignKeysCompara',
   DESCRIPTION => 'Foreign key relationships are not violated',
-  GROUPS      => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation'],
+  GROUPS      => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'compara_blastocyst'],
   DB_TYPES    => ['compara'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/NoDataOnGenomeComponents.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/NoDataOnGenomeComponents.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'NoDataOnGenomeComponents',
   DESCRIPTION    => 'Data is only allowed on principle genomes and not components',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_syntenies', 'compara_homology_annotation'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_syntenies', 'compara_homology_annotation', 'compara_blastocyst'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['constrained_element', 'dnafrag', 'dnafrag_region', 'gene_member', 'genome_db', 'genomic_align', 'seq_member']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/WhitespaceCritical.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/WhitespaceCritical.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'WhitespaceCritical',
   DESCRIPTION => 'Fields do not contain carriage returns ("\r")',
-  GROUPS      => ['compara', 'compara_homology_annotation', 'compara_references', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['compara', 'compara_blastocyst', 'compara_homology_annotation', 'compara_references', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -158,6 +158,7 @@
          "ancestral",
          "brc4_core",
          "compara",
+         "compara_blastocyst",
          "compara_gene_trees",
          "compara_master",
          "compara_syntenies",
@@ -179,6 +180,7 @@
          "ancestral",
          "brc4_core",
          "compara",
+         "compara_blastocyst",
          "compara_gene_trees",
          "compara_genome_alignments",
          "compara_master",
@@ -276,7 +278,8 @@
          "compara_master",
          "compara_syntenies",
          "compara_references",
-         "compara_homology_annotation"
+         "compara_homology_annotation",
+         "compara_blastocyst"
       ],
       "name" : "CheckDuplicatedTaxaNames",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckDuplicatedTaxaNames"
@@ -387,7 +390,8 @@
       "groups" : [
          "compara",
          "compara_gene_trees",
-         "compara_homology_annotation"
+         "compara_homology_annotation",
+         "compara_blastocyst"
       ],
       "name" : "CheckHomology",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckHomology"
@@ -398,7 +402,8 @@
       "groups" : [
          "compara",
          "compara_gene_trees",
-         "compara_homology_annotation"
+         "compara_homology_annotation",
+         "compara_blastocyst"
       ],
       "name" : "CheckHomologyMLSS",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckHomologyMLSS"
@@ -537,7 +542,8 @@
          "compara",
          "compara_gene_trees",
          "compara_references",
-         "compara_homology_annotation"
+         "compara_homology_annotation",
+         "compara_blastocyst"
       ],
       "name" : "CheckSequenceTable",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckSequenceTable"
@@ -565,7 +571,8 @@
          "compara_master",
          "compara_syntenies",
          "compara_references",
-         "compara_homology_annotation"
+         "compara_homology_annotation",
+         "compara_blastocyst"
       ],
       "name" : "CheckSpeciesSetTable",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckSpeciesSetTable"
@@ -648,7 +655,8 @@
          "compara",
          "compara_gene_trees",
          "compara_genome_alignments",
-         "compara_homology_annotation"
+         "compara_homology_annotation",
+         "compara_blastocyst"
       ],
       "name" : "CigarCheck",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CigarCheck"
@@ -1068,6 +1076,7 @@
          "ancestral",
          "brc4_core",
          "compara",
+         "compara_blastocyst",
          "compara_gene_trees",
          "compara_genome_alignments",
          "compara_homology_annotation",
@@ -1337,7 +1346,8 @@
          "compara_master",
          "compara_syntenies",
          "compara_references",
-         "compara_homology_annotation"
+         "compara_homology_annotation",
+         "compara_blastocyst"
       ],
       "name" : "ForeignKeysCompara",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ForeignKeysCompara"
@@ -1875,7 +1885,8 @@
          "compara_gene_trees",
          "compara_genome_alignments",
          "compara_syntenies",
-         "compara_homology_annotation"
+         "compara_homology_annotation",
+         "compara_blastocyst"
       ],
       "name" : "NoDataOnGenomeComponents",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::NoDataOnGenomeComponents"
@@ -2630,6 +2641,7 @@
       "description" : "Fields do not contain carriage returns (\"\\r\")",
       "groups" : [
          "compara",
+         "compara_blastocyst",
          "compara_homology_annotation",
          "compara_references",
          "core",


### PR DESCRIPTION
## Description
For the compara blastocyst, the pipeine automatically datachecks the integrity of the data within the pipeline before copying to the per-species RR compara databases. This is a necessary precaution. However, certain schema checks are not necessary for the pipeline, because the pipeline database differs from the compara schema in engine and therefore use of key restraints. So here we have a dc_group specific to the pipeline that checks the same data as in the final RR compara dbs, but without any schema checks, since these are expected to differ, and will be run on the individual databases once copy has completed.

## Jira Ticket
[ENSCOMPARASW-4960](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-4960)