### PR TITLE
updated method to add new genebuild metakeys

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/VersionedGenes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/VersionedGenes.pm
@@ -47,7 +47,7 @@ sub tests {
   # full_genebuild, projection_build, mixed_strategy_build, maker_genebuild
   my $version_expected = 0;
   foreach my $method (@$methods) {
-    if ($method =~ /build/) {
+    if ($method =~ /build|anno|braker|standard/) {
       $version_expected = 1;
     }
   }


### PR DESCRIPTION
Updated regex for method in VersionedGenes.pm in order to include the new genebuild pipelines (braker, anno, standard).
Marc, could you please double check that this will not affect any Production code?