### PR TITLE
Update/check annotation source

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AnnotationSource.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AnnotationSource.pm
@@ -1,0 +1,56 @@
+=head1 LICENSE
+Copyright [2018-2022] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::AnnotationSource;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'AnnotationSource',
+  DESCRIPTION    => 'If present, the annotation_source meta key must be from an approved list',
+  GROUPS         => ['rapid_release'],
+  DATACHECK_TYPE => 'critical',
+  DB_TYPES       => ['core'],
+  TABLES         => ['meta']
+};
+sub tests{
+  my ($self) = @_;
+  
+  my $mca = $self->dba->get_adaptor('MetaContainer');
+  
+ SKIP: {
+     my $method = $mca->single_value_by_key('genebuild.method');
+     if($method ne 'braker' && $method ne 'import') {
+         skip "Annotation source key not needed for Ensembl builds", 1;
+     }
+
+     my $desc = "'species.annotation_source' meta_key exists";
+     my $annotation_source = lc($mca->single_value_by_key('species.annotation_source'));
+     ok($annotation_source, $desc);
+
+     my $sources = 'braker|genbank|refseq|community|flybase|wormbase|veupathdb|noninsdc';
+     my $source_desc = "Source is allowed";
+
+     skip 'species.annotation_source meta key does not exist', 1 unless defined $annotation_source;
+
+     like($annotation_source, qr/^$sources$/, $source_desc);
+  }
+
+
+}

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AnnotationSource.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AnnotationSource.pm
@@ -36,7 +36,7 @@ sub tests{
   
  SKIP: {
      my $method = $mca->single_value_by_key('genebuild.method');
-     if($method ne 'braker' && $method ne 'import') {
+     if($method ne 'braker' && $method ne 'import' && $method ne 'external_annotation_import''') {
          skip "Annotation source key not needed for Ensembl builds", 1;
      }
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AnnotationSource.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AnnotationSource.pm
@@ -36,7 +36,7 @@ sub tests{
   
  SKIP: {
      my $method = $mca->single_value_by_key('genebuild.method');
-     if($method ne 'braker' && $method ne 'import' && $method ne 'external_annotation_import''') {
+     if($method ne 'braker' && $method ne 'import' && $method ne 'external_annotation_import') {
          skip "Annotation source key not needed for Ensembl builds", 1;
      }
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
@@ -271,7 +271,7 @@ sub annotation_source{
      }
      
      my $desc = "'species.annotation_source' meta_key exists";
-     my $annotation_source = $mca->single_value_by_key('species.annotation_source');
+     my $annotation_source = lc($mca->single_value_by_key('species.annotation_source'));
      ok($annotation_source, $desc);
      
      my $sources = 'braker|genbank|refseq|community|flybase|wormbase|veupathdb|noninsdc';

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
@@ -47,7 +47,6 @@ sub tests {
     $self->projected_transcripts();
     $self->repeat_analysis();
     $self->strain_type();
-    $self->annotation_source();
   } elsif ($self->dba->group eq 'variation') {
     $self->has_polyphen();
     $self->has_sift();
@@ -257,32 +256,6 @@ sub has_sift {
     my $values = $mca->list_value_by_key('sift_version');
     ok(scalar @$values, $desc);
   }
-}
-
-sub annotation_source{
-  my ($self) = @_;
-
-  my $mca = $self->dba->get_adaptor('MetaContainer');
-
- SKIP: {
-     my $method = $mca->single_value_by_key('genebuild.method');
-     if($method ne 'braker' && $method ne 'import') {
-	 skip "Annotation source key not needed for Ensembl builds", 1;
-     }
-     
-     my $desc = "'species.annotation_source' meta_key exists";
-     my $annotation_source = lc($mca->single_value_by_key('species.annotation_source'));
-     ok($annotation_source, $desc);
-     
-     my $sources = 'braker|genbank|refseq|community|flybase|wormbase|veupathdb|noninsdc';
-     my $source_desc = "Source is allowed";
-     
-     skip 'species.annotation_source meta key does not exist', 1 unless defined $annotation_source;
-
-     like($annotation_source, qr/^$sources$/, $source_desc);
-  }
-
-  
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
@@ -47,6 +47,7 @@ sub tests {
     $self->projected_transcripts();
     $self->repeat_analysis();
     $self->strain_type();
+    $self->annotation_source();
   } elsif ($self->dba->group eq 'variation') {
     $self->has_polyphen();
     $self->has_sift();
@@ -256,6 +257,32 @@ sub has_sift {
     my $values = $mca->list_value_by_key('sift_version');
     ok(scalar @$values, $desc);
   }
+}
+
+sub annotation_source{
+  my ($self) = @_;
+
+  my $mca = $self->dba->get_adaptor('MetaContainer');
+
+ SKIP: {
+     my $method = $mca->single_value_by_key('genebuild.method');
+     if($method ne 'braker' && $method ne 'import') {
+	 skip "Annotation source key not needed for Ensembl builds", 1;
+     }
+     
+     my $desc = "'species.annotation_source' meta_key exists";
+     my $annotation_source = $mca->single_value_by_key('species.annotation_source');
+     ok($annotation_source, $desc);
+     
+     my $sources = 'braker|genbank|refseq|community|flybase|wormbase|veupathdb|noninsdc';
+     my $source_desc = "Source is allowed";
+     
+     skip 'species.annotation_source meta key does not exist', 1 unless defined $annotation_source;
+
+     like($annotation_source, qr/^$sources$/, $source_desc);
+  }
+
+  
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -115,6 +115,15 @@
       "name" : "AnalysisWebDataFormat",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::AnalysisWebDataFormat"
    },
+   "AnnotationSource" : {
+      "datacheck_type" : "critical",
+      "description" : "If present, the annotation_source meta key must be from an approved list",
+      "groups" : [
+         "rapid_release"
+      ],
+      "name" : "AnnotationSource",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::AnnotationSource"
+   },
    "Archive" : {
       "datacheck_type" : "critical",
       "description" : "Gene archive table is up to date",


### PR DESCRIPTION
If genebuild method is 'braker' or 'import' (@vsitnik any others should be included) will check for existence of species.annotation_source meta key and will check that value is in allowed list ('braker|genbank|refseq|community|flybase|wormbase|veupathdb|noninsdc' - note I lowercase the value before checking since that's what Production and Web plan to do with it)

Tested on Human db (all passed - skips test)
`perl /hps/software/users/ensembl/repositories/leanne/ensembl-datacheck/scripts/run_datachecks.pl -host mysql-ens-genebuild-prod-1 -port 4527 -u ensro -dbn homo_sapiens_gca018471065v1_core_107_1 -dbt core -n MetaKeyConditional`
Tested on Braker db (all passed, meta key exists and value = 'braker')
`perl /hps/software/users/ensembl/repositories/leanne/ensembl-datacheck/scripts/run_datachecks.pl -host mysql-ens-genebuild-prod-2 -port 4528 -u ensro -dbn leanne_epicampocera_succincta_gca932527255v1_core_108_1 -dbt core -n MetaKeyConditional`