### PR TITLE
Get Vertebrates BioMart species from dedicated file

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MartDatasetName.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MartDatasetName.pm
@@ -51,7 +51,7 @@ sub skip_tests {
   my $production_name = $mca->get_production_name;
   my $schema_version = $mca->get_schema_version;
 
-  if ($division =~ '/EnsemblVertebrates|EnsemblMetazoa|EnsemblPlants/') {
+  if ($division =~ '/EnsemblVertebrates/') {
     my $mart_species = mart_species($division, $schema_version);
     if (!grep( /$production_name/, @$mart_species) ){
       return (1, 'No mart for this species');
@@ -124,7 +124,7 @@ sub mart_species {
   $division = lc($division);
 
   my $url_base = 'https://raw.githubusercontent.com/Ensembl/ensembl-compara';
-  my $url_file = "conf/${division}/allowed_species.json";
+  my $url_file = "conf/${division}/biomart_species.json";
 
   my $branch_url = "${url_base}/release/$schema_version/$url_file";
   my $main_url = "${url_base}/main/$url_file";


### PR DESCRIPTION
## Description

A dedicated BioMart species list file (`biomart_species.json`) has been added to the Vertebrates Compara species config in [Compara PR #583](https://github.com/Ensembl/ensembl-compara/pull/583).

This PR effectively configures the `MartDatasetName` to take the Vertebrates BioMart species list from the new `biomart_species.json` file instead of the Vertebrates `allowed_species.json` file.

## Benefits

Having the Vertebrates BioMart `biomart_species.json` file alongside the Vertebrates Compara `allowed_species.json` file will allow the Vertebrates Compara species to differ from the Vertebrates BioMart species, while still maintaining an automatic consistency check.

## Possible Drawbacks

None expected.
