### PR TITLE
Rename BRC4 to VEuPathDB (only in datachecks) and add/rename its meta keys

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AlignFeatureExternalDB.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AlignFeatureExternalDB.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'AlignFeatureExternalDB',
   DESCRIPTION    => 'All alignment features are linked to an external DB',
-  GROUPS         => ['annotation', 'core', 'brc4_core', 'corelike'],
+  GROUPS         => ['annotation', 'core', 'vpdb_core', 'corelike'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['cdna', 'core', 'otherfeatures', 'rnaseq'],
   TABLES         => ['coord_system', 'dna_align_feature', 'protein_align_feature', 'seq_region']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AltAllele.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AltAllele.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'AltAllele',
   DESCRIPTION => 'Alt allele group members map back to the same chromosome',
-  GROUPS      => ['core', 'brc4_core', 'geneset'],
+  GROUPS      => ['core', 'vpdb_core', 'geneset'],
   DB_TYPES    => ['core'],
 };
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AltAlleleGroup.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AltAlleleGroup.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'AltAlleleGroup',
   DESCRIPTION => 'No alt_allele_group has more than one gene from the primary assembly',
-  GROUPS      => ['core', 'brc4_core', 'geneset'],
+  GROUPS      => ['core', 'vpdb_core', 'geneset'],
   DB_TYPES    => ['core']
 };
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AnalysisDescription.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AnalysisDescription.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'AnalysisDescription',
   DESCRIPTION => 'Gene analyses have descriptions',
-  GROUPS      => ['analysis_description', 'core', 'brc4_core', 'corelike', 'geneset'],
+  GROUPS      => ['analysis_description', 'core', 'vpdb_core', 'corelike', 'geneset'],
   DB_TYPES    => ['core', 'otherfeatures'],
   TABLES      => ['analysis', 'analysis_description', 'gene', 'prediction_transcript', 'transcript']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AnalysisFormat.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AnalysisFormat.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'AnalysisFormat',
   DESCRIPTION => 'Analysis logic name and date are formatted correctly',
-  GROUPS      => ['ancestral', 'brc4_core', 'core', 'corelike'],
+  GROUPS      => ['ancestral', 'vpdb_core', 'core', 'corelike'],
   DB_TYPES    => ['cdna', 'core', 'otherfeatures', 'rnaseq'],
   TABLES      => ['analysis'],
   PER_DB      => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AssemblyExceptions.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AssemblyExceptions.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'AssemblyExceptions',
   DESCRIPTION => 'Assembly exceptions are correctly configured',
-  GROUPS      => ['ancestral', 'assembly', 'brc4_core', 'core'],
+  GROUPS      => ['ancestral', 'assembly', 'vpdb_core', 'core'],
   DB_TYPES    => ['core'],
   TABLES      => ['analysis', 'assembly_exception', 'dna_align_feature',
                   'external_db', 'seq_region',],

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AssemblyExceptionsMapping.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AssemblyExceptionsMapping.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'AssemblyExceptionsMapping',
   DESCRIPTION    => 'Assembly exceptions have alignment mappings',
