### PR TITLE
Skip checking the meta table for blanks

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
@@ -57,13 +57,14 @@ sub tests {
 
   foreach my $nullable (@$nullables) {
     my ($table, $column) = @$nullable;
-
-    my $desc = "Nullable column $table.$column has no '' or 'NULL' string values";
-    my $sql  = qq/
-      SELECT COUNT(*) FROM $table
-      WHERE $column = '' OR $column = 'NULL'
-    /;
+    if ($table ne "meta"){
+	my $desc = "Nullable column $table.$column has no '' or 'NULL' string values";
+	my $sql  = qq/
+	    SELECT COUNT(*) FROM $table
+	    WHERE $column = '' OR $column = 'NULL'
+	    /;
     is_rows_zero($self->dba, $sql, $desc);
+    }
   }
 }
 


### PR DESCRIPTION
Now that the meta_values are NULLable, this check is run on the meta table and, inevitably, there are empty strings in the meta_values.
To allow beta handover on schema 110, I'm skipping this check on the meta table.

I tested on my beta testing db
`perl /hps/nobackup/flicek/ensembl/genebuild/leanne/beta/handover_rr59/ensembl-datacheck/scripts/run_datachecks.pl -host mysql-ens-genebuild-prod-1 -port 4527 -user ensro -dbname amphiduros_pacificus_gca949316495v1_core_110_1 -dbtype core -n BlankNulls`
and it passed.