### PR TITLE
Prefix check for stable_ids in compara gene trees

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckComparaStableIDs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckComparaStableIDs.pm
@@ -55,7 +55,29 @@ sub tests {
         AND stable_id IS NULL
   /;
   is_rows_zero($self->dba, $sql_2, $desc_2);
-  
+
+  my %prefixes = (
+    "vertebrates" => "ENSGT",
+    "plants"      => "EPIGT",
+    "pan"         => "EGGT0",
+    "metazoa"     => "EMGT0",
+    "protists"    => "EPrGT",
+    "fungi"       => "EFGT0"
+  );
+
+  my $division = $self->dba->get_division();
+  my $prefix = $prefixes{$division};
+
+  my $desc_3 = "There is a single consistent stable_id prefix for all gene trees";
+  my $sql_3 = qq/
+    SELECT * FROM gene_tree_root
+      WHERE member_type = 'protein'
+        AND tree_type = 'tree'
+        AND clusterset_id =  "default"
+        AND LEFT(stable_id, 5) != "$prefix"
+  /;
+  is_rows_zero($self->dba, $sql_3, $desc_3);
+
 }
 
 1;


### PR DESCRIPTION
### Description
For e105 there was some difficulty with gene tree `stable_id`s and `stable_id_history` mapping. This has been manually repaired, but it was flagged that there was some old legacy-created and painful edge-case nomenclature producing ugly `stable_ids` which did not follow the idea prefixes for gene trees. This check only checks the `"default"` `tree` tree-type trees that are expected to have this nomenclature. The `supertrees` are generally `PTHR` and are excepted in this case, and non-`default` trees are not expected to contain the prefix either, for example cultivars and strains trees follow a different nomenclature for gene tree `stable_id`.

### Tests
Below is the expected output following correction of the data
```
CheckComparaStableIDs .. 
# Subtest: CheckComparaStableIDs
    # Subtest: multi, compara, twalsh_default_fungi_protein_trees_108, multi
        ok 1 - There are no NULL stable_ids in family
        ok 2 - There are no NULL stable_ids for gene trees in gene_tree_root
        ok 3 - There is a single consistent stable_id prefix for all gene trees
        1..3
    ok 1 - multi, compara, twalsh_default_fungi_protein_trees_108, multi
    1..1
ok 1 - CheckComparaStableIDs
1..1
ok
All tests successful.
Files=1, Tests=1,  3 wallclock secs ( 0.05 usr +  0.01 sys =  0.06 CPU)
Result: PASS
```