### PR TITLE
CheckHomologyMLSS: check the appropriate homologies in the reindexing pipelines.

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomologyMLSS.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomologyMLSS.pm
@@ -43,7 +43,7 @@ sub tests {
   my $dba    = $self->dba;
   my $helper = $dba->dbc->sql_helper;
   my @method_links = qw(ENSEMBL_ORTHOLOGUES ENSEMBL_PARALOGUES ENSEMBL_HOMOEOLOGUES ENSEMBL_PROJECTIONS);
-  if ($dba->dbc->dbname !~ /ensembl_compara|protein_trees|ncrna_trees/) {
+  if ($dba->dbc->dbname !~ /ensembl_compara|protein_trees|ncrna_trees|reindexed_trees/) {
     @method_links = qw(ENSEMBL_HOMOLOGUES);
   }
 


### PR DESCRIPTION
The CheckHomologyMLSS datacheck was [checking the rapid release homologies](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-5651) when running in the reindexing pipelines.
This PR makes sure that the right homologies are checked by tweaking the regexp checking the database name.
It was tested by running the murinae ncRNA trees reindexing pipeline on the e109 database.