### PR TITLE
Add support to GCF to ease moving core dbs between beta/rapid and main

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyFormat.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyFormat.pm
@@ -44,7 +44,7 @@ sub tests {
   my %formats = (
     'annotation.provider_url'        => '(https?:\/\/.+|www.*\.ensembl\.org)',
     'assembly.provider_url'          => '(https?:\/\/.+|www.*\.ensembl\.org)',
-    'assembly.accession'             => 'GCA_\d+\.\d+',
+    'assembly.accession'             => 'GC[AF]_\d+\.\d+',
     'assembly.date'                  => '\d{4}-\d{2}',
     'assembly.default'               => '[\w\.\-]+',
     'genebuild.id'                   => '\d+',

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesTaxonomy.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesTaxonomy.pm
@@ -49,7 +49,7 @@ sub tests {
   # scientific name, to disambiguate in the case of multiple strains
   # or assemblies of the same species. Since the taxonomy database does
   # not always have that information, remove it before comparing.
-  $sci_name =~ s/ \(GCA_\d+\)//;
+  $sci_name =~ s/ \(GC[AF]_\d+\)//;
   $sci_name =~ s/ (str\.|strain) .*//;
 
   my $desc_1 = 'Species-related meta data exists';


### PR DESCRIPTION
We tend to release in both beta/rapid and then main site some of our organisms, so users can access core information quickly and then add other relevant features such as CACTUS alignments and protein trees. To ease us moving core databases from one system to the other, it would be helpful to add support for GCF values in `assembly.accession` meta key.

_Scope:_ e113, thus the PR against `main`