### PR TITLE
Added datacheck for timely release of eHive semaphors

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/TimelySemaphoreRelease.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/TimelySemaphoreRelease.pm
@@ -75,8 +75,6 @@ sub tests {
 
     my $test_name = "Semaphores were released in a timely manner.";
     is(scalar @$array, 0 , $test_name);
-
-    return 1;
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/TimelySemaphoreRelease.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/TimelySemaphoreRelease.pm
@@ -23,7 +23,6 @@ use strict;
 
 use Moose;
 use Test::More;
-use Data::Dumper;
 
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
@@ -38,7 +37,6 @@ use constant {
 
 sub tests {
     my ($self) = @_;
-    # A typical test may use the sql_helper:
  
     my $sql = q{
         SELECT

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/TimelySemaphoreRelease.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/TimelySemaphoreRelease.pm
@@ -1,0 +1,85 @@
+=head1 LICENSE
+
+Copyright [2018-2023] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::TimelySemaphoreRelease;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Data::Dumper;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'TimelySemaphoreRelease',
+  DESCRIPTION    => 'Check that every semaphored job was started only after all of its fan jobs had completed.',
+  GROUPS         => ['compara_gene_tree_pipelines'],
+  DATACHECK_TYPE => 'critical',
+  DB_TYPES       => ['compara'],
+  TABLES         => ['job', 'semaphore']
+};
+
+sub tests {
+    my ($self) = @_;
+    # A typical test may use the sql_helper:
+ 
+    my $sql = q{
+        SELECT
+            job.job_id AS job_id,
+            job.when_completed,
+            semaphore.semaphore_id,
+            dependent_job_id,
+            dep_job.when_completed AS dep_completed,
+            dep_job.runtime_msec AS dep_runtime_msec,
+            CEILING(
+                (
+                    TIMESTAMPDIFF(SECOND, job.when_completed, dep_job.when_completed)
+                    - (dep_job.runtime_msec / 1000)
+                )
+            ) AS delta
+        FROM
+            job
+        JOIN
+            semaphore ON job.controlled_semaphore_id = semaphore.semaphore_id
+        JOIN
+            job AS dep_job ON semaphore.dependent_job_id = dep_job.job_id
+        HAVING
+            delta < 0;
+    };
+    my $helper  = $self->dba->dbc->sql_helper;
+    my $array   = $helper->execute(-SQL => $sql, USE_HASHREFS => 1);
+
+    if(scalar @$array > 0) {
+        my @msg = ("job_id\twhen_completed\tsemaphore_id\tdependent_job_id\tdep_completed\tdep_runtime_msec\tdelta\n");
+        foreach my $elem (@$array) {
+            push @msg, "$elem->{job_id}\t$elem->{when_completed}\t$elem->{semaphore_id}\t$elem->{dependent_job_id}" . 
+            "\t$elem->{dep_completed}\t$elem->{dep_runtime_msec}\t$elem->{delta}\n";
+        }
+        diag(@msg);
+    }
+
+    my $test_name = "Semaphores were released in a timely manner.";
+    is(scalar @$array, 0 , $test_name);
+
+    return 1;
+}
+
+1;
+

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -832,15 +832,6 @@
       "name" : "ComparePhenotypeFeatures",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ComparePhenotypeFeatures"
    },
-   "CompareVariationRows" : {
-      "datacheck_type" : "advisory",
-      "description" : "Compare number of rows between two variation databases",
-      "groups" : [
-         "compare_variation"
-      ],
-      "name" : "CompareVariationRows",
-      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareVariationRows"
-   },
    "ComparePreviousVersionGenomicProbeFeaturesByArray" : {
       "datacheck_type" : "advisory",
       "description" : "Checks for loss of probes features from genomic mappings for each array that is not organised into probe sets.",
@@ -1058,6 +1049,15 @@
       ],
       "name" : "CompareVariationFeatures",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareVariationFeatures"
+   },
+   "CompareVariationRows" : {
+      "datacheck_type" : "advisory",
+      "description" : "Compare number of rows between two variation databases",
+      "groups" : [
+         "compare_variation"
+      ],
+      "name" : "CompareVariationRows",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareVariationRows"
    },
    "CompareVariationSets" : {
       "datacheck_type" : "advisory",
@@ -2606,6 +2606,15 @@
       ],
       "name" : "TagCoverageStats",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::TagCoverageStats"
+   },
+   "TimelySemaphoreRelease" : {
+      "datacheck_type" : "critical",
+      "description" : "Check that every semaphored job was started only after all of its fan jobs had completed.",
+      "groups" : [
+         "compara_gene_tree_pipelines"
+      ],
+      "name" : "TimelySemaphoreRelease",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::TimelySemaphoreRelease"
    },
    "TranscriptBounds" : {
       "datacheck_type" : "critical",


### PR DESCRIPTION
# Description of the problem
Early semaphore release issues affected several pipelines in e111. Such issues have been reported before, in e109 Vertebrates FTP dumps, [e105 Mammals EPOwithExt](https://genomes-ebi.slack.com/archives/D0255PFSNKW/p1625849995012100), [e103 default ncRNAtrees](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/Intentions+for+release+103), and in [e96 Plants](https://www.ebi.ac.uk/seqdb/confluence/display/EnsCom/2019-02-27).

But the impact of this issue in e111 — one pipeline completely rerun, a second pipeline with out-of-sync homology data — calls for measures to catch such issues as soon as possible.

# Scope of the pull request

The aim of this PR is to create a datacheck (**TimelySemaphoreRelease**) which queries the semaphore and job tables to check that every dependent semaphore job was started only after all of its fan jobs had completed. The datacheck should fail if this is not the case for any semaphored job.
Relevant compara ticket: [ENSCOMPARASW-6845](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-6845)

*WARNING: the position of the CompareVariationRows index entry was changed by this PR.*

# Testing

The datacheck was manually run on two databases where failure is expected and one where pass is expected.