### PR TITLE
New DC group xref_gene_symbol_transformer to allow for gene name duplication

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareGOXref.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareGOXref.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CompareGOXref',
   DESCRIPTION    => 'Compare GO xref counts between two databases, categorised by source',
-  GROUPS         => ['compare_core', 'xref', 'xref_go_projection'],
+  GROUPS         => ['compare_core', 'xref', 'xref_gene_symbol_transformer', 'xref_go_projection'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['core']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareProjectedGOXrefs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareProjectedGOXrefs.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CompareProjectedGOXrefs',
   DESCRIPTION    => 'Compare GO xref counts between two databases, categorised by source coming from the info_type',
-  GROUPS         => ['compare_core', 'xref', 'xref_go_projection'],
+  GROUPS         => ['compare_core', 'xref', 'xref_gene_symbol_transformer', 'xref_go_projection'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['core'],
   TABLES         => ['xref']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareProjectedGeneNames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareProjectedGeneNames.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CompareProjectedGeneNames',
   DESCRIPTION    => 'Compare Projected Gene Name counts between two databases',
-  GROUPS         => ['compare_core', 'xref', 'xref_name_projection'],
+  GROUPS         => ['compare_core', 'xref', 'xref_gene_symbol_transformer', 'xref_name_projection'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['core'],
   TABLES         => ['xref','gene','object_xref','seq_region','coord_system']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareProjectedSynonyms.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareProjectedSynonyms.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CompareProjectedSynonyms',
   DESCRIPTION    => 'Compare Projected Synonyms counts between two databases, categorised by db_name coming from the external_db',
-  GROUPS         => ['compare_core', 'xref', 'xref_name_projection'],
+  GROUPS         => ['compare_core', 'xref', 'xref_gene_symbol_transformer', 'xref_name_projection'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['core'],
   TABLES         => ['xref','external_db','external_synonym','object_xref']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSynonym.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSynonym.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CompareSynonym',
   DESCRIPTION    => 'Compare synonym counts between two databases, categorised by external_db',
-  GROUPS         => ['compare_core', 'xref', 'xref_mapping'],
+  GROUPS         => ['compare_core', 'xref', 'xref_gene_symbol_transformer', 'xref_mapping'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['core']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareXref.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareXref.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'CompareXref',
   DESCRIPTION    => 'Compare xref counts between two databases, categorised by external_db',
-  GROUPS         => ['compare_core', 'xref', 'xref_mapping'],
+  GROUPS         => ['compare_core', 'xref', 'xref_gene_symbol_transformer', 'xref_mapping'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['core']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExists.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExists.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'DisplayXrefExists',
   DESCRIPTION    => 'At least one gene name exists',
-  GROUPS         => ['core', 'xref', 'xref_name_projection'],
+  GROUPS         => ['core', 'xref', 'xref_gene_symbol_transformer', 'xref_name_projection'],
   DATACHECK_TYPE => 'advisory',
   TABLES         => ['coord_system', 'gene', 'seq_region', 'transcript', 'xref'],
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefFormat.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefFormat.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'DisplayXrefFormat',
   DESCRIPTION    => 'Gene names are correctly formatted',
-  GROUPS         => ['core', 'xref', 'xref_mapping'],
+  GROUPS         => ['core', 'xref', 'xref_gene_symbol_transformer', 'xref_mapping'],
   DB_TYPES       => ['core'],
   TABLES         => ['coord_system', 'external_db', 'gene', 'seq_region', 'xref'],
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DuplicateXref.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DuplicateXref.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'DuplicateXref',
   DESCRIPTION    => 'Xrefs have been added twice with different descriptions or versions',
-  GROUPS         => ['core', 'xref', 'xref_mapping'],
+  GROUPS         => ['core', 'xref', 'xref_gene_symbol_transformer', 'xref_mapping'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['core'],
   TABLES         => ['xref'],

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GOXrefEvidence.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GOXrefEvidence.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'GOXrefEvidence',
   DESCRIPTION => 'All GO xrefs have an evidence',
-  GROUPS      => ['xref', 'core'],
+  GROUPS      => ['xref', 'xref_gene_symbol_transformer', 'core'],
   DB_TYPES    => ['core'],
   TABLES      => ['object_xref', 'ontology_xref', 'xref'],
   PER_DB      => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneDescriptions.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneDescriptions.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'GeneDescriptions',
   DESCRIPTION    => 'Gene descriptions are correctly formatted',
-  GROUPS         => ['core', 'xref', 'xref_mapping'],
+  GROUPS         => ['core', 'xref', 'xref_gene_symbol_transformer', 'xref_mapping'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['core'],
   TABLES         => ['coord_system', 'gene', 'seq_region']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/HGNCNumeric.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/HGNCNumeric.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'HGNCNumeric',
   DESCRIPTION => 'HGNC xrefs do not have the accession as the display_label',
-  GROUPS      => ['core', 'xref'],
+  GROUPS      => ['core', 'xref', 'xref_gene_symbol_transformer'],
   TABLES      => ['external_db', 'object_xref', 'xref'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/HGNCTypes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/HGNCTypes.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'HGNCTypes',
   DESCRIPTION => 'HGNC xrefs are attached to the appropriate object',
-  GROUPS      => ['core', 'xref'],
+  GROUPS      => ['core', 'xref', 'xref_gene_symbol_transformer'],
   TABLES      => ['external_db', 'object_xref', 'xref'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/NCBIGeneLabels.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/NCBIGeneLabels.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'NCBIGeneLabels',
   DESCRIPTION    => 'NCBI genes have display xrefs',
-  GROUPS         => ['corelike', 'xref'],
+  GROUPS         => ['corelike', 'xref', 'xref_gene_symbol_transformer'],
   DB_TYPES       => ['otherfeatures'],
   TABLES         => ['external_db', 'gene', 'object_xref', 'transcript', 'xref'],
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ObjectXrefNull.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ObjectXrefNull.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'ObjectXrefNull',
   DESCRIPTION    => 'Object_xrefs should be linked to an analysis',
-  GROUPS         => ['brc4_core', 'core', 'xref'],
+  GROUPS         => ['brc4_core', 'core', 'xref', 'xref_gene_symbol_transformer'],
   DATACHECK_TYPE => 'advisory',
   TABLES         => ['object_xref']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/StableIdDisplayXref.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/StableIdDisplayXref.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'StableIdDisplayXref',
   DESCRIPTION    => 'Genes/Transcript display_xref does not have display_label set as stable_id',
-  GROUPS         => ['core', 'xref', 'xref_mapping'],
+  GROUPS         => ['core', 'xref', 'xref_gene_symbol_transformer', 'xref_mapping'],
   DB_TYPES       => ['core'],
   TABLES         => ['gene','transcript','xref']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/TranscriptDisplayXrefSuffix.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/TranscriptDisplayXrefSuffix.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'TranscriptDisplayXrefSuffix',
   DESCRIPTION    => 'Transcripts do not have a display xref with a -20* suffix. These are created by the non-vert Xref pipeline unless a flag is enabled: http://www.ebi.ac.uk/seqdb/confluence/display/EnsGen/Xref+mapping#Xrefmapping-CustomisingXrefMapping(DisplayXrefs)',
-  GROUPS         => ['xref', 'core'],
+  GROUPS         => ['xref', 'xref_gene_symbol_transformer', 'core'],
   DB_TYPES       => ['core'],
   TABLES         => ['transcript', 'xref', 'object_xref','seq_region','coord_system'],
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/UniProtDisplayXref.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/UniProtDisplayXref.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'UniProtDisplayXref',
   DESCRIPTION    => 'Gene display xrefs are only attached to UniProtKB Gene Names (Uniprot_gn)',
-  GROUPS         => ['core', 'xref', 'xref_mapping'],
+  GROUPS         => ['core', 'xref', 'xref_gene_symbol_transformer', 'xref_mapping'],
   DB_TYPES       => ['core'],
   TABLES         => ['gene', 'xref', 'external_db','seq_region','coord_system'],
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/UnreviewedXrefs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/UnreviewedXrefs.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'UnreviewedXrefs',
   DESCRIPTION    => 'Uniprot xrefs do not have Unreviewed as their primary DB accession',
-  GROUPS         => ['core', 'xref', 'xref_mapping'],
+  GROUPS         => ['core', 'xref', 'xref_gene_symbol_transformer', 'xref_mapping'],
   DB_TYPES       => ['core'],
   TABLES         => ['xref','external_db'],
   PER_DB         => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/XrefFormat.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/XrefFormat.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'XrefFormat',
   DESCRIPTION    => 'Xref accessions, labels, and descriptions are validly formatted',
-  GROUPS         => ['core', 'xref', 'xref_mapping'],
+  GROUPS         => ['core', 'xref', 'xref_gene_symbol_transformer', 'xref_mapping'],
   DB_TYPES       => ['core'],
   TABLES         => ['identity_xref', 'xref'],
   PER_DB         => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/XrefPrefixes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/XrefPrefixes.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'XrefPrefixes',
   DESCRIPTION    => 'Check that xrefs have the correct prefix for their dbprimary_acc',
-  GROUPS         => ['core', 'xref', 'xref_mapping'],
+  GROUPS         => ['core', 'xref', 'xref_gene_symbol_transformer', 'xref_mapping'],
   DB_TYPES       => ['core'],
   TABLES         => ['xref', 'external_db'],
   PER_DB         => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/XrefTypes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/XrefTypes.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'XrefTypes',
   DESCRIPTION    => 'Xrefs are only attached to one feature type.',
-  GROUPS         => ['core', 'xref', 'xref_mapping'],
+  GROUPS         => ['core', 'xref', 'xref_gene_symbol_transformer', 'xref_mapping'],
   DB_TYPES       => ['core'],
   TABLES         => ['external_db', 'object_xref', 'xref'],
   PER_DB         => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -758,6 +758,7 @@
       "groups" : [
          "compare_core",
          "xref",
+         "xref_gene_symbol_transformer",
          "xref_go_projection"
       ],
       "name" : "CompareGOXref",
@@ -901,6 +902,7 @@
       "groups" : [
          "compare_core",
          "xref",
+         "xref_gene_symbol_transformer",
          "xref_go_projection"
       ],
       "name" : "CompareProjectedGOXrefs",
@@ -912,6 +914,7 @@
       "groups" : [
          "compare_core",
          "xref",
+         "xref_gene_symbol_transformer",
          "xref_name_projection"
       ],
       "name" : "CompareProjectedGeneNames",
@@ -923,6 +926,7 @@
       "groups" : [
          "compare_core",
          "xref",
+         "xref_gene_symbol_transformer",
          "xref_name_projection"
       ],
       "name" : "CompareProjectedSynonyms",
@@ -1005,6 +1009,7 @@
       "groups" : [
          "compare_core",
          "xref",
+         "xref_gene_symbol_transformer",
          "xref_mapping"
       ],
       "name" : "CompareSynonym",
@@ -1070,6 +1075,7 @@
       "groups" : [
          "compare_core",
          "xref",
+         "xref_gene_symbol_transformer",
          "xref_mapping"
       ],
       "name" : "CompareXref",
@@ -1288,6 +1294,7 @@
       "groups" : [
          "core",
          "xref",
+         "xref_gene_symbol_transformer",
          "xref_name_projection"
       ],
       "name" : "DisplayXrefExists",
@@ -1299,6 +1306,7 @@
       "groups" : [
          "core",
          "xref",
+         "xref_gene_symbol_transformer",
          "xref_mapping"
       ],
       "name" : "DisplayXrefFormat",
@@ -1366,6 +1374,7 @@
       "groups" : [
          "core",
          "xref",
+         "xref_gene_symbol_transformer",
          "xref_mapping"
       ],
       "name" : "DuplicateXref",
@@ -1544,6 +1553,7 @@
       "description" : "All GO xrefs have an evidence",
       "groups" : [
          "xref",
+         "xref_gene_symbol_transformer",
          "core"
       ],
       "name" : "GOXrefEvidence",
@@ -1590,6 +1600,7 @@
       "groups" : [
          "core",
          "xref",
+         "xref_gene_symbol_transformer",
          "xref_mapping"
       ],
       "name" : "GeneDescriptions",
@@ -1668,6 +1679,7 @@
       "groups" : [
          "core",
          "xref"
+         "xref_gene_symbol_transformer",
       ],
       "name" : "HGNCNumeric",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::HGNCNumeric"
@@ -1678,6 +1690,7 @@
       "groups" : [
          "core",
          "xref"
+         "xref_gene_symbol_transformer",
       ],
       "name" : "HGNCTypes",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::HGNCTypes"
@@ -2012,7 +2025,8 @@
       "description" : "NCBI genes have display xrefs",
       "groups" : [
          "corelike",
-         "xref"
+         "xref",
+         "xref_gene_symbol_transformer"
       ],
       "name" : "NCBIGeneLabels",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::NCBIGeneLabels"
@@ -2038,7 +2052,8 @@
       "groups" : [
          "brc4_core",
          "core",
-         "xref"
+         "xref",
+         "xref_gene_symbol_transformer"
       ],
       "name" : "ObjectXrefNull",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ObjectXrefNull"
@@ -2525,6 +2540,7 @@
       "groups" : [
          "core",
          "xref",
+         "xref_gene_symbol_transformer",
          "xref_mapping"
       ],
       "name" : "StableIdDisplayXref",
@@ -2624,6 +2640,7 @@
       "groups" : [
          "core",
          "xref",
+         "xref_gene_symbol_transformer",
          "xref_mapping"
       ],
       "name" : "UniProtDisplayXref",
@@ -2661,6 +2678,7 @@
       "groups" : [
          "core",
          "xref",
+         "xref_gene_symbol_transformer",
          "xref_mapping"
       ],
       "name" : "UnreviewedXrefs",
@@ -2836,6 +2854,7 @@
       "groups" : [
          "core",
          "xref",
+         "xref_gene_symbol_transformer",
          "xref_mapping"
       ],
       "name" : "XrefFormat",
@@ -2847,6 +2866,7 @@
       "groups" : [
          "core",
          "xref",
+         "xref_gene_symbol_transformer",
          "xref_mapping"
       ],
       "name" : "XrefPrefixes",
@@ -2858,6 +2878,7 @@
       "groups" : [
          "core",
          "xref",
+         "xref_gene_symbol_transformer",
          "xref_mapping"
       ],
       "name" : "XrefTypes",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1678,8 +1678,8 @@
       "description" : "HGNC xrefs do not have the accession as the display_label",
       "groups" : [
          "core",
-         "xref"
-         "xref_gene_symbol_transformer",
+         "xref",
+         "xref_gene_symbol_transformer"
       ],
       "name" : "HGNCNumeric",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::HGNCNumeric"
@@ -1689,8 +1689,8 @@
       "description" : "HGNC xrefs are attached to the appropriate object",
       "groups" : [
          "core",
-         "xref"
-         "xref_gene_symbol_transformer",
+         "xref",
+         "xref_gene_symbol_transformer"
       ],
       "name" : "HGNCTypes",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::HGNCTypes"

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2610,6 +2610,7 @@
       "description" : "Transcripts do not have a display xref with a -20* suffix. These are created by the non-vert Xref pipeline unless a flag is enabled: http://www.ebi.ac.uk/seqdb/confluence/display/EnsGen/Xref+mapping#Xrefmapping-CustomisingXrefMapping(DisplayXrefs)",
       "groups" : [
          "xref",
+         "xref_gene_symbol_transformer",
          "core"
       ],
       "name" : "TranscriptDisplayXrefSuffix",


### PR DESCRIPTION
This new group would be used by the Gene Symbol Transformer pipeline to assign gene names in RapidRelease