### PR TITLE
Alternative compatibility for BINARY column schema

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSchema.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSchema.pm
@@ -151,6 +151,9 @@ sub normalise_table_def {
   $table =~ s/[^\)]+\Z//gm;
   $table =~ s/,\s*\)\Z/\n\)/m;
 
+  # Simplify alternative nomenclature for binary columns
+  $table =~ s/CHARACTER SET LATIN1 COLLATE LATIN1_BIN/BINARY/gm;
+
   # Key order can be variable, so extract into an ordered list.
   my @keys = $table =~ /^((?:PRIMARY |UNIQUE )*KEY.*),*/gm;
   foreach (@keys) {


### PR DESCRIPTION
### Description

During within-compara datachecks and following a schema change to distinguish `UNIQUE` columns with `BINARY` for case sensitivity it was flagged in `CompareSchema` that a different way of writing the schema is returned to the one provided in `table.sql` - which is again different to the one returned by `Travis` - so this is the easiest fix to ensure consistency. The two different ways of writing it are otherwise equivalent.

### Testing

This has been tested on the current e107 Metazoa compara release database with the current compara `table.sql` schema fllowing initial failure (see below), and this fixes the issue.

```
#          $got->{gene_member_qc}{table} = 'CREATE TABLE gene_member_qc (
--
#     gene_member_stable_id VARCHAR(128) CHARACTER SET LATIN1 COLLATE LATIN1_BIN NOT NULL,
#     genome_db_id INT UNSIGNED NOT NULL,
#     seq_member_id INT UNSIGNED,
#     n_species INT,
#     n_orth INT,
#     avg_cov FLOAT,
#     status VARCHAR(50) NOT NULL,
#     )'
#     $expected->{gene_member_qc}{table} = 'CREATE TABLE gene_member_qc (
#     gene_member_stable_id VARCHAR(128) BINARY NOT NULL,
#     genome_db_id INT UNSIGNED NOT NULL,
#     seq_member_id INT UNSIGNED,
#     n_species INT,
#     n_orth INT,
#     avg_cov FLOAT,
#     status VARCHAR(50) NOT NULL,
#     )'
```