-  GROUPS         => ['assembly', 'core', 'brc4_core'],
+  GROUPS         => ['assembly', 'core', 'vpdb_core'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['core'],
   TABLES         => ['analysis', 'assembly_exception', 'dna_align_feature',

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AssemblySeqregion.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AssemblySeqregion.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'AssemblySeqregion',
   DESCRIPTION => 'Assembly and seq_region tables are consistent',
-  GROUPS      => ['ancestral', 'assembly', 'brc4_core', 'core'],
+  GROUPS      => ['ancestral', 'assembly', 'vpdb_core', 'core'],
   DB_TYPES    => ['core'],
   TABLES      => ['assembly', 'coord_system', 'seq_region'],
   PER_DB      => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankEnums.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankEnums.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'BlankEnums',
   DESCRIPTION => 'Enum columns do not have empty string values',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_blastocyst', 'compara_gene_trees', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'compara_gene_tree_pipelines', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['ancestral', 'vpdb_core', 'compara', 'compara_blastocyst', 'compara_gene_trees', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'compara_gene_tree_pipelines', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/BlankNulls.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'BlankNulls',
   DESCRIPTION => 'Nullable columns do not have empty string values',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_blastocyst', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'compara_gene_tree_pipelines', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['ancestral', 'vpdb_core', 'compara', 'compara_blastocyst', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'compara_gene_tree_pipelines', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CanonicalTranscripts.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CanonicalTranscripts.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'CanonicalTranscripts',
   DESCRIPTION => 'Canonical transcripts and translation are correctly configured',
-  GROUPS      => ['core', 'brc4_core', 'geneset'],
+  GROUPS      => ['core', 'vpdb_core', 'geneset'],
   DB_TYPES    => ['core'],
   TABLES      => ['attrib_type', 'coord_system', 'exon', 'exon_transcript', 'gene', 'seq_region', 'transcript', 'transcript_attrib', 'translation']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ChromosomesAnnotated.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ChromosomesAnnotated.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'ChromosomesAnnotated',
   DESCRIPTION    => 'Chromosomal seq_regions have appropriate attribute',
-  GROUPS         => ['assembly', 'core', 'brc4_core'],
+  GROUPS         => ['assembly', 'core', 'vpdb_core'],
   DB_TYPES       => ['core'],
   TABLES         => ['attrib_type', 'coord_system', 'seq_region', 'seq_region_attrib']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSchema.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSchema.pm
@@ -32,7 +32,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'CompareSchema',
   DESCRIPTION => 'Compare database schema to definition in SQL file',
-  GROUPS      => ['compara', 'compara_homology_annotation', 'compara_references', 'core', 'brc4_core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['compara', 'compara_homology_annotation', 'compara_references', 'core', 'vpdb_core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'production', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledAnalysis.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledAnalysis.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'ControlledAnalysis',
   DESCRIPTION => 'Analysis descriptions and display settings are consistent with production database',
-  GROUPS      => ['analysis_description', 'core', 'brc4_core', 'corelike'],
+  GROUPS      => ['analysis_description', 'core', 'vpdb_core', 'corelike'],
   DB_TYPES    => ['cdna', 'core', 'otherfeatures', 'rnaseq'],
   TABLES      => ['analysis', 'analysis_description'],
   PER_DB      => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCore.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'ControlledTablesCore',
   DESCRIPTION => 'Controlled tables are consistent with production database',
-  GROUPS      => ['controlled_tables', 'core', 'brc4_core', 'corelike'],
+  GROUPS      => ['controlled_tables', 'core', 'vpdb_core', 'corelike'],
   DB_TYPES    => ['cdna', 'core', 'otherfeatures', 'rnaseq'],
   TABLES      => ['attrib_type', 'biotype', 'external_db', 'misc_set', 'unmapped_reason'],
   PER_DB      => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DatabaseCollation.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DatabaseCollation.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'DatabaseCollation',
   DESCRIPTION => 'All tables have the same collation (latin1_swedish_ci)',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_blastocyst', 'compara_gene_trees', 'compara_genome_alignments', 'compara_homology_annotation', 'compara_master', 'compara_references', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['ancestral', 'vpdb_core', 'compara', 'compara_blastocyst', 'compara_gene_trees', 'compara_genome_alignments', 'compara_homology_annotation', 'compara_master', 'compara_references', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayableGenes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayableGenes.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'DisplayableGenes',
   DESCRIPTION    => 'Genes are displayable and have web_data attached to their analysis',
-  GROUPS         => ['analysis_description', 'core', 'brc4_core', 'corelike', 'geneset'],
+  GROUPS         => ['analysis_description', 'core', 'vpdb_core', 'corelike', 'geneset'],
   DATACHECK_TYPE => 'advisory',
   DB_TYPES       => ['core', 'otherfeatures', 'rnaseq', 'cdna'],
   TABLES         => ['gene', 'analysis', 'analysis_description']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayableSampleGene.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayableSampleGene.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'DisplayableSampleGene',
   DESCRIPTION => 'Sample gene is displayable and has web_data attached to its analysis',
-  GROUPS      => ['analysis_description', 'core', 'brc4_core', 'geneset', 'meta_sample'],
+  GROUPS      => ['analysis_description', 'core', 'vpdb_core', 'geneset', 'meta_sample'],
   DB_TYPES    => ['core'],
   TABLES      => ['analysis', 'analysis_description', 'gene', 'meta']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ExonBounds.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ExonBounds.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'ExonBounds',
   DESCRIPTION => 'Exon regions are non-overlapping, and are consistent with their transcripts',
-  GROUPS      => ['core', 'brc4_core', 'corelike', 'geneset'],
+  GROUPS      => ['core', 'vpdb_core', 'corelike', 'geneset'],
   DB_TYPES    => ['core', 'otherfeatures'],
 };
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ExonRank.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ExonRank.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'ExonRank',
   DESCRIPTION => 'Exon ranks are unique and sequential',
-  GROUPS      => ['core', 'brc4_core', 'corelike', 'geneset'],
+  GROUPS      => ['core', 'vpdb_core', 'corelike', 'geneset'],
   DB_TYPES    => ['core', 'otherfeatures'],
   PER_DB      => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/FeatureBounds.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/FeatureBounds.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'FeatureBounds',
   DESCRIPTION => 'Feature co-ordinates are within the bounds of their seq_region',
-  GROUPS      => ['annotation', 'core', 'brc4_core', 'corelike'],
+  GROUPS      => ['annotation', 'core', 'vpdb_core', 'corelike'],
   DB_TYPES    => ['core', 'otherfeatures'],
   TABLES      => ['assembly_exception', 'coord_system', 'density_feature', 'ditag_feature', 'dna_align_feature', 'marker_feature', 'misc_feature', 'protein_align_feature', 'repeat_feature', 'seq_region', 'simple_feature']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeys.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ForeignKeys.pm
@@ -32,7 +32,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'ForeignKeys',
   DESCRIPTION => 'Foreign key relationships are not violated',
-  GROUPS      => ['ancestral', 'brc4_core', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['ancestral', 'vpdb_core', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1,
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBiotypes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBiotypes.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'GeneBiotypes',
   DESCRIPTION => 'Genes and transcripts have valid biotypes',
-  GROUPS      => ['controlled_tables', 'core', 'brc4_core', 'corelike', 'geneset'],
+  GROUPS      => ['controlled_tables', 'core', 'vpdb_core', 'corelike', 'geneset'],
   DB_TYPES    => ['core', 'otherfeatures'],
   TABLES      => ['biotype', 'coord_system', 'gene', 'seq_region', 'transcript']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBounds.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneBounds.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'GeneBounds',
   DESCRIPTION => 'Genes are within the bounds of their seq_region',
-  GROUPS      => ['core', 'brc4_core', 'corelike', 'geneset'],
+  GROUPS      => ['core', 'vpdb_core', 'corelike', 'geneset'],
   DB_TYPES    => ['core', 'otherfeatures'],
   TABLES      => ['coord_system', 'exon', 'gene', 'seq_region', 'transcript']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneStableID.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneStableID.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'GeneStableID',
   DESCRIPTION => 'Genes, transcripts, exons and translations have non-NULL, unique stable IDs',
-  GROUPS      => ['core', 'brc4_core', 'geneset'],
+  GROUPS      => ['core', 'vpdb_core', 'geneset'],
   DB_TYPES    => ['core'],
   TABLES      => ['coord_system', 'exon', 'gene', 'seq_region', 'transcript', 'translation']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneStrands.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneStrands.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'GeneStrands',
   DESCRIPTION => 'Genes have valid strand values',
-  GROUPS      => ['core', 'brc4_core', 'corelike', 'geneset'],
+  GROUPS      => ['core', 'vpdb_core', 'corelike', 'geneset'],
   DB_TYPES    => ['core', 'otherfeatures'],
   TABLES      => ['coord_system', 'exon', 'gene', 'prediction_exon', 'prediction_transcript', 'seq_region', 'transcript']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/LRG.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/LRG.pm
@@ -32,7 +32,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'LRG',
   DESCRIPTION => 'LRG features and seq_regions are correctly configured',
-  GROUPS      => ['brc4_core', 'core'],
+  GROUPS      => ['vpdb_core', 'core'],
   DB_TYPES    => ['core'],
   TABLES      => ['coord_system', 'gene',  'seq_region', 'transcript'],
   PER_DB      => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MTCodonTable.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MTCodonTable.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'MTCodonTable',
   DESCRIPTION    => 'MT seq region has codon table attribute',
-  GROUPS         => ['core', 'brc4_core'],
+  GROUPS         => ['core', 'vpdb_core'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['core'],
   TABLES         => ['attrib_type', 'coord_system', 'seq_region', 'seq_region_attrib']

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaCoord.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaCoord.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'MetaCoord',
   DESCRIPTION => 'The meta_coord table is correctly populated',
-  GROUPS      => ['annotation', 'brc4_core', 'core', 'core_sync', 'corelike', 'funcgen', 'geneset', 'protein_features', 'variation'],
+  GROUPS      => ['annotation', 'vpdb_core', 'core', 'core_sync', 'corelike', 'funcgen', 'geneset', 'protein_features', 'variation'],
   DB_TYPES    => ['cdna', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   FORCE       => 1
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyAssembly.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyAssembly.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'MetaKeyAssembly',
   DESCRIPTION => 'Assembly data and meta keys are consistent',
-  GROUPS      => ['assembly', 'core', 'brc4_core', 'meta'],
+  GROUPS      => ['assembly', 'core', 'vpdb_core', 'meta'],
   DB_TYPES    => ['core'],
   TABLES      => ['assembly', 'attrib_type', 'coord_system', 'meta', 'seq_region', 'seq_region_attrib']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyCardinality.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyCardinality.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'MetaKeyCardinality',
   DESCRIPTION => 'A subset of meta keys must only have a single value',
-  GROUPS      => ['ancestral', 'brc4_core', 'core', 'meta', 'meta_sample'],
+  GROUPS      => ['ancestral', 'vpdb_core', 'core', 'meta', 'meta_sample'],
   DB_TYPES    => ['core'],
   TABLES      => ['meta']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyConditional.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'MetaKeyConditional',
   DESCRIPTION => 'Conditional meta keys exist if the data requires them',
-  GROUPS      => ['core', 'brc4_core', 'meta', 'variation'],
+  GROUPS      => ['core', 'vpdb_core', 'meta', 'variation'],
   DB_TYPES    => ['core', 'variation'],
   TABLES      => ['meta']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyFormat.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyFormat.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'MetaKeyFormat',
   DESCRIPTION => 'Meta values are correctly formatted and linked',
-  GROUPS      => ['ancestral', 'brc4_core', 'core', 'meta', 'meta_sample', 'variation'],
+  GROUPS      => ['ancestral', 'vpdb_core', 'core', 'meta', 'meta_sample', 'variation'],
   DB_TYPES    => ['core', 'variation'],
   TABLES      => ['meta']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyLevel.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyLevel.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'MetaKeyLevel',
   DESCRIPTION => 'Meta keys are correctly assigned at species or database level',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'meta', 'variation'],
+  GROUPS      => ['ancestral', 'vpdb_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'meta', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyVPDB.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyVPDB.pm
@@ -16,7 +16,7 @@ limitations under the License.
 
 =cut
 
-package Bio::EnsEMBL::DataCheck::Checks::MetaKeyBRC4;
+package Bio::EnsEMBL::DataCheck::Checks::MetaKeyVPDB;
 
 use warnings;
 use strict;
@@ -27,9 +27,9 @@ use Test::More;
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
-  NAME           => 'MetaKeyBRC4',
-  DESCRIPTION    => 'Expected meta keys for BRC4 cores',
-  GROUPS         => ['brc4_core'],
+  NAME           => 'MetaKeyVPDB',
+  DESCRIPTION    => 'Expected meta keys for VEuPathDB cores',
+  GROUPS         => ['vpdb_core'],
   DB_TYPES       => ['core'],
   TABLES         => ['meta']
 };
@@ -42,8 +42,9 @@ sub tests {
   my @expected = qw/
   assembly.accession
   species.taxonomy_id
-  BRC4.component
-  BRC4.organism_abbrev
+  veupathdb.build_version
+  veupathdb.component_db
+  veupathdb.organism_abbrev
   /;
   foreach my $meta_key (@expected) {
     my $values = $mca->list_value_by_key($meta_key);
@@ -52,7 +53,7 @@ sub tests {
     ok(scalar(@$values) == 1, $desc);
   }
   
-  my $desc = "BRC4 component is valid";
+  my $desc = "VEuPathDB Component DB is valid";
   my %ok_components = map { $_ => 1 } qw(
     AmoebaDB
     CryptoDB
@@ -67,7 +68,7 @@ sub tests {
     TriTrypDB
     VectorBase
   );
-  my ($component) = @{ $mca->list_value_by_key("BRC4.component") };
+  my ($component) = @{ $mca->list_value_by_key("veupathdb.component_db") };
   if ($component) {
     ok(exists $ok_components{$component}, $desc);
   }

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MitochondriaAnnotated.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MitochondriaAnnotated.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'MitochondriaAnnotated',
   DESCRIPTION    => 'Mitochondrial seq_regions have appropriate attribute',
-  GROUPS         => ['assembly', 'core', 'brc4_core'],
+  GROUPS         => ['assembly', 'core', 'vpdb_core'],
   DB_TYPES       => ['core'],
   TABLES         => ['attrib_type', 'coord_system', 'seq_region', 'seq_region_attrib']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MySQLStorageEngine.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MySQLStorageEngine.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'MySQLStorageEngine',
   DESCRIPTION => 'Database schema matches expected MySQL storage engine',
-  GROUPS      => ['compara', 'compara_homology_annotation', 'core', 'brc4_core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['compara', 'compara_homology_annotation', 'core', 'vpdb_core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   PER_DB      => 1,
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ObjectXrefNull.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ObjectXrefNull.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'ObjectXrefNull',
   DESCRIPTION    => 'Object_xrefs should be linked to an analysis',
-  GROUPS         => ['brc4_core', 'core', 'xref', 'xref_gene_symbol_transformer'],
+  GROUPS         => ['vpdb_core', 'core', 'xref', 'xref_gene_symbol_transformer'],
   DATACHECK_TYPE => 'advisory',
   TABLES         => ['object_xref']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/PlastidsAnnotated.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/PlastidsAnnotated.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'PlastidsAnnotated',
   DESCRIPTION    => 'Plastid seq_regions have appropriate attribute',
-  GROUPS         => ['assembly', 'core', 'brc4_core'],
+  GROUPS         => ['assembly', 'core', 'vpdb_core'],
   DB_TYPES       => ['core'],
   TABLES         => ['attrib_type', 'coord_system', 'seq_region', 'seq_region_attrib']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/PolyploidAttribs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/PolyploidAttribs.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'PolyploidAttribs',
   DESCRIPTION => 'Component genomes are annotated for polyploid genomes',
-  GROUPS      => ['assembly', 'core', 'brc4_core'],
+  GROUPS      => ['assembly', 'core', 'vpdb_core'],
   DB_TYPES    => ['core'],
   TABLES      => ['attrib_type', 'seq_region', 'seq_region_attrib']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ProteinTranslation.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ProteinTranslation.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'ProteinTranslation',
   DESCRIPTION => 'All protein-coding genes have a valid translation',
-  GROUPS      => ['core', 'brc4_core', 'geneset'],
+  GROUPS      => ['core', 'vpdb_core', 'geneset'],
   DB_TYPES    => ['core'],
   TABLES      => ['assembly', 'dna', 'exon', 'exon_transcript', 'gene', 'seq_region', 'seq_region_attrib', 'transcript', 'transcript_attrib', 'translation', 'translation_attrib']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'RepeatFeatures',
   DESCRIPTION => 'Repeat feature coordinates are present and correct',
-  GROUPS      => ['annotation', 'core', 'brc4_core'],
+  GROUPS      => ['annotation', 'core', 'vpdb_core'],
   DB_TYPES    => ['core'],
   TABLES      => ['analysis', 'coord_system', 'repeat_feature', 'seq_region'],
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaPatchesApplied.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaPatchesApplied.pm
@@ -31,7 +31,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SchemaPatchesApplied',
   DESCRIPTION => 'Schema patches are up-to-date',
-  GROUPS      => ['brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['vpdb_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'production', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaType.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaType.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SchemaType',
   DESCRIPTION => 'The schema type meta key matches the DB name',
-  GROUPS      => ['brc4_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['vpdb_core', 'compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'compara_references', 'compara_homology_annotation', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaVersion.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SchemaVersion.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SchemaVersion',
   DESCRIPTION => 'The schema version meta key matches the DB name',
-  GROUPS      => ['ancestral', 'brc4_core', 'compara', 'compara_homology_annotation', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
+  GROUPS      => ['ancestral', 'vpdb_core', 'compara', 'compara_homology_annotation', 'core', 'corelike', 'funcgen', 'schema', 'variation'],
   DB_TYPES    => ['cdna', 'compara', 'core', 'funcgen', 'otherfeatures', 'rnaseq', 'variation'],
   TABLES      => ['meta'],
   PER_DB      => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionNames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionNames.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SeqRegionNames',
   DESCRIPTION => 'Seq_region names are unique (top-level) or consistent (non-top-level)',
-  GROUPS      => ['ancestral', 'assembly', 'brc4_core', 'core'],
+  GROUPS      => ['ancestral', 'assembly', 'vpdb_core', 'core'],
   DB_TYPES    => ['core'],
   TABLES      => ['attrib_type', 'coord_system', 'seq_region', 'seq_region_attrib']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionRank.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionRank.pm
@@ -30,7 +30,7 @@ use Bio::EnsEMBL::DataCheck::Test::DataCheck;
 use constant {
   NAME        => 'SeqRegionRank',
   DESCRIPTION => 'Chromosomes have rank 1',
-  GROUPS      => ['assembly', 'core', 'brc4_core'],
+  GROUPS      => ['assembly', 'core', 'vpdb_core'],
   DB_TYPES    => ['core'],
   TABLES      => ['attrib_type', 'coord_system', 'seq_region', 'seq_region_attrib']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionSynonyms.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionSynonyms.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SeqRegionSynonyms',
   DESCRIPTION => 'Seq_region synonyms do not clash with seq region names',
-  GROUPS      => ['assembly', 'brc4_core', 'core'],
+  GROUPS      => ['assembly', 'vpdb_core', 'core'],
   DB_TYPES    => ['core'],
   TABLES      => ['attrib_type', 'coord_system', 'seq_region', 'seq_region_synonym']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionTopLevel.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionTopLevel.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SeqRegionTopLevel',
   DESCRIPTION => 'Top-level seq_regions are appropriately configured',
-  GROUPS      => ['assembly', 'core', 'brc4_core', 'corelike', 'geneset'],
+  GROUPS      => ['assembly', 'core', 'vpdb_core', 'corelike', 'geneset'],
   DB_TYPES    => ['core'],
 };
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionVPDB.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SeqRegionVPDB.pm
@@ -16,7 +16,7 @@ limitations under the License.
 
 =cut
 
-package Bio::EnsEMBL::DataCheck::Checks::SeqRegionBRC4;
+package Bio::EnsEMBL::DataCheck::Checks::SeqRegionVPDB;
 
 use warnings;
 use strict;
@@ -28,9 +28,9 @@ use Bio::EnsEMBL::DataCheck::Test::DataCheck;
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
-  NAME           => 'SeqRegionBRC4',
-  DESCRIPTION    => 'Seq_region for BRC4 have correct attributes',
-  GROUPS         => ['brc4_core'],
+  NAME           => 'SeqRegionVPDB',
+  DESCRIPTION    => 'Seq_region for VEuPathDB have correct attributes',
+  GROUPS         => ['vpdb_core'],
   DB_TYPES       => ['core'],
   TABLES         => ['attrib_type', 'coord_system', 'external_db', 'seq_region', 'seq_region_attrib', 'seq_region_synonym']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SequenceLevel.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SequenceLevel.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SequenceLevel',
   DESCRIPTION => 'DNA is attached, and only attached, to sequence-level seq_regions',
-  GROUPS      => ['assembly', 'core', 'brc4_core'],
+  GROUPS      => ['assembly', 'core', 'vpdb_core'],
   DB_TYPES    => ['core'],
   TABLES      => ['coord_system', 'dna', 'seq_region'],
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SimpleFeatureAnalysisTypes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SimpleFeatureAnalysisTypes.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'SimpleFeatureAnalysisTypes',
   DESCRIPTION    => 'Simple features are not from analysis type gene, mrna and cds',
-  GROUPS         => ['core', 'brc4_core'],
+  GROUPS         => ['core', 'vpdb_core'],
   DB_TYPES       => ['core'],
   TABLES         => ['gene', 'analysis', 'analysis_description']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesNameUnique.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesNameUnique.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SpeciesNameUnique',
   DESCRIPTION => 'Species production_name and alias are unique across all databases in the registry',
-  GROUPS      => ['core', 'brc4_core', 'meta'],
+  GROUPS      => ['core', 'vpdb_core', 'meta'],
   DB_TYPES    => ['core'],
   TABLES      => ['meta'],
   PER_DB      => 1,

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesTaxonomy.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesTaxonomy.pm
@@ -29,7 +29,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'SpeciesTaxonomy',
   DESCRIPTION => 'Taxonomic meta keys are consistent with taxonomy database',
-  GROUPS      => ['core', 'brc4_core', 'meta'],
+  GROUPS      => ['core', 'vpdb_core', 'meta'],
   DB_TYPES    => ['core'],
   TABLES      => ['meta']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/TranscriptBounds.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/TranscriptBounds.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'TranscriptBounds',
   DESCRIPTION => 'Gene and transcript bounds are consistent',
-  GROUPS      => ['core', 'brc4_core', 'corelike', 'geneset'],
+  GROUPS      => ['core', 'vpdb_core', 'corelike', 'geneset'],
   DB_TYPES    => ['core', 'otherfeatures'],
   TABLES      => ['attrib_type', 'coord_system', 'gene', 'seq_region', 'transcript', 'transcript_attrib']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/UnlocatedTranscripts.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/UnlocatedTranscripts.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'UnlocatedTranscripts',
   DESCRIPTION => 'Transcripts are linked to sequences',
-  GROUPS      => ['core', 'brc4_core', 'corelike', 'geneset'],
+  GROUPS      => ['core', 'vpdb_core', 'corelike', 'geneset'],
   DB_TYPES    => ['core', 'otherfeatures'],
   TABLES      => ['transcript'],
   PER_DB      => 1

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ValidTranscripts.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ValidTranscripts.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'ValidTranscripts',
   DESCRIPTION => 'Transcripts have translations, if appropriate',
-  GROUPS      => ['core', 'brc4_core', 'corelike', 'geneset'],
+  GROUPS      => ['core', 'vpdb_core', 'corelike', 'geneset'],
   DB_TYPES    => ['core', 'otherfeatures'],
   TABLES      => ['biotype', 'coord_system', 'seq_region', 'transcript', 'translation']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ValidTranslations.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ValidTranslations.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME        => 'ValidTranslations',
   DESCRIPTION => 'Translations have appropriate properties',
-  GROUPS      => ['core', 'brc4_core', 'corelike', 'geneset'],
+  GROUPS      => ['core', 'vpdb_core', 'corelike', 'geneset'],
   DB_TYPES    => ['core', 'otherfeatures'],
   TABLES      => ['coord_system', 'exon', 'exon_transcript', 'seq_region', 'transcript', 'translation']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/VersionedGenesVPDB.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/VersionedGenesVPDB.pm
@@ -16,7 +16,7 @@ limitations under the License.
 
 =cut
 
-package Bio::EnsEMBL::DataCheck::Checks::VersionedGenesBRC4;
+package Bio::EnsEMBL::DataCheck::Checks::VersionedGenesVPDB;
 
 use warnings;
 use strict;
@@ -28,9 +28,9 @@ use Bio::EnsEMBL::DataCheck::Test::DataCheck;
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
-  NAME        => 'VersionedGenesBRC4',
-  DESCRIPTION => 'Genes are unversioned in BRC4 databases',
-  GROUPS      => ['brc4_core'],
+  NAME        => 'VersionedGenesVPDB',
+  DESCRIPTION => 'Genes are unversioned in VEuPathDB databases',
+  GROUPS      => ['vpdb_core'],
   DB_TYPES    => ['core'],
   TABLES      => ['coord_system', 'gene', 'seq_region', 'transcript', 'translation']
 };

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -32,7 +32,7 @@
       "groups" : [
          "annotation",
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike"
       ],
       "name" : "AlignFeatureExternalDB",
@@ -53,7 +53,7 @@
       "description" : "Alt allele group members map back to the same chromosome",
       "groups" : [
          "core",
-         "brc4_core",
+         "vpdb_core",
          "geneset"
       ],
       "name" : "AltAllele",
@@ -64,7 +64,7 @@
       "description" : "No alt_allele_group has more than one gene from the primary assembly",
       "groups" : [
          "core",
-         "brc4_core",
+         "vpdb_core",
          "geneset"
       ],
       "name" : "AltAlleleGroup",
@@ -76,7 +76,7 @@
       "groups" : [
          "analysis_description",
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike",
          "geneset"
       ],
@@ -88,7 +88,7 @@
       "description" : "Analysis logic name and date are formatted correctly",
       "groups" : [
          "ancestral",
-         "brc4_core",
+         "vpdb_core",
          "core",
          "corelike"
       ],
@@ -129,7 +129,7 @@
       "groups" : [
          "ancestral",
          "assembly",
-         "brc4_core",
+         "vpdb_core",
          "core"
       ],
       "name" : "AssemblyExceptions",
@@ -141,7 +141,7 @@
       "groups" : [
          "assembly",
          "core",
-         "brc4_core"
+         "vpdb_core"
       ],
       "name" : "AssemblyExceptionsMapping",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::AssemblyExceptionsMapping"
@@ -152,7 +152,7 @@
       "groups" : [
          "ancestral",
          "assembly",
-         "brc4_core",
+         "vpdb_core",
          "core"
       ],
       "name" : "AssemblySeqregion",
@@ -163,7 +163,7 @@
       "description" : "Enum columns do not have empty string values",
       "groups" : [
          "ancestral",
-         "brc4_core",
+         "vpdb_core",
          "compara",
          "compara_blastocyst",
          "compara_gene_trees",
@@ -186,7 +186,7 @@
       "description" : "Nullable columns do not have empty string values",
       "groups" : [
          "ancestral",
-         "brc4_core",
+         "vpdb_core",
          "compara",
          "compara_blastocyst",
          "compara_gene_trees",
@@ -242,7 +242,7 @@
       "description" : "Canonical transcripts and translation are correctly configured",
       "groups" : [
          "core",
-         "brc4_core",
+         "vpdb_core",
          "geneset"
       ],
       "name" : "CanonicalTranscripts",
@@ -716,7 +716,7 @@
       "groups" : [
          "assembly",
          "core",
-         "brc4_core"
+         "vpdb_core"
       ],
       "name" : "ChromosomesAnnotated",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::ChromosomesAnnotated"
@@ -976,7 +976,7 @@
          "compara_homology_annotation",
          "compara_references",
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike",
          "funcgen",
          "schema",
@@ -1125,7 +1125,7 @@
       "groups" : [
          "analysis_description",
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike"
       ],
       "name" : "ControlledAnalysis",
@@ -1172,7 +1172,7 @@
       "groups" : [
          "controlled_tables",
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike"
       ],
       "name" : "ControlledTablesCore",
@@ -1245,7 +1245,7 @@
       "description" : "All tables have the same collation (latin1_swedish_ci)",
       "groups" : [
          "ancestral",
-         "brc4_core",
+         "vpdb_core",
          "compara",
          "compara_blastocyst",
          "compara_gene_trees",
@@ -1345,7 +1345,7 @@
       "groups" : [
          "analysis_description",
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike",
          "geneset"
       ],
@@ -1358,7 +1358,7 @@
       "groups" : [
          "analysis_description",
          "core",
-         "brc4_core",
+         "vpdb_core",
          "geneset",
          "meta_sample"
       ],
@@ -1410,7 +1410,7 @@
       "description" : "Exon regions are non-overlapping, and are consistent with their transcripts",
       "groups" : [
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike",
          "geneset"
       ],
@@ -1422,7 +1422,7 @@
       "description" : "Exon ranks are unique and sequential",
       "groups" : [
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike",
          "geneset"
       ],
@@ -1445,7 +1445,7 @@
       "groups" : [
          "annotation",
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike"
       ],
       "name" : "FeatureBounds",
@@ -1488,7 +1488,7 @@
       "description" : "Foreign key relationships are not violated",
       "groups" : [
          "ancestral",
-         "brc4_core",
+         "vpdb_core",
          "core",
          "corelike",
          "funcgen",
@@ -1571,7 +1571,7 @@
       "groups" : [
          "controlled_tables",
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike",
          "geneset"
       ],
@@ -1583,7 +1583,7 @@
       "description" : "Genes are within the bounds of their seq_region",
       "groups" : [
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike",
          "geneset"
       ],
@@ -1627,7 +1627,7 @@
       "description" : "Genes, transcripts, exons and translations have non-NULL, unique stable IDs",
       "groups" : [
          "core",
-         "brc4_core",
+         "vpdb_core",
          "geneset"
       ],
       "name" : "GeneStableID",
@@ -1638,7 +1638,7 @@
       "description" : "Genes have valid strand values",
       "groups" : [
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike",
          "geneset"
       ],
@@ -1753,7 +1753,7 @@
       "datacheck_type" : "critical",
       "description" : "LRG features and seq_regions are correctly configured",
       "groups" : [
-         "brc4_core",
+         "vpdb_core",
          "core"
       ],
       "name" : "LRG",
@@ -1836,7 +1836,7 @@
       "description" : "MT seq region has codon table attribute",
       "groups" : [
          "core",
-         "brc4_core"
+         "vpdb_core"
       ],
       "name" : "MTCodonTable",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MTCodonTable"
@@ -1876,7 +1876,7 @@
       "description" : "The meta_coord table is correctly populated",
       "groups" : [
          "annotation",
-         "brc4_core",
+         "vpdb_core",
          "core",
          "core_sync",
          "corelike",
@@ -1894,27 +1894,27 @@
       "groups" : [
          "assembly",
          "core",
-         "brc4_core",
+         "vpdb_core",
          "meta"
       ],
       "name" : "MetaKeyAssembly",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MetaKeyAssembly"
    },
-   "MetaKeyBRC4" : {
+   "MetaKeyVPDB" : {
       "datacheck_type" : "critical",
-      "description" : "Expected meta keys for BRC4 cores",
+      "description" : "Expected meta keys for VEuPathDB cores",
       "groups" : [
-         "brc4_core"
+         "vpdb_core"
       ],
-      "name" : "MetaKeyBRC4",
-      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MetaKeyBRC4"
+      "name" : "MetaKeyVPDB",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MetaKeyVPDB"
    },
    "MetaKeyCardinality" : {
       "datacheck_type" : "critical",
       "description" : "A subset of meta keys must only have a single value",
       "groups" : [
          "ancestral",
-         "brc4_core",
+         "vpdb_core",
          "core",
          "meta",
          "meta_sample"
@@ -1927,7 +1927,7 @@
       "description" : "Conditional meta keys exist if the data requires them",
       "groups" : [
          "core",
-         "brc4_core",
+         "vpdb_core",
          "meta",
          "variation"
       ],
@@ -1950,7 +1950,7 @@
       "description" : "Meta values are correctly formatted and linked",
       "groups" : [
          "ancestral",
-         "brc4_core",
+         "vpdb_core",
          "core",
          "meta",
          "meta_sample",
@@ -1964,7 +1964,7 @@
       "description" : "Meta keys are correctly assigned at species or database level",
       "groups" : [
          "ancestral",
-         "brc4_core",
+         "vpdb_core",
          "compara",
          "compara_gene_trees",
          "compara_genome_alignments",
@@ -1995,7 +1995,7 @@
       "groups" : [
          "assembly",
          "core",
-         "brc4_core"
+         "vpdb_core"
       ],
       "name" : "MitochondriaAnnotated",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MitochondriaAnnotated"
@@ -2035,7 +2035,7 @@
          "compara",
          "compara_homology_annotation",
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike",
          "funcgen",
          "schema",
@@ -2074,7 +2074,7 @@
       "datacheck_type" : "advisory",
       "description" : "Object_xrefs should be linked to an analysis",
       "groups" : [
-         "brc4_core",
+         "vpdb_core",
          "core",
          "xref",
          "xref_gene_symbol_transformer"
@@ -2134,7 +2134,7 @@
       "groups" : [
          "assembly",
          "core",
-         "brc4_core"
+         "vpdb_core"
       ],
       "name" : "PlastidsAnnotated",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::PlastidsAnnotated"
@@ -2145,7 +2145,7 @@
       "groups" : [
          "assembly",
          "core",
-         "brc4_core"
+         "vpdb_core"
       ],
       "name" : "PolyploidAttribs",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::PolyploidAttribs"
@@ -2221,7 +2221,7 @@
       "description" : "All protein-coding genes have a valid translation",
       "groups" : [
          "core",
-         "brc4_core",
+         "vpdb_core",
          "geneset"
       ],
       "name" : "ProteinTranslation",
@@ -2280,7 +2280,7 @@
       "groups" : [
          "annotation",
          "core",
-         "brc4_core"
+         "vpdb_core"
       ],
       "name" : "RepeatFeatures",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::RepeatFeatures"
@@ -2309,7 +2309,7 @@
       "datacheck_type" : "critical",
       "description" : "Schema patches are up-to-date",
       "groups" : [
-         "brc4_core",
+         "vpdb_core",
          "compara",
          "compara_gene_trees",
          "compara_genome_alignments",
@@ -2328,7 +2328,7 @@
       "datacheck_type" : "critical",
       "description" : "The schema type meta key matches the DB name",
       "groups" : [
-         "brc4_core",
+         "vpdb_core",
          "compara",
          "compara_gene_trees",
          "compara_genome_alignments",
@@ -2350,7 +2350,7 @@
       "description" : "The schema version meta key matches the DB name",
       "groups" : [
          "ancestral",
-         "brc4_core",
+         "vpdb_core",
          "compara",
          "compara_homology_annotation",
          "core",
@@ -2362,14 +2362,14 @@
       "name" : "SchemaVersion",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SchemaVersion"
    },
-   "SeqRegionBRC4" : {
+   "SeqRegionVPDB" : {
       "datacheck_type" : "critical",
-      "description" : "Seq_region for BRC4 have correct attributes",
+      "description" : "Seq_region for VEuPathDB have correct attributes",
       "groups" : [
-         "brc4_core"
+         "vpdb_core"
       ],
-      "name" : "SeqRegionBRC4",
-      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SeqRegionBRC4"
+      "name" : "SeqRegionVPDB",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SeqRegionVPDB"
    },
    "SeqRegionNames" : {
       "datacheck_type" : "critical",
@@ -2377,7 +2377,7 @@
       "groups" : [
          "ancestral",
          "assembly",
-         "brc4_core",
+         "vpdb_core",
          "core"
       ],
       "name" : "SeqRegionNames",
@@ -2419,7 +2419,7 @@
       "groups" : [
          "assembly",
          "core",
-         "brc4_core"
+         "vpdb_core"
       ],
       "name" : "SeqRegionRank",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SeqRegionRank"
@@ -2429,7 +2429,7 @@
       "description" : "Seq_region synonyms do not clash with seq region names",
       "groups" : [
          "assembly",
-         "brc4_core",
+         "vpdb_core",
          "core"
       ],
       "name" : "SeqRegionSynonyms",
@@ -2441,7 +2441,7 @@
       "groups" : [
          "assembly",
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike",
          "geneset"
       ],
@@ -2463,7 +2463,7 @@
       "groups" : [
          "assembly",
          "core",
-         "brc4_core"
+         "vpdb_core"
       ],
       "name" : "SequenceLevel",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SequenceLevel"
@@ -2484,7 +2484,7 @@
       "description" : "Simple features are not from analysis type gene, mrna and cds",
       "groups" : [
          "core",
-         "brc4_core"
+         "vpdb_core"
       ],
       "name" : "SimpleFeatureAnalysisTypes",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SimpleFeatureAnalysisTypes"
@@ -2521,7 +2521,7 @@
       "description" : "Species production_name and alias are unique across all databases in the registry",
       "groups" : [
          "core",
-         "brc4_core",
+         "vpdb_core",
          "meta"
       ],
       "name" : "SpeciesNameUnique",
@@ -2541,7 +2541,7 @@
       "description" : "Taxonomic meta keys are consistent with taxonomy database",
       "groups" : [
          "core",
-         "brc4_core",
+         "vpdb_core",
          "meta"
       ],
       "name" : "SpeciesTaxonomy",
@@ -2620,7 +2620,7 @@
       "description" : "Gene and transcript bounds are consistent",
       "groups" : [
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike",
          "geneset"
       ],
@@ -2688,7 +2688,7 @@
       "description" : "Transcripts are linked to sequences",
       "groups" : [
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike",
          "geneset"
       ],
@@ -2712,7 +2712,7 @@
       "description" : "Transcripts have translations, if appropriate",
       "groups" : [
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike",
          "geneset"
       ],
@@ -2724,7 +2724,7 @@
       "description" : "Translations have appropriate properties",
       "groups" : [
          "core",
-         "brc4_core",
+         "vpdb_core",
          "corelike",
          "geneset"
       ],
@@ -2831,14 +2831,14 @@
       "name" : "VersionedGenes",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::VersionedGenes"
    },
-   "VersionedGenesBRC4" : {
+   "VersionedGenesVPDB" : {
       "datacheck_type" : "critical",
-      "description" : "Genes are unversioned in BRC4 databases",
+      "description" : "Genes are unversioned in VEuPathDB databases",
       "groups" : [
-         "brc4_core"
+         "vpdb_core"
       ],
-      "name" : "VersionedGenesBRC4",
-      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::VersionedGenesBRC4"
+      "name" : "VersionedGenesVPDB",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::VersionedGenesVPDB"
    },
    "WhitespaceAdvisory" : {
       "datacheck_type" : "advisory",


### PR DESCRIPTION
BRC4 is the name of the grant, and if the new one is granted, it will become BRC5, so we better rename it to its corresponding project, VEuPathDB (where less critical, not planning on changing core db content besides the meta keys).