### PR TITLE
added exception for stable id prefix

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConsistent.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConsistent.pm
@@ -99,6 +99,7 @@ sub consistent_meta_keys {
     WHERE
       meta_key LIKE 'species.%' AND
       meta_key <> 'species.biomart_dataset' AND
+      meta_key <> 'species.stable_id_prefix' AND
       species_id = $species_id
     ORDER BY
       meta_key_value_pair


### PR DESCRIPTION
The  otherfeatures db usually has RefSeq import with its own stable id prefix or cDNA without the stable id, the stable id prefix meta key if present follows the one the core db. In the new genebuild pipeline the otherfeature db  hasn't the same stable id prefix that is present in the core db because the annotation is provided by Braker. So we have two stable is prefix.
Will it cause any issue for Production/Web? 
Can we add an exception for the stable id prefix in order to pass the  DCs?