### PR TITLE
Changes to support EVA datachecks

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/VariationClasses.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/VariationClasses.pm
@@ -24,6 +24,7 @@ use strict;
 use Moose;
 use Test::More;
 use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+use Bio::EnsEMBL::DataCheck::Utils qw/sql_count/;
 
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
@@ -53,8 +54,15 @@ sub tests {
     /;
     cmp_rows($self->dba, $sql_hgmd, '>', 1, 'Number of variation classes is correct for source HGMD');
   } 
+  my $eva_sql = qq(
+    SELECT COUNT(source_id)
+    FROM source
+    WHERE source.name='EVA';
+    );
+  my $count = sql_count($self->dba, $eva_sql);
+  $self->checkClassAttrib('EVA', 'Number of variation classes is correct for source EVA') if ($count == 1);
 
-  $self->checkClassAttrib('dbSNP', 'Number of variation classes is correct for source dbSNP');
+  $self->checkClassAttrib('dbSNP', 'Number of variation classes is correct for source dbSNP') if (!$count);
 
 }
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/VariationClasses.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/VariationClasses.pm
@@ -60,9 +60,11 @@ sub tests {
     WHERE source.name='EVA';
     );
   my $count = sql_count($self->dba, $eva_sql);
-  $self->checkClassAttrib('EVA', 'Number of variation classes is correct for source EVA') if ($count == 1);
-
-  $self->checkClassAttrib('dbSNP', 'Number of variation classes is correct for source dbSNP') if (!$count);
+  if(!$count) {
+  $self->checkClassAttrib('dbSNP', 'Number of variation classes is correct for source dbSNP');
+  } else {
+  $self->checkClassAttrib('EVA', 'Number of variation classes is correct for source EVA');
+}
 
 }
 


### PR DESCRIPTION
[ENSVAR-5000](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5000)
This datacheck is intended to make sure VariationClasses check is done based on the source of the variants.
The idea is if EVA is present in the source table then import was done using EVA so only EVA checks, if not present dbSNP check is done.