### PR TITLE
EP-7110: Refactor HGNCMultipleGenes to allow comparison with threshold

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareHGNCMultipleGenes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareHGNCMultipleGenes.pm
@@ -54,9 +54,8 @@ sub tests {
   cmp_ok($multi_hgnc_diff, "<=", 5, $desc);
 }
 
-
 sub multiple_hgnc_percentage {
-  my ($db_adaptor) = @_;
+  my ($self, $db_adaptor) = @_;
 
   my $dbea = $db_adaptor->get_adaptor('DBEntry');
   my $ga = $db_adaptor->get_adaptor('Gene');

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareHGNCMultipleGenes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareHGNCMultipleGenes.pm
@@ -48,7 +48,7 @@ sub tests {
     $old_multi_hgnc_percentage = $self->multiple_hgnc_percentage($old_dba);
   }
 
-  my $multi_hgnc_diff = $cur_hgnc_percentage - $old_multi_hgnc_percentage;
+  my $multi_hgnc_diff = $cur_multi_hgnc_percentage - $old_multi_hgnc_percentage;
 
   my $desc = "HGNC symbols assigned to multiple genes have not increased more than 5%";
   cmp_ok($multi_hgnc_diff, "<=", 5, $desc);

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -729,6 +729,17 @@
       "name" : "CompareGenotypes",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareGenotypes"
    },
+   "CompareHGNCMultipleGenes" : {
+      "datacheck_type" : "advisory",
+      "description" : "HGNC-derived gene names assigned to multiple genes have not increased more than 5%",
+      "groups" : [
+         "compare_core",
+         "xref",
+         "xref_name_projection"
+      ],
+      "name" : "CompareHGNCMultipleGenes",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareHGNCMultipleGenes"
+   },
    "CompareMSANames" : {
       "datacheck_type" : "advisory",
       "description" : "The species_sets from the previous database are still present",
@@ -1544,17 +1555,6 @@
       ],
       "name" : "GenomeStatistics",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::GenomeStatistics"
-   },
-   "HGNCMultipleGenes" : {
-      "datacheck_type" : "advisory",
-      "description" : "HGNC-derived gene names are not given to multiple genes",
-      "groups" : [
-         "core",
-         "xref",
-         "xref_name_projection"
-      ],
-      "name" : "HGNCMultipleGenes",
-      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::HGNCMultipleGenes"
    },
    "HGNCNumeric" : {
       "datacheck_type" : "critical",


### PR DESCRIPTION
Refactor `HGNCMultipleGenes` into `CompareHGNCMultipleGenes`.

The new DC will fail only if the increase in HGNC symbols assigned to multiple genes compared to the previous release is above 5%.