### PR TITLE
Fixed typo in stanble ID prefix in CheckComparaStableIDs.

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckComparaStableIDs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckComparaStableIDs.pm
@@ -58,7 +58,7 @@ sub tests {
 
   my %prefixes = (
     "vertebrates" => "ENSGT",
-    "plants"      => "EPIGT",
+    "plants"      => "EPlGT",
     "pan"         => "EGGT0",
     "metazoa"     => "EMGT0",
     "protists"    => "EPrGT",


### PR DESCRIPTION
There was a typo in the plants stable ID prefix in the CheckComparaStableIDs check.