### PR TITLE
Add datacheck MemberXrefAccessTime

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MemberXrefAccessTime.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MemberXrefAccessTime.pm
@@ -66,8 +66,7 @@ sub tests {
     LIMIT 1;
   /;
 
-  my $external_db_names = $helper->execute_simple(-SQL => $external_db_query);
-  my $external_db_name = $external_db_names->[0];  # only one external db is needed
+  my $external_db_name = $helper->execute_single_result(-SQL => $external_db_query);
 
 
   my $avg_tree_size_query = q/

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MemberXrefAccessTime.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MemberXrefAccessTime.pm
@@ -1,0 +1,138 @@
+=head1 LICENSE
+
+Copyright [2018-2023] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::MemberXrefAccessTime;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+
+use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
+use Bio::EnsEMBL::Compara::DBSQL::XrefAssociationAdaptor;
+use Bio::EnsEMBL::Hive::Utils qw/timeout/;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+
+use constant {
+  NAME           => 'MemberXrefAccessTime',
+  DESCRIPTION    => 'Compara member xref data can be accessed in a timely manner',
+  GROUPS         => ['compara_annot_highlight'],
+  DATACHECK_TYPE => 'critical',
+  DB_TYPES       => ['compara'],
+  PER_DB         => 1,
+  # The 'TABLES' array is left empty in case an issue arises with Member Xref access of unchanged data.
+  # Relevant tables are: external_db, gene_member, gene_tree_node, gene_tree_root, member_xref, seq_member
+  TABLES         => [],
+};
+
+
+sub skip_tests {
+  my ($self) = @_;
+
+  if ( $self->dba->get_division eq 'vertebrates' ) {
+    return( 1, "The member_xref table is not populated for vertebrates" );
+  }
+}
+
+sub tests {
+  my ($self) = @_;
+
+  my $helper = $self->dba->dbc->sql_helper;
+
+
+  my $external_db_query = q/
+    SELECT
+      db_name
+    FROM
+      external_db
+    LIMIT 1;
+  /;
+
+  my $external_db_names = $helper->execute_simple(-SQL => $external_db_query);
+  my $external_db_name = $external_db_names->[0];  # only one external db is needed
+
+
+  my $avg_tree_size_query = q/
+      SELECT
+          ROUND(AVG(gene_count))
+      FROM
+          gene_tree_root
+      JOIN
+          gene_tree_root_attr USING(root_id)
+      WHERE
+          tree_type = 'tree'
+      AND
+          clusterset_id = 'default'
+      AND
+          gene_count  > 4;
+  /;
+
+  my $avg_tree_size = $helper->execute_single_result(-SQL => $avg_tree_size_query);
+
+
+  my $test_tree_query = q/
+      SELECT
+          root_id
+      FROM
+          gene_tree_root
+      JOIN
+          gene_tree_root_attr
+      USING
+          (root_id)
+      WHERE
+          tree_type = 'tree'
+      AND
+          clusterset_id = 'default'
+      AND
+          gene_count >= ?
+      ORDER BY
+          gene_count;
+  /;
+
+  my $gene_tree_root_ids = $helper->execute_simple(-SQL => $test_tree_query, -PARAMS => [$avg_tree_size]);
+
+
+  my $xref_assoc_dba = Bio::EnsEMBL::Compara::DBSQL::XrefAssociationAdaptor->new($self->dba);
+  my $gene_tree_dba = $self->dba->get_GeneTreeAdaptor;
+
+  my $member_xref_access_timeout = 60;
+
+  my $timed_out_tree_stable_id;
+  foreach my $root_id (@{$gene_tree_root_ids}) {
+    my $tree = $gene_tree_dba->fetch_by_root_id($root_id);
+
+    my $return_value = timeout( sub {
+      my @xrefs = sort { $a cmp $b } @{$xref_assoc_dba->get_associated_xrefs_for_tree($tree , $external_db_name)};
+      if (scalar(@xrefs) > 0) {
+        my @xref_members = @{$xref_assoc_dba->get_members_for_xref($tree, $xrefs[0], $external_db_name)};
+      }
+    }, $member_xref_access_timeout);
+
+    if ($return_value == -2) {
+      $timed_out_tree_stable_id = $tree->stable_id;
+    }
+  }
+
+  my $desc = "Member xref data can be accessed in a timely manner";
+  is($timed_out_tree_stable_id, undef, $desc);
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -832,15 +832,6 @@
       "name" : "ComparePhenotypeFeatures",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ComparePhenotypeFeatures"
    },
-   "CompareVariationRows" : {
-      "datacheck_type" : "advisory",
-      "description" : "Compare number of rows between two variation databases",
-      "groups" : [
-         "compare_variation"
-      ],
-      "name" : "CompareVariationRows",
-      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareVariationRows"
-   },
    "ComparePreviousVersionGenomicProbeFeaturesByArray" : {
       "datacheck_type" : "advisory",
       "description" : "Checks for loss of probes features from genomic mappings for each array that is not organised into probe sets.",
@@ -1058,6 +1049,15 @@
       ],
       "name" : "CompareVariationFeatures",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareVariationFeatures"
+   },
+   "CompareVariationRows" : {
+      "datacheck_type" : "advisory",
+      "description" : "Compare number of rows between two variation databases",
+      "groups" : [
+         "compare_variation"
+      ],
+      "name" : "CompareVariationRows",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareVariationRows"
    },
    "CompareVariationSets" : {
       "datacheck_type" : "advisory",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1863,6 +1863,15 @@
       "name" : "MemberProductionCounts",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MemberProductionCounts"
    },
+   "MemberXrefAccessTime" : {
+      "datacheck_type" : "critical",
+      "description" : "Compara member xref data can be accessed in a timely manner",
+      "groups" : [
+         "compara_annot_highlight"
+      ],
+      "name" : "MemberXrefAccessTime",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MemberXrefAccessTime"
+   },
    "MetaCoord" : {
       "datacheck_type" : "critical",
       "description" : "The meta_coord table is correctly populated",


### PR DESCRIPTION
## Description of the problem

In Ensembl 109 the access time of Member Xref data from the Metazoa Compara database was prohibitively slow, causing gene-tree displays to fail with an Ajax error ([ENSWEB-6789](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6789)).

It has been proposed to develop a datacheck ([ENSCOMPARASW-6449](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-6449)) to catch and fix this kind of issue at an earlier stage in the release cycle.

## Scope of the pull request

This PR adds a datacheck (`MemberXrefAccessTime`) which tests that access of Member Xref data via the Compara Perl API is not prohibitively slow.

This datacheck is added to the `compara_annot_highlight` group so that it can be run as soon as the `member_xref` and `external_db` tables of the relevant Compara database have been populated.

Note that in the datacheck config, the `TABLES` array is left empty in case an issue arises with Member Xref access of data that has not changed.

_WARNING: like #557, this PR moves the CompareVariationRows datacheck index entry so that it is placed alphabetically._

## Testing

The datacheck was run on 2 example Metazoa Compara databases: one unmodified database and one database with the primary key of the `member_xref` table dropped.

As expected, the datacheck passed on the former database and failed on the latter.

---

The datacheck was also run on `ensembl_compara_fungi_57_110`, and passed in 21 minutes and 27.83 seconds.
