### PR TITLE
Remove data_files related discontinued checks

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DataFilesExist.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DataFilesExist.pm
@@ -53,9 +53,6 @@ sub skip_tests {
 sub tests {
   my ($self) = @_;
 
-  $self->alignment_has_bigwig();
-  $self->segmentation_file_has_bigbed();
-  $self->motif_feature_has_bigbed();
   $self->data_files_exist();
 }
 


### PR DESCRIPTION
In order to reflect the new regulatory build approach, we decided to remove the following checks:
- alignment_has_bigwig();
- segmentation_file_has_bigbed();
- motif_feature_has_bigbed();

We're still keeping the check's code as a safety measure since the mentioned approach is still being developed.
We expect to remove them in the next release.