### PR TITLE
Extend MartDatasetName mart filter to Metazoa

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MartDatasetName.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MartDatasetName.pm
@@ -51,7 +51,7 @@ sub skip_tests {
   my $production_name = $mca->get_production_name;
   my $schema_version = $mca->get_schema_version;
 
-  if ($division =~ '/EnsemblVertebrates/') {
+  if ($division =~ /^(EnsemblVertebrates|EnsemblMetazoa)$/) {
     my $mart_species = mart_species($division, $schema_version);
     if (!grep( /$production_name/, @$mart_species) ){
       return (1, 'No mart for this species');


### PR DESCRIPTION
## Description

With the introduction of a BioMart species list for Metazoa in e112, datacheck code which previously applied only to the Vertebrates division needs to be revised to apply also to the Metazoa division.

**Related JIRA tickets:**
- [ENSINT-1549](https://www.ebi.ac.uk/panda/jira/browse/ENSINT-1549)

## Overview of changes

In the `MartDatasetName` datacheck, the mart species filter is extended so that it also matches on the Metazoa division.

## Testing

The updated regex was tested locally to ensure that it correctly matched the strings `EnsemblVertebrates` and `EnsemblMetazoa`.
