### PR TITLE
Add subtest to check for missing GOC or WGA scores

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGOCScoreStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGOCScoreStats.pm
@@ -21,6 +21,7 @@ package Bio::EnsEMBL::DataCheck::Checks::CheckGOCScoreStats;
 use warnings;
 use strict;
 
+use List::Util qw/sum/;
 use Moose;
 use Test::More;
 
@@ -51,6 +52,14 @@ sub tests {
 
   my $prev_results = $prev_helper->execute_into_hash( -SQL => $sql );
   my $curr_results = $curr_helper->execute_into_hash( -SQL => $sql );
+
+  my $prev_has_goc_scores = sum values %$prev_results ? 1 : 0;
+  my $curr_has_goc_scores = sum values %$curr_results ? 1 : 0;
+
+  if ($prev_has_goc_scores) {
+    my $desc = "There are still goc_score stats";
+    is( $curr_has_goc_scores, $prev_has_goc_scores, $desc );
+  }
 
   foreach my $type ( keys %$prev_results ) {
     my $desc = "There are the same number of goc_score populated rows between releases for $type";

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGOCScoreStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGOCScoreStats.pm
@@ -55,11 +55,8 @@ sub tests {
 
   my $prev_has_goc_scores = sum values %$prev_results ? 1 : 0;
   my $curr_has_goc_scores = sum values %$curr_results ? 1 : 0;
-
-  if ($prev_has_goc_scores) {
-    my $desc = "There are still goc_score stats";
-    is( $curr_has_goc_scores, $prev_has_goc_scores, $desc );
-  }
+  my $desc_2 = "goc_score stats have not disappeared";
+  cmp_ok( $curr_has_goc_scores, ">=", $prev_has_goc_scores, $desc_2 );
 
   foreach my $type ( keys %$prev_results ) {
     my $desc = "There are the same number of goc_score populated rows between releases for $type";

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckWGACoverageStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckWGACoverageStats.pm
@@ -56,11 +56,8 @@ sub tests {
 
   my $prev_has_wga_scores = sum values %$prev_results ? 1 : 0;
   my $curr_has_wga_scores = sum values %$curr_results ? 1 : 0;
-
-  if ($prev_has_wga_scores) {
-    my $desc = "There are still wga_coverage stats";
-    is( $curr_has_wga_scores, $prev_has_wga_scores, $desc );
-  }
+  my $desc_2 = "wga_coverage stats have not disappeared";
+  cmp_ok( $curr_has_wga_scores, ">=", $prev_has_wga_scores, $desc_2 );
 
   foreach my $type ( keys %$prev_results ) {
     my $desc = "There are the same number of wga_coverage populated rows between releases for $type";

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckWGACoverageStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckWGACoverageStats.pm
@@ -21,6 +21,7 @@ package Bio::EnsEMBL::DataCheck::Checks::CheckWGACoverageStats;
 use warnings;
 use strict;
 
+use List::Util qw/sum/;
 use Moose;
 use Test::More;
 use Bio::EnsEMBL::Utils::SqlHelper;
@@ -52,6 +53,14 @@ sub tests {
 
   my $prev_results = $prev_helper->execute_into_hash( -SQL => $sql );
   my $curr_results = $curr_helper->execute_into_hash( -SQL => $sql );
+
+  my $prev_has_wga_scores = sum values %$prev_results ? 1 : 0;
+  my $curr_has_wga_scores = sum values %$curr_results ? 1 : 0;
+
+  if ($prev_has_wga_scores) {
+    my $desc = "There are still wga_coverage stats";
+    is( $curr_has_wga_scores, $prev_has_wga_scores, $desc );
+  }
 
   foreach my $type ( keys %$prev_results ) {
     my $desc = "There are the same number of wga_coverage populated rows between releases for $type";


### PR DESCRIPTION
The Compara datachecks `CheckGOCScoreStats` and `CheckWGACoverageStats` flag drops in GOC score or WGA coverage stats (respectively) relative to a previous release. These may fail due to changes in the proportions of homologies of different types, drops in the number of GOC/WGA stats in one or more homology types, or the complete loss of GOC/WGA stats relative to a previous release that had such stats.

This PR adds an additional subtest to each datacheck, which specifically checks for the complete loss of GOC/WGA stats in a given release, so that such data loss is more clearly flagged.