### PR TITLE
Update query to fetch analysis information

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledAnalysis.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledAnalysis.pm
@@ -85,8 +85,6 @@ sub tests {
     FROM
       analysis_description ad LEFT OUTER JOIN
       web_data wd USING (web_data_id)
-    WHERE 
-      ad.is_current = 1
   /;
   my $prod_dba      = $self->get_dba('multi', 'production');
   my $prod_helper   = $prod_dba->dbc->sql_helper;


### PR DESCRIPTION
When bringing back old core dbs these can contain deprecated analyses and removing those can be quite painful and introduces the potential of making mistakes. If having these in the core db is not dangerous for Production or Web, it may be easiest to remove the requirement of an analysis to be current.

_Note:_ there is no need to add any other conditions since `logic_name` is UNIQUE in `analysis_description`, so there is no chance that two configurations of the same analysis are returned.