### PR TITLE
Fix Schema DCs to fit edgecases

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSchema.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSchema.pm
@@ -181,6 +181,7 @@ sub normalise_table_def {
 
   # Remove keys from table definition since they have been extracted.
   $table =~ s/^((?:PRIMARY |UNIQUE |FOREIGN )*KEY\s.*)\n//gm;
+  $table =~ s/^((?:CONSTRAINT |UNIQUE |KEY ).*)\n//gm;
 
   my ($table_name) = $table =~ /CREATE TABLE (\S+)/m;
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MySQLStorageEngine.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MySQLStorageEngine.pm
@@ -38,7 +38,7 @@ use constant {
 sub tests {
   my ($self) = @_;
   my $database_name = $self->dba->dbc->dbname;
-  my $engine = 'MyISAM';
+  my $engine = ($database_name =~ /_compara_/ and $database_name !~ /ensembl/) ? 'InnoDB' : 'MyISAM';
   my $diag = "Non-$engine table";
   my $desc = "All tables are using MySQL $engine storage engine";
   my $sql = qq/ SELECT TABLE_NAME FROM 


### PR DESCRIPTION
## Description
There were failing schema related DCs for the compara RR databases. Whilst fixing this on compara side it was noticed that the DCs themselves needed slight tweaks too.
* `CompareSchema` DC was missing a particular syntax for `UNIQUE KEY` and `CONSTRAINTS` so this line has been added.
* `MySQLStorageEngine` was hardcoded to MyISAM engine check, which is fine for every database except the compara RR databases, which require InnoDB engine, so a ternary has been chucked in to fit.

## Jira Ticket:
[ENSCOMPARASW-4959](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-4959)

## Related PR
https://github.com/Ensembl/ensembl-compara/pull/363 <- for interest/further understanding

## Testing
- Tested on RR db on `InnoDB` schema
- Tested on e104 and e105 main release compara 