### PR TITLE
Add tBLAT to known methods in CheckGenomicAlignments

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignments.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignments.pm
@@ -41,7 +41,7 @@ sub skip_tests {
   my ($self) = @_;
   my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
 
-  my @method_links = qw(LASTZ_NET LASTZ_PATCH EPO EPO_EXTENDED PECAN POLYPLOID);
+  my @method_links = qw(LASTZ_NET LASTZ_PATCH EPO EPO_EXTENDED PECAN POLYPLOID TRANSLATED_BLAT_NET);
   my @mlsss;
   foreach my $method (@method_links) {
     my $mlss = $mlss_adap->fetch_all_by_method_link_type($method);
@@ -59,7 +59,7 @@ sub tests {
   my ($self) = @_;
   my $dba    = $self->dba;
   my $helper = $dba->dbc->sql_helper;
-  my @method_links = qw(LASTZ_NET LASTZ_PATCH EPO EPO_EXTENDED PECAN POLYPLOID);
+  my @method_links = qw(LASTZ_NET LASTZ_PATCH EPO EPO_EXTENDED PECAN POLYPLOID TRANSLATED_BLAT_NET);
 
   my $expected_align_count;
   my @tables    = qw(genomic_align genomic_align_block);


### PR DESCRIPTION
In Ensembl Protists Compara 109, there are 121 `TRANSLATED_BLAT_NET` MLSSes with genomic alignment data, but this method type is not in the `@method_links` array of known genomic alignment methods in the `CheckGenomicAlignments` datacheck, so the DC fails even though all the genomic alignment rows are associated with a known alignment method. This PR adds `TRANSLATED_BLAT_NET` to the array of known genomic alignment methods, allowing the datacheck to support alignments of this type.