### PR TITLE
Fix race condition for fan-funnel jobs

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/RunDataChecks.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/RunDataChecks.pm
@@ -156,7 +156,6 @@ sub write_output {
     output_file        => $self->param('output_file'),
   };
 
-  $self->dataflow_output_id($summary, 1);
 
   foreach my $datacheck ( @{$self->param('datachecks')} ) {
     # It's not possible to pass the dba parameter to another module;
@@ -180,6 +179,8 @@ sub write_output {
       $self->dataflow_output_id($output, 4);
     }
   }
+
+  $self->dataflow_output_id($summary, 1);
 }
 
 sub datacheck_params {


### PR DESCRIPTION
When running the data checks after the xref pipeline, the following error was appearing, though not every time:
"The group of semaphored jobs is incomplete ! Some fan jobs (coming from dataflow_rule_id(s) Bio::EnsEMBL::Hive::DataflowRule=HASH(0x6a0ac10)) are missing a job on their funnel."

This happens due to setting the dataflow output id for branch #1 (funnel) before entering the loop for creating jobs (fan) and setting the dataflow output id for other branches (#3 and #4).

This fix doesn't affect the flow of the code or the jobs so it shouldn't have negative impacts.
Tests were run and they are succeeding.