### PR TITLE
Added new param shout_db_not_found_in_registry

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Pipeline/DbDataChecks_conf.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Pipeline/DbDataChecks_conf.pm
@@ -198,6 +198,7 @@ sub pipeline_analyses {
     {
       -logic_name        => 'DbFactory',
       -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::DbFactory',
+      -shout_db_not_found_in_registry => 1,
       -analysis_capacity => 10,
       -max_retry_count   => 0,
       -flow_into         => {


### PR DESCRIPTION
Production  module DbFactory list the dbname for given species list. If dbname not found in registry file pipeline wont result in failure.
This new param  shout_db_not_found_in_registry  helps to set the pipeline status to fail when dbs not found in registry.