### PR TITLE
Fix alt allele data checks by ignoring new IS_PAR relationships

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AltAllele.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AltAllele.pm
@@ -23,7 +23,6 @@ use strict;
 
 use Moose;
 use Test::More;
-use Data::Dumper;
 
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AltAllele.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AltAllele.pm
@@ -23,6 +23,7 @@ use strict;
 
 use Moose;
 use Test::More;
+use Data::Dumper;
 
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
@@ -41,10 +42,13 @@ sub tests {
 
   my @multiple_chromosomes = ();
 
-  foreach my $aag (@$aags) {
+  AAG: foreach my $aag (@$aags) {
     my $genes = $aag->get_all_Genes();
     my %chrs;
     foreach (@$genes) {
+      # skip aag if gene member has a "IS_PAR" relationship
+      my $type_flag = $aag->attribs($_->dbID);
+      next AAG if (exists $type_flag->{IS_PAR});
       if ($_->slice->is_reference) {
         $chrs{$_->slice->seq_region_name}++;
       } else {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AltAlleleGroup.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AltAlleleGroup.pm
@@ -41,10 +41,13 @@ sub tests {
 
   my @multiple_reference = ();
 
-  foreach my $aag (@$aags) {
+  AAG: foreach my $aag (@$aags) {
     my $genes = $aag->get_all_Genes();
     my $reference = 0;
     foreach (@$genes) {
+      # skip aag if gene member has a "IS_PAR" relationship
+      my $type_flag = $aag->attribs($_->dbID);
+      next AAG if (exists $type_flag->{IS_PAR});
       $reference += $_->slice->is_reference;
     }
     push @multiple_reference, $aag->dbID if $reference > 1;


### PR DESCRIPTION
Following work to create new Y-PAR genes in the core database for Release 110 (project summary: https://www.ebi.ac.uk/seqdb/confluence/display/ENSCORE/Y+PAR+Genes): 1) a gene can now belong to one or more alt allele groups, and 2) there is a new 'IS_PAR' alt allele relationship to link between X- and Y-PAR genes. 

These changes have caused the data check expected counts for AltAllele and AltAlleleGroup to fail. This PR fixes the issue by removing the alt allele groups containing the new 'IS_PAR' alt allele relationships from the data check counts.