### PR TITLE
For projection builds: Allow up to 100 gene with without a transcript that has a matching biotype

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBiotypes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBiotypes.pm
@@ -136,9 +136,18 @@ sub biotype_groups {
     }
   }
 
-  my $desc_1 = 'genes have at least one transcript with a matching biotype group';
-  is(scalar(@group_mismatch), 0, $desc_1);
-
+  my $mca = $self->dba->get_adaptor('MetaContainer');
+  if($mca->single_value_by_key('genebuild.method') eq 'projection_build'){
+      if (scalar(@group_mismatch) > 100){
+	  my $desc_proj = 'genes have at least one transcript with a matching biotype group';
+	  is(scalar(@group_mismatch), 100, $desc_proj);
+      }
+  }
+  else {
+      my $desc_1 = 'genes have at least one transcript with a matching biotype group';
+      is(scalar(@group_mismatch), 0, $desc_1);
+  }
+  
   my $desc_2 = '"pseudogene" genes do not have coding transcripts';
   is(scalar(@pseudogene_mismatch), 0, $desc_2);
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBiotypes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBiotypes.pm
@@ -139,7 +139,7 @@ sub biotype_groups {
   my $mca = $self->dba->get_adaptor('MetaContainer');
   if($mca->single_value_by_key('genebuild.method') eq 'projection_build'){
       if (scalar(@group_mismatch) > 100){
-	  my $desc_proj = 'genes have at least one transcript with a matching biotype group';
+	  my $desc_proj = 'found no more that 100 genes with mismatched transcript biotype groups';
 	  is(scalar(@group_mismatch), 100, $desc_proj);
       }
   }


### PR DESCRIPTION
To allow for human projections to pass DCs we need to allow a small number of genes to have transcripts that have different biotypes