### PR TITLE
Skip ProteinFunctionPredictions tests for VCF-only species

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareProteinFunctionPredictions.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareProteinFunctionPredictions.pm
@@ -40,7 +40,7 @@ sub skip_tests {
   my ($self) = @_;
 
   my $mca = $self->dba->get_adaptor('MetaContainer');
-  my $vcf = list_value_by_key('variation_source.vcf')->[0] || 0;
+  my $vcf = $mca->list_value_by_key('variation_source.vcf')->[0] || 0;
 
   if ($vcf) {
     return( 1, "Protein function predictions are not expected for species whose variation source is VCF." );

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareProteinFunctionPredictions.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareProteinFunctionPredictions.pm
@@ -36,6 +36,17 @@ use constant {
   TABLES         => ['attrib', 'protein_function_predictions', 'protein_function_predictions_attrib']
 };
 
+sub skip_tests {
+  my ($self) = @_;
+
+  my $mca = $self->dba->get_adaptor('MetaContainer');
+  my $vcf = list_value_by_key('variation_source.vcf')->[0] || 0;
+
+  if ($vcf) {
+    return( 1, "Protein function predictions are not expected for species whose variation source is VCF." );
+  }
+}
+
 sub tests {
   my ($self) = @_;
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ProteinFunctionPredictions.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ProteinFunctionPredictions.pm
@@ -29,11 +29,22 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
   NAME        => 'ProteinFunctionPredictions',
-  DESCRIPTION => 'prediction_matrix is not NULL or empty',
+  DESCRIPTION => 'Protein function predictions are present and correct',
   GROUPS      => ['variation'],
   DB_TYPES    => ['variation'],
   TABLES      => ['protein_function_predictions']
 };
+
+sub skip_tests {
+  my ($self) = @_;
+
+  my $mca = $self->dba->get_adaptor('MetaContainer');
+  my $vcf = list_value_by_key('variation_source.vcf')->[0] || 0;
+
+  if ($vcf) {
+    return( 1, "Protein function predictions are not expected for species whose variation source is VCF." );
+  }
+}
 
 sub tests {
   my ($self) = @_;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ProteinFunctionPredictions.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ProteinFunctionPredictions.pm
@@ -39,7 +39,7 @@ sub skip_tests {
   my ($self) = @_;
 
   my $mca = $self->dba->get_adaptor('MetaContainer');
-  my $vcf = list_value_by_key('variation_source.vcf')->[0] || 0;
+  my $vcf = $mca->list_value_by_key('variation_source.vcf')->[0] || 0;
 
   if ($vcf) {
     return( 1, "Protein function predictions are not expected for species whose variation source is VCF." );

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2174,7 +2174,7 @@
    },
    "ProteinFunctionPredictions" : {
       "datacheck_type" : "critical",
-      "description" : "prediction_matrix is not NULL or empty",
+      "description" : "Protein function predictions are present and correct",
       "groups" : [
          "variation"
       ],


### PR DESCRIPTION
VCF-only species have no predictions for protein function (empty tables for `protein_function_predictions` and `protein_function_predictions_attrib`). This PR ensures tests associated with ProteinFunctionPredictions are skipped for those species.

### Testing

Test with two variation species with different variation sources:
* VCF:
```
perl ensembl-datacheck/scripts/run_datachecks.pl \
     $(v1 details script) \
     --old_server_uri $(v1 details url) \
     --server_uri $(v1 details url) \
     --name ProteinFunctionPredictions,CompareProteinFunctionPredictions \
     --dbname coturnix_japonica_variation_110_2
```
* Database:
```
perl ensembl-datacheck/scripts/run_datachecks.pl \
     $(v1 details script) \
     --old_server_uri $(v1 details url) \
     --server_uri $(v1 details url) \
     --name ProteinFunctionPredictions,CompareProteinFunctionPredictions \
     --dbname felis_catus_variation_110_9
```