### PR TITLE
new datacheck added to check meta key strain group for rapid release …

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesStrainGroup.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesStrainGroup.pm
@@ -1,0 +1,53 @@
+=head1 LICENSE
+
+Copyright [2018-2022] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::SpeciesStrainGroup;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'SpeciesStrainGroup',
+  DESCRIPTION    => 'Disallow Species Strain Group Meta Key',
+  GROUPS         => ['rapid_release'],
+  DATACHECK_TYPE => 'critical',
+  DB_TYPES       => ['core'],
+  TABLES         => ['meta']
+};
+
+sub tests {
+  my ($self) = @_;
+
+  my $mca = $self->dba->get_adaptor("MetaContainer");
+
+  # Check if species.strain_group exists in meta table 
+
+  my $desc = "Disallow species strain group";
+  my $species_strain_group = $mca->single_value_by_key('species.strain_group');
+
+  ok( ! defined $species_strain_group, $desc);
+
+}
+
+1;
+

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2388,6 +2388,15 @@
       "name" : "SpeciesNameUnique",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SpeciesNameUnique"
    },
+   "SpeciesStrainGroup" : {
+      "datacheck_type" : "critical",
+      "description" : "Disallow Species Strain Group Meta Key",
+      "groups" : [
+         "rapid_release"
+      ],
+      "name" : "SpeciesStrainGroup",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SpeciesStrainGroup"
+   },
    "SpeciesTaxonomy" : {
       "datacheck_type" : "critical",
       "description" : "Taxonomic meta keys are consistent with taxonomy database",


### PR DESCRIPTION
Disallow species.strain_group meta key in core dbs for rapid release 