### PR TITLE
Remove the 'chain' part for Alphafold accessions

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckAlphafoldEntries.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckAlphafoldEntries.pm
@@ -53,7 +53,7 @@ sub tests {
     from protein_feature pf, analysis a
     where a.analysis_id = pf.analysis_id
     and a.logic_name = 'alphafold_import'
-    and pf.hit_name REGEXP 'AF\-[A-Za-z0-9]+\-F[0-9]+\.[A-Z]'
+    and pf.hit_name REGEXP 'AF\-[A-Za-z0-9]+\-F[0-9]+'
   /;
   is_rows_nonzero($self->dba, $sql_2, $desc_2);
 


### PR DESCRIPTION
We used to store a 'chain' tag with the Alphafold accession, like this: AF-P63151-F1.A It was decided to drop that part (.A), as it is not currently used and creates more work.