### PR TITLE
Add datacheck CactusMetadataConsistency

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CactusMetadataConsistency.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CactusMetadataConsistency.pm
@@ -1,0 +1,84 @@
+=head1 LICENSE
+
+Copyright [2018-2023] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::CactusMetadataConsistency;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+
+use Bio::EnsEMBL::Hive::Utils qw/destringify/;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'CactusMetadataConsistency',
+  DESCRIPTION    => 'Each Cactus alignment has consistent metadata',
+  GROUPS         => ['compara', 'compara_genome_alignments'],
+  DATACHECK_TYPE => 'critical',
+  DB_TYPES       => ['compara'],
+  TABLES         => ['genome_db', 'method_link', 'method_link_species_set', 'method_link_species_set_tag',
+                     'species_tree_node', 'species_tree_root']
+};
+
+sub tests {
+  my ($self) = @_;
+
+  my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
+  my $gdb_adap = $self->dba->get_GenomeDBAdaptor;
+
+  my $cactus_mlsses = $mlss_adap->fetch_all_by_method_link_type('CACTUS_HAL');
+
+  unless (scalar(@{$cactus_mlsses})) {
+    plan skip_all => "No Cactus MLSSes in this database";
+  }
+
+  foreach my $mlss (@{$cactus_mlsses}) {
+
+    my $species_map = destringify($mlss->get_value_for_tag('HAL_mapping', '{}'));
+    my @hal_gdb_ids = keys %{$species_map};
+
+    my $mlss_name = $mlss->name;
+    my $mlss_id = $mlss->dbID;
+
+    my $desc_1 = "HAL mapping data found for $mlss_name ($mlss_id)";
+    ok(scalar(@hal_gdb_ids) > 0, $desc_1);
+
+    my $mlss_sp_tree = $mlss->species_tree;
+    my $desc_2 = "Species tree found for $mlss_name ($mlss_id)";
+    isnt($mlss_sp_tree, undef, $desc_2);
+
+    foreach my $hal_gdb_id (@hal_gdb_ids) {
+      my $hal_gdb = $gdb_adap->fetch_by_dbID($hal_gdb_id);
+
+      my $desc_3 = "$mlss_name HAL mapping GenomeDB (genome_db_id:$hal_gdb_id) is present";
+      isnt($hal_gdb, undef, $desc_3);
+
+      my $desc_4 = "$mlss_name HAL mapping GenomeDB (genome_db_id:$hal_gdb_id) is current";
+      ok(defined $hal_gdb && $hal_gdb->is_current, $desc_4);
+
+      my $desc_5 = "$mlss_name HAL mapping GenomeDB (genome_db_id:$hal_gdb_id) is in species tree";
+      my %mlss_sp_tree_gdb_ids = map { $_ => 1 } keys %{$mlss_sp_tree->get_genome_db_id_2_node_hash()};
+      ok(exists $mlss_sp_tree_gdb_ids{$hal_gdb_id}, $desc_5);
+    }
+  }
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -832,15 +832,6 @@
       "name" : "ComparePhenotypeFeatures",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ComparePhenotypeFeatures"
    },
-   "CompareVariationRows" : {
-      "datacheck_type" : "advisory",
-      "description" : "Compare number of rows between two variation databases",
-      "groups" : [
-         "compare_variation"
-      ],
-      "name" : "CompareVariationRows",
-      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareVariationRows"
-   },
    "ComparePreviousVersionGenomicProbeFeaturesByArray" : {
       "datacheck_type" : "advisory",
       "description" : "Checks for loss of probes features from genomic mappings for each array that is not organised into probe sets.",
@@ -1058,6 +1049,15 @@
       ],
       "name" : "CompareVariationFeatures",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareVariationFeatures"
+   },
+   "CompareVariationRows" : {
+      "datacheck_type" : "advisory",
+      "description" : "Compare number of rows between two variation databases",
+      "groups" : [
+         "compare_variation"
+      ],
+      "name" : "CompareVariationRows",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareVariationRows"
    },
    "CompareVariationSets" : {
       "datacheck_type" : "advisory",
@@ -1688,6 +1688,16 @@
       ],
       "name" : "GenomeStatistics",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::GenomeStatistics"
+   },
+   "CactusMetadataConsistency" : {
+      "datacheck_type" : "critical",
+      "description" : "Each Cactus alignment has consistent metadata",
+      "groups" : [
+         "compara",
+         "compara_genome_alignments"
+      ],
+      "name" : "CactusMetadataConsistency",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CactusMetadataConsistency"
    },
    "HGNCNumeric" : {
       "datacheck_type" : "critical",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -227,6 +227,16 @@
       "name" : "BlankSets",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::BlankSets"
    },
+   "CactusMetadataConsistency" : {
+      "datacheck_type" : "critical",
+      "description" : "Each Cactus alignment has consistent metadata",
+      "groups" : [
+         "compara",
+         "compara_genome_alignments"
+      ],
+      "name" : "CactusMetadataConsistency",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CactusMetadataConsistency"
+   },
    "CanonicalTranscripts" : {
       "datacheck_type" : "critical",
       "description" : "Canonical transcripts and translation are correctly configured",
@@ -1688,16 +1698,6 @@
       ],
       "name" : "GenomeStatistics",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::GenomeStatistics"
-   },
-   "CactusMetadataConsistency" : {
-      "datacheck_type" : "critical",
-      "description" : "Each Cactus alignment has consistent metadata",
-      "groups" : [
-         "compara",
-         "compara_genome_alignments"
-      ],
-      "name" : "CactusMetadataConsistency",
-      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CactusMetadataConsistency"
    },
    "HGNCNumeric" : {
       "datacheck_type" : "critical",


### PR DESCRIPTION
## Description of the problem

Issues have arisen in recent releases with Cactus genomic alignment metadata consistency: in one case a retired `GenomeDB` was present in the HAL mapping which links a Compara database to its configured Cactus alignments, and in another case a species in the HAL mapping was not present in the corresponding species tree. Tickets have been created proposing to develop a datatcheck for each of these issues ([ENSCOMPARASW-5088](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-5088) and [ENSCOMPARASW-6834](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-6834), respectively).

The datacheck which would be added by this PR tests both cases.

## Scope of the pull request

This PR adds a Compara datacheck (`CactusMetadataConsistency`) which tests that for each Cactus MLSS in a Compara database:
- a HAL mapping is present in the database;
- a corresponding species tree is present in the database;
- each `genome_db_id` in the HAL mapping is present in the database, is current, and can be found in the species tree.

_WARNING: like https://github.com/Ensembl/ensembl-datacheck/pull/557, this PR moves the CompareVariationRows datacheck index entry so that it is placed alphabetically._

## Testing

The datacheck was tested successfully on 3 example Metazoa Compara databases. For further information on testing, please see [ENSCOMPARASW-6834](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-6834).
