### PR TITLE
Improve protein_function_predictions data checks (e110)

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ProteinFunctionPredictions.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ProteinFunctionPredictions.pm
@@ -37,12 +37,19 @@ use constant {
 
 sub tests {
   my ($self) = @_;
-  my $desc = 'prediction_matrix is NOT NULL or empty';
-  my $sql  = qq/
+
+  my $desc1 = 'protein_function_predictions has one or more rows';
+  my $sql1  = qq/
+    SELECT COUNT(*) FROM protein_function_predictions
+  /;
+  is_rows_nonzero($self->dba, $sql1, $desc1);
+
+  my $desc2 = 'prediction_matrix is NOT NULL or empty';
+  my $sql2  = qq/
     SELECT COUNT(*) FROM protein_function_predictions
     WHERE prediction_matrix IS NULL OR prediction_matrix = ''
   /;
-  is_rows_zero($self->dba, $sql, $desc);
+  is_rows_zero($self->dba, $sql2, $desc2);
 
 }
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ProteinFunctionPredictions.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ProteinFunctionPredictions.pm
@@ -52,41 +52,39 @@ sub tests {
   is_rows_zero($self->dba, $sql2, $desc2);
 
   sub has_predictor_data {
-    my ($type, $table, $sql) = @_;
-    
+    my ($self, $type, $table) = @_;
+
     # Check if data type is found in 'meta' table
-    my $var_dba = $self->get_dba(undef, 'variation');
-    skip 'No variation database', 1 unless defined $var_dba;
-    my ($type_in_meta) = $var_dba->selectall_arrayref(
-      sprintf('SELECT COUNT(*) > 0 FROM meta WHERE meta_key LIKE "%s%%";', $type);
+    my $type_in_meta = $self->dba->dbc->db_handle->selectrow_array(
+      sprintf('SELECT COUNT(*) > 0 FROM meta WHERE meta_key LIKE "%s%%";', $type));
 
     my $sql = qq/
-      SELECT COUNT(*)
-      FROM %s pfp JOIN attrib a
-      ON (a.attrib_id = pfp.analysis_attrib_id)
-      WHERE a.value LIKE "%s%%";
+     SELECT COUNT(*)
+     FROM %s pfp JOIN attrib a
+     ON (a.attrib_id = pfp.analysis_attrib_id)
+     WHERE a.value LIKE "%s%%";
     /;
     $sql = sprintf($sql, $table, $type);
 
-    my $desc, $diag;
+    my ($desc, $diag);
     if ($type_in_meta) {
       # If found in meta, data for that data type should be available
-      $desc = sprintf("'%s' has data in meta and %s", $type, $table);
+      $desc = sprintf("%s has data in meta and %s", $type, $table);
       is_rows_nonzero($self->dba, $sql, $desc);
     } else {
       # If not found in meta, no data should be available for that data type
-      $desc = sprintf("'%s' has no data in meta and %s", $type, $table);
+      $desc = sprintf("%s doesn't have data in meta and %s", $type, $table);
       $diag = sprintf(
-        "Entry containing '%s' is missing from meta table, but data found for '%s' in %s",
+        "Entry containing '%s' is missing from meta table, but data found for %s in %s",
         $type, $type, $table);
       is_rows_zero($self->dba, $sql, $desc, $diag);
     }
   }
-  has_predictor_data("sift",     "protein_function_predictions");
-  has_predictor_data("sift",     "protein_function_predictions_attrib");
-  has_predictor_data("cadd",     "protein_function_predictions");
-  has_predictor_data("dbnsfp",   "protein_function_predictions");
-  has_predictor_data("polyphen", "protein_function_predictions");
+  $self->has_predictor_data("sift",     "protein_function_predictions");
+  $self->has_predictor_data("sift",     "protein_function_predictions_attrib");
+  $self->has_predictor_data("cadd",     "protein_function_predictions");
+  $self->has_predictor_data("dbnsfp",   "protein_function_predictions");
+  $self->has_predictor_data("polyphen", "protein_function_predictions");
 
 }
 


### PR DESCRIPTION
[ENSVAR-4445](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4445):
* Check if `protein_function_predictions` has one or more rows.
* Check if `protein_function_predictions` and `protein_function_predictions_attrib` have data based on data types from `meta` table (`cadd`, `sift`, `polyphen` and `dbnsfp`).
* For the data types that are not available in the `meta` table, check if `protein_function_predictions` doesn't contain data for those data types.

Most species only have SIFT data, so this should not raise issues if the other data types are missing.

## Testing

You can test a single datacheck with the following command: `perl ensembl-datacheck/scripts/run_datachecks.pl $(v2 details script) -dbname nuno_homo_sapiens_variation_109_38_outdated_citations -name ProteinFunctionPredictions -dbtype variation`

| Condition | Pass? | Example |
| --------- | :----: | --------- |
| 1. Test with a human database with data in `protein_function_predictions` and `protein_function_predictions_attrib` for all data types | ✅ | `perl ensembl-datacheck/scripts/run_datachecks.pl $(v3 details script) -dbname homo_sapiens_variation_109_38 -name ProteinFunctionPredictions -dbtype variation` |
| 2. Remove all entries for a certain data type from `meta` (e.g., `dbnsfp_version`) | ❌ | |
| 3. Remove data for a certain data type (e.g., all CADD predictions) from `protein_function_predictions` | ❌ | |
| 4. Truncate `protein_function_predictions` and `protein_function_predictions_attrib ` | ❌ | |
| 5. Test with a non-human database with data in `protein_function_predictions` and `protein_function_predictions_atrrib` | ✅ | `perl ensembl-datacheck/scripts/run_datachecks.pl $(v1 details script) -dbname mus_musculus_variation_109_39 -name ProteinFunctionPredictions -dbtype variation` |
