### PR TITLE
add skip repeat features for projection builds, e.g. human haplotypes

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
@@ -49,6 +49,11 @@ sub tests {
       skip "Repeat features not mandatory for viruses", 1;
     }
 
+    if($mc->single_value_by_key('genebuild.method') eq 'projection_build') {
+      skip "Repeat features not mandatory for projection builds", 1;
+    }
+
+    
     # Don't need to worry about species_id, because we don't do this
     # query for collection dbs...
     my @logic_names = ('dust', 'trf');

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
@@ -49,7 +49,7 @@ sub tests {
       skip "Repeat features not mandatory for viruses", 1;
     }
 
-    if($mc->single_value_by_key('genebuild.method') eq 'projection_build') {
+    if($mca->single_value_by_key('genebuild.method') eq 'projection_build') {
       skip "Repeat features not mandatory for projection builds", 1;
     }
 


### PR DESCRIPTION
Repeat analyses are not run on projection builds, so necessary to skip this test for those with genebuild.method=>'projection_build'