### PR TITLE
Updated the MemberProductionCounts DC

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MemberProductionCounts.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MemberProductionCounts.pm
@@ -69,14 +69,23 @@ sub tests {
     WHERE collection = ?
   /;
 
-  my $constraint = "tree_type = 'tree' AND ref_root_id IS NULL";
-  my $sqlCollections = qq/
-     SELECT DISTINCT clusterset_id 
-       FROM gene_tree_root 
-     WHERE $constraint
-   /;
-
-  my $collections = $helper->execute_simple( -SQL => $sqlCollections );
+  #my $constraint = "tree_type = 'tree' AND ref_root_id IS NULL";
+  #my $sqlCollections = qq/
+  #  SELECT DISTINCT clusterset_id 
+  #    FROM gene_tree_root 
+  #  WHERE $constraint
+  # /;
+  my $clusterset_query = q/
+    SELECT DISTINCT clusterset_id, species_set_id
+      FROM gene_tree_root
+        JOIN method_link_species_set USING(method_link_species_set_id)
+    WHERE tree_type = 'tree'
+      AND ref_root_id IS NULL;
+  /;
+  
+  my %clusterset_to_ss_id = map { $_->{'clusterset_id'} => $_->{'species_set_id'} } @{$helper->execute(-SQL => $clusterset_query, -USE_HASHREFS => 1)};
+  my $collections = [keys %clusterset_to_ss_id];
+  #my $collections = $helper->execute_simple( -SQL => $sqlCollections );
 
   my $sqlFamilies = q/
     SELECT COUNT(*) 
@@ -85,11 +94,14 @@ sub tests {
   my $family_count = $helper->execute_single_result( -SQL => $sqlFamilies );
 
   my $sqlPolyploids = q/
-    SELECT COUNT(*) 
-      FROM genome_db 
-    WHERE genome_component IS NOT NULL
-  /; # Assumes that the polyploid genomes are found in all the collections
-  my $polyploid_count = $helper->execute_single_result( -SQL => $sqlPolyploids );
+     SELECT COUNT(*)
+       FROM genome_db 
+         JOIN species_set 
+           USING(genome_db_id) 
+     WHERE species_set_id = ? AND genome_component IS NOT NULL;
+  /; 
+  # Assumes that the polyploid genomes are found in all the collections
+  # my $polyploid_count = $helper->execute_single_result( -SQL => $sqlPolyploids );
 
   my $sqlGeneTrees = qq/
     SELECT COUNT(*) 
@@ -113,7 +125,7 @@ sub tests {
 
     my $genetree_count = $helper->execute_single_result( -SQL => $sqlGeneTrees,  PARAMS => [$collection] );
     my $cafetrees_count = $helper->execute_single_result( -SQL => $sqlCAFETrees, PARAMS => [$collection] );
-    
+    my $polyploid_count = $helper->execute_single_result( -SQL => $sqlPolyploids, PARAMS => [$clusterset_to_ss_id{$collection}] ); 
     my @counts = ($family_count, $genetree_count, $cafetrees_count, $genetree_count, $genetree_count, $polyploid_count);
 
     #Test for families commented out for duration of compara production freeze, this may return in the future

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MemberProductionCounts.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MemberProductionCounts.pm
@@ -69,12 +69,6 @@ sub tests {
     WHERE collection = ?
   /;
 
-  #my $constraint = "tree_type = 'tree' AND ref_root_id IS NULL";
-  #my $sqlCollections = qq/
-  #  SELECT DISTINCT clusterset_id 
-  #    FROM gene_tree_root 
-  #  WHERE $constraint
-  # /;
   my $clusterset_query = q/
     SELECT DISTINCT clusterset_id, species_set_id
       FROM gene_tree_root
@@ -85,7 +79,6 @@ sub tests {
   
   my %clusterset_to_ss_id = map { $_->{'clusterset_id'} => $_->{'species_set_id'} } @{$helper->execute(-SQL => $clusterset_query, -USE_HASHREFS => 1)};
   my $collections = [keys %clusterset_to_ss_id];
-  #my $collections = $helper->execute_simple( -SQL => $sqlCollections );
 
   my $sqlFamilies = q/
     SELECT COUNT(*) 
@@ -100,8 +93,6 @@ sub tests {
            USING(genome_db_id) 
      WHERE species_set_id = ? AND genome_component IS NOT NULL;
   /; 
-  # Assumes that the polyploid genomes are found in all the collections
-  # my $polyploid_count = $helper->execute_single_result( -SQL => $sqlPolyploids );
 
   my $sqlGeneTrees = qq/
     SELECT COUNT(*) 


### PR DESCRIPTION
MemberProductionCounts data check assumed that all collections have homoeologues which is not true. This DC was flagged up during release 111 for rice. This DC is now updated to handle the collections that do not have homoeologues. 