### PR TITLE
New compara gene tree specific pipeline group

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankEnums.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankEnums.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'BlankEnums',
   DESCRIPTION => 'Enum columns do not have empty string values',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_blastocyst', 'compara_gene_trees', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_blastocyst', 'compara_gene_trees', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'compara_gene_tree_pipelines', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'BlankNulls',
   DESCRIPTION => 'Nullable columns do not have empty string values',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_blastocyst', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_blastocyst', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'compara_gene_tree_pipelines', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckCAFETable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckCAFETable.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckCAFETable',
   DESCRIPTION    => 'Each row should show a one-to-many relationship',
-  GROUPS         => ['compara', 'compara_gene_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_gene_tree_pipelines'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['cafe_species_gene']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckComparaStableIDs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckComparaStableIDs.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckComparaStableIDs',
   DESCRIPTION    => 'gene trees in gene_tree_root and family all have stable_ids generated',
-  GROUPS         => ['compara', 'compara_gene_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_gene_tree_pipelines'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['family', 'gene_tree_root']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckEmptyLeavesTrees.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckEmptyLeavesTrees.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckEmptyLeavesTrees',
   DESCRIPTION    => 'Check that none of the gene tree leaves have children',
-  GROUPS         => ['compara', 'compara_gene_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_gene_tree_pipelines'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['gene_tree_node']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckFlatProteinTrees.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckFlatProteinTrees.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckFlatProteinTrees',
   DESCRIPTION    => 'Check protein tree integrity ensuring number of leaves with parent node at root < 3',
-  GROUPS         => ['compara', 'compara_gene_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_gene_tree_pipelines'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['gene_tree_node', 'gene_tree_root']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGeneGainLossData.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGeneGainLossData.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckGeneGainLossData',
   DESCRIPTION    => 'ncRNA and protein trees must have gene Gain/Loss trees',
-  GROUPS         => ['compara', 'compara_gene_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_gene_tree_pipelines'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['CAFE_gene_family', 'gene_tree_root']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGeneTreeRootMLSS.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGeneTreeRootMLSS.pm
@@ -32,7 +32,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckGeneTreeRootMLSS',
   DESCRIPTION    => 'The expected number of gene_tree_root MLSSs are present',
-  GROUPS         => ['compara', 'compara_gene_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_gene_tree_pipelines'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['method_link_species_set', 'gene_tree_root']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomology.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomology.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckHomology',
   DESCRIPTION    => 'Check homology_id are all one-to-many for homology_members',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_homology_annotation', 'compara_blastocyst'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_homology_annotation', 'compara_blastocyst', 'compara_gene_tree_pipelines'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['homology', 'homology_member']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomologyMLSS.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomologyMLSS.pm
@@ -32,7 +32,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckHomologyMLSS',
   DESCRIPTION    => 'The expected number of homologys MLSSs are present',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_homology_annotation', 'compara_blastocyst'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_homology_annotation', 'compara_blastocyst', 'compara_gene_tree_pipelines'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['method_link_species_set', 'homology']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckJSONObjects.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckJSONObjects.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckJSONObjects',
   DESCRIPTION    => 'Check that all JSON objects in gene_tree_object_store are valid',
-  GROUPS         => ['compara', 'compara_gene_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_gene_tree_pipelines'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['gene_tree_object_store']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckOrthologyQCThresholds.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckOrthologyQCThresholds.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckOrthologyQCThresholds',
   DESCRIPTION    => 'Check that some wga_coverage and goc_score thresholds have been populated',
-  GROUPS         => ['compara', 'compara_gene_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_gene_tree_pipelines'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['method_link_species_set_attr']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSequenceTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSequenceTable.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckSequenceTable',
   DESCRIPTION    => 'Check for sequence length and availability',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_references', 'compara_homology_annotation', 'compara_blastocyst'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_references', 'compara_homology_annotation', 'compara_blastocyst', 'compara_gene_tree_pipelines'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['sequence']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesTreeNodeAttr.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesTreeNodeAttr.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckSpeciesTreeNodeAttr',
   DESCRIPTION    => 'Check some entries in species_tree_node_attr are > 0',
-  GROUPS         => ['compara', 'compara_gene_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_gene_tree_pipelines'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['species_tree_node_attr', 'species_tree_root']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesTrees.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesTrees.pm
@@ -32,7 +32,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CheckSpeciesTrees',
   DESCRIPTION    => 'The expected number of species trees have been merged',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_gene_tree_pipelines'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['method_link_species_set', 'species_set', 'species_tree_root']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CigarCheck.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CigarCheck.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CigarCheck',
   DESCRIPTION    => 'The cigar_line must not have negative numbers or zeros in it',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_homology_annotation', 'compara_blastocyst'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_homology_annotation', 'compara_blastocyst', 'compara_gene_tree_pipelines'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['family_member', 'gene_align_member', 'genomic_align', 'homology_member', 'peptide_align_feature'],

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/HighConfidence.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/HighConfidence.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'HighConfidence',
   DESCRIPTION    => 'Checks that the HighConfidenceOrthologs pipeline has been run',
-  GROUPS         => ['compara', 'compara_gene_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_gene_tree_pipelines'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['homology']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagHomology.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagHomology.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'MLSSTagHomology',
   DESCRIPTION => 'Homologies have appropriate tags',
-  GROUPS      => ['compara', 'compara_gene_trees'],
+  GROUPS      => ['compara', 'compara_gene_trees', 'compara_gene_tree_pipelines'],
   DB_TYPES    => ['compara'],
   TABLES      => ['method_link', 'method_link_species_set', 'method_link_species_set_tag']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagThresholdDs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagThresholdDs.pm
@@ -32,7 +32,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'MLSSTagThresholdDs',
   DESCRIPTION => 'Threshold values for ds exist, if appropriate',
-  GROUPS      => ['compara', 'compara_gene_trees'],
+  GROUPS      => ['compara', 'compara_gene_trees', 'compara_gene_tree_pipelines'],
   DB_TYPES    => ['compara'],
   TABLES      => ['method_link', 'method_link_species_set', 'method_link_species_set_attr']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MemberProductionCounts.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MemberProductionCounts.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'MemberProductionCounts',
   DESCRIPTION    => 'Checks that the gene_member counts are appropriately populated',
-  GROUPS         => ['compara', 'compara_gene_trees'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_gene_tree_pipelines'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['CAFE_gene_family', 'family', 'gene_member', 'gene_member_hom_stats', 'gene_tree_root', 'genome_db']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/NoDataOnGenomeComponents.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/NoDataOnGenomeComponents.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'NoDataOnGenomeComponents',
   DESCRIPTION    => 'Data is only allowed on principle genomes and not components',
-  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_syntenies', 'compara_homology_annotation', 'compara_blastocyst'],
+  GROUPS         => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_syntenies', 'compara_homology_annotation', 'compara_blastocyst', 'compara_gene_tree_pipelines'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['constrained_element', 'dnafrag', 'dnafrag_region', 'gene_member', 'genome_db', 'genomic_align', 'seq_member']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/UniqueKeysCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/UniqueKeysCompara.pm
@@ -32,7 +32,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'UniqueKeysCompara',
   DESCRIPTION => 'Unique key relationships are not violated',
-  GROUPS      => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies'],
+  GROUPS      => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_gene_tree_pipelines'],
   DB_TYPES    => ['compara'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -164,6 +164,7 @@
          "compara_syntenies",
          "compara_references",
          "compara_homology_annotation",
+         "compara_gene_tree_pipelines",
          "core",
          "corelike",
          "funcgen",
@@ -187,6 +188,7 @@
          "compara_syntenies",
          "compara_references",
          "compara_homology_annotation",
+         "compara_gene_tree_pipelines",
          "core",
          "corelike",
          "funcgen",
@@ -223,7 +225,8 @@
       "description" : "Each row should show a one-to-many relationship",
       "groups" : [
          "compara",
-         "compara_gene_trees"
+         "compara_gene_trees",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "CheckCAFETable",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckCAFETable"
@@ -233,7 +236,8 @@
       "description" : "gene trees in gene_tree_root and family all have stable_ids generated",
       "groups" : [
          "compara",
-         "compara_gene_trees"
+         "compara_gene_trees",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "CheckComparaStableIDs",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckComparaStableIDs"
@@ -289,7 +293,8 @@
       "description" : "Check that none of the gene tree leaves have children",
       "groups" : [
          "compara",
-         "compara_gene_trees"
+         "compara_gene_trees",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "CheckEmptyLeavesTrees",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckEmptyLeavesTrees"
@@ -309,7 +314,8 @@
       "description" : "Check protein tree integrity ensuring number of leaves with parent node at root < 3",
       "groups" : [
          "compara",
-         "compara_gene_trees"
+         "compara_gene_trees",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "CheckFlatProteinTrees",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckFlatProteinTrees"
@@ -329,7 +335,8 @@
       "description" : "ncRNA and protein trees must have gene Gain/Loss trees",
       "groups" : [
          "compara",
-         "compara_gene_trees"
+         "compara_gene_trees",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "CheckGeneGainLossData",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckGeneGainLossData"
@@ -339,7 +346,8 @@
       "description" : "The expected number of gene_tree_root MLSSs are present",
       "groups" : [
          "compara",
-         "compara_gene_trees"
+         "compara_gene_trees",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "CheckGeneTreeRootMLSS",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckGeneTreeRootMLSS"
@@ -391,7 +399,8 @@
          "compara",
          "compara_gene_trees",
          "compara_homology_annotation",
-         "compara_blastocyst"
+         "compara_blastocyst",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "CheckHomology",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckHomology"
@@ -403,7 +412,8 @@
          "compara",
          "compara_gene_trees",
          "compara_homology_annotation",
-         "compara_blastocyst"
+         "compara_blastocyst",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "CheckHomologyMLSS",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckHomologyMLSS"
@@ -424,7 +434,8 @@
       "description" : "Check that all JSON objects in gene_tree_object_store are valid",
       "groups" : [
          "compara",
-         "compara_gene_trees"
+         "compara_gene_trees",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "CheckJSONObjects",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckJSONObjects"
@@ -515,7 +526,8 @@
       "description" : "Check that some wga_coverage and goc_score thresholds have been populated",
       "groups" : [
          "compara",
-         "compara_gene_trees"
+         "compara_gene_trees",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "CheckOrthologyQCThresholds",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckOrthologyQCThresholds"
@@ -564,7 +576,8 @@
          "compara_gene_trees",
          "compara_references",
          "compara_homology_annotation",
-         "compara_blastocyst"
+         "compara_blastocyst",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "CheckSequenceTable",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckSequenceTable"
@@ -603,7 +616,8 @@
       "description" : "Check some entries in species_tree_node_attr are > 0",
       "groups" : [
          "compara",
-         "compara_gene_trees"
+         "compara_gene_trees",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "CheckSpeciesTreeNodeAttr",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckSpeciesTreeNodeAttr"
@@ -614,7 +628,8 @@
       "groups" : [
          "compara",
          "compara_gene_trees",
-         "compara_genome_alignments"
+         "compara_genome_alignments",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "CheckSpeciesTrees",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CheckSpeciesTrees"
@@ -677,7 +692,8 @@
          "compara_gene_trees",
          "compara_genome_alignments",
          "compara_homology_annotation",
-         "compara_blastocyst"
+         "compara_blastocyst",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "CigarCheck",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CigarCheck"
@@ -1581,7 +1597,8 @@
       "description" : "Checks that the HighConfidenceOrthologs pipeline has been run",
       "groups" : [
          "compara",
-         "compara_gene_trees"
+         "compara_gene_trees",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "HighConfidence",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::HighConfidence"
@@ -1639,7 +1656,8 @@
       "description" : "Homologies have appropriate tags",
       "groups" : [
          "compara",
-         "compara_gene_trees"
+         "compara_gene_trees",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "MLSSTagHomology",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MLSSTagHomology"
@@ -1689,7 +1707,8 @@
       "description" : "Threshold values for ds exist, if appropriate",
       "groups" : [
          "compara",
-         "compara_gene_trees"
+         "compara_gene_trees",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "MLSSTagThresholdDs",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MLSSTagThresholdDs"
@@ -1719,7 +1738,8 @@
       "description" : "Checks that the gene_member counts are appropriately populated",
       "groups" : [
          "compara",
-         "compara_gene_trees"
+         "compara_gene_trees",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "MemberProductionCounts",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MemberProductionCounts"
@@ -1916,7 +1936,8 @@
          "compara_genome_alignments",
          "compara_syntenies",
          "compara_homology_annotation",
-         "compara_blastocyst"
+         "compara_blastocyst",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "NoDataOnGenomeComponents",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::NoDataOnGenomeComponents"
@@ -2499,7 +2520,8 @@
          "compara_gene_trees",
          "compara_genome_alignments",
          "compara_master",
-         "compara_syntenies"
+         "compara_syntenies",
+         "compara_gene_tree_pipelines"
       ],
       "name" : "UniqueKeysCompara",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::UniqueKeysCompara"


### PR DESCRIPTION
## Description

In order to improve compara processing efficiency and quality control of gene tree and homology data we have decided to integrate datachecks into the gene tree pipelines. Here I propose a new group: `compara_gene_tree_pipelines`, which has been tested on gene tree data as DCs that are expected to pass.
Compara use eHive pipeline databases to store our data before we copy the necessary data into a release database. This datacheck group is a subset of the `compara_gene_trees` group with datachecks removed that are not applicable to gene tree pipeline databases.

This DC group has been tested on a gene tree pipeline.