### PR TITLE
Add datacheck support for CACTUS_DB alignment data

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CactusMetadataConsistency.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CactusMetadataConsistency.pm
@@ -44,7 +44,11 @@ sub tests {
   my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
   my $gdb_adap = $self->dba->get_GenomeDBAdaptor;
 
-  my $cactus_mlsses = $mlss_adap->fetch_all_by_method_link_type('CACTUS_HAL');
+  my $cactus_mlsses = [];
+  foreach my $method_type ('CACTUS_DB', 'CACTUS_HAL') {
+    my $cactus_mlsses_of_type = $mlss_adap->fetch_all_by_method_link_type($method_type);
+    push(@{$cactus_mlsses}, @{$cactus_mlsses_of_type});
+  }
 
   unless (scalar(@{$cactus_mlsses})) {
     plan skip_all => "No Cactus MLSSes in this database";

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignGenomeDBs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignGenomeDBs.pm
@@ -40,7 +40,7 @@ use constant {
 sub skip_tests {
     my ($self) = @_;
     my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
-    my @methods = qw (PECAN EPO EPO_EXTENDED LASTZ_NET LASTZ_PATCH);
+    my @methods = qw (CACTUS_DB PECAN EPO EPO_EXTENDED LASTZ_NET LASTZ_PATCH);
     my $db_name = $self->dba->dbc->dbname;
 
     my @mlsses;
@@ -60,7 +60,7 @@ sub tests {
   my $helper = $dba->dbc->sql_helper;
   my $mlss_adap = $dba->get_MethodLinkSpeciesSetAdaptor;
   my $gdb_adap = $dba->get_GenomeDBAdaptor;
-  my @mlss_types = qw ( PECAN EPO EPO_EXTENDED LASTZ_NET LASTZ_PATCH);
+  my @mlss_types = qw (CACTUS_DB PECAN EPO EPO_EXTENDED LASTZ_NET LASTZ_PATCH);
   my $ancestral = $gdb_adap->fetch_all_by_name('ancestral_sequences');
   my @mlsses;
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignments.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckGenomicAlignments.pm
@@ -41,7 +41,7 @@ sub skip_tests {
   my ($self) = @_;
   my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
 
-  my @method_links = qw(LASTZ_NET LASTZ_PATCH EPO EPO_EXTENDED PECAN POLYPLOID TRANSLATED_BLAT_NET);
+  my @method_links = qw(CACTUS_DB LASTZ_NET LASTZ_PATCH EPO EPO_EXTENDED PECAN POLYPLOID TRANSLATED_BLAT_NET);
   my @mlsss;
   foreach my $method (@method_links) {
     my $mlss = $mlss_adap->fetch_all_by_method_link_type($method);
@@ -59,7 +59,7 @@ sub tests {
   my ($self) = @_;
   my $dba    = $self->dba;
   my $helper = $dba->dbc->sql_helper;
-  my @method_links = qw(LASTZ_NET LASTZ_PATCH EPO EPO_EXTENDED PECAN POLYPLOID TRANSLATED_BLAT_NET);
+  my @method_links = qw(CACTUS_DB LASTZ_NET LASTZ_PATCH EPO EPO_EXTENDED PECAN POLYPLOID TRANSLATED_BLAT_NET);
 
   my $expected_align_count;
   my @tables    = qw(genomic_align genomic_align_block);

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMSANames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckMSANames.pm
@@ -38,7 +38,7 @@ use constant {
 sub skip_tests {
     my ($self) = @_;
     my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
-    my @methods = qw( EPO EPO_EXTENDED PECAN );
+    my @methods = qw( CACTUS_DB EPO EPO_EXTENDED PECAN );
     my $db_name = $self->dba->dbc->dbname;
     
     my @mlsses;
@@ -56,7 +56,7 @@ sub skip_tests {
 sub tests {
   my ($self) = @_;
   my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
-  my @methods = qw( EPO EPO_EXTENDED PECAN );
+  my @methods = qw( CACTUS_DB EPO EPO_EXTENDED PECAN );
   my $db_name = $self->dba->dbc->dbname;
   my $dbc = $self->dba->dbc;
   my @mlsses;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesTrees.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckSpeciesTrees.pm
@@ -42,7 +42,7 @@ sub tests {
   my ($self) = @_;
   my $dba    = $self->dba;
   my $helper = $dba->dbc->sql_helper;
-  my @method_links = qw(CACTUS_HAL EPO EPO_EXTENDED PECAN PROTEIN_TREES NC_TREES SPECIES_TREE);
+  my @method_links = qw(CACTUS_DB CACTUS_HAL EPO EPO_EXTENDED PECAN PROTEIN_TREES NC_TREES SPECIES_TREE);
 
   my $expected_tree_count;
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareMSANames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareMSANames.pm
@@ -43,7 +43,7 @@ sub tests {
   my $prev_db_name = $prev_dba->dbc->dbname;
   my $curr_mlss_adap = $curr_dba->get_MethodLinkSpeciesSetAdaptor;
   my $prev_mlss_adap = $prev_dba->get_MethodLinkSpeciesSetAdaptor;
-  my @mlss_types = qw ( PECAN EPO EPO_EXTENDED CACTUS_HAL );
+  my @mlss_types = qw ( PECAN EPO EPO_EXTENDED CACTUS_HAL CACTUS_DB );
   my @curr_mlsses;
   my @prev_mlsses;
   

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagMultipleAlignment.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagMultipleAlignment.pm
@@ -39,7 +39,7 @@ use constant {
 sub skip_tests {
   my ($self) = @_;
   my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
-  my @methods = qw( EPO EPO_EXTENDED PECAN );
+  my @methods = qw( CACTUS_DB EPO EPO_EXTENDED PECAN );
   my $db_name = $self->dba->dbc->dbname;
   
   my @mlsses;
@@ -63,6 +63,7 @@ sub tests {
 
   has_tags($self->dba, 'EPO', $tags);
   has_tags($self->dba, 'PECAN', $tags);
+  has_tags($self->dba, 'CACTUS_DB', $tags);
 
   push @$tags, 'base_mlss_id';
   has_tags($self->dba, 'EPO_EXTENDED', $tags);

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MultipleGenomicAlignBlockIds.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MultipleGenomicAlignBlockIds.pm
@@ -39,7 +39,7 @@ use constant {
 sub skip_tests {
     my ($self) = @_;
     my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
-    my @methods = qw (PECAN CACTUS_HAL LASTZ_NET LASTZ_PATCH EPO_EXTENDED);
+    my @methods = qw (CACTUS_DB PECAN CACTUS_HAL LASTZ_NET LASTZ_PATCH EPO_EXTENDED);
     my $db_name = $self->dba->dbc->dbname;
 
     my @mlsses;
@@ -58,7 +58,7 @@ sub tests {
   my $dba = $self->dba;
   my $dbc = $dba->dbc;
   my $mlss_adap = $dba->get_MethodLinkSpeciesSetAdaptor;
-  my @mlss_types = qw (PECAN CACTUS_HAL LASTZ_NET LASTZ_PATCH EPO_EXTENDED);
+  my @mlss_types = qw (CACTUS_DB PECAN CACTUS_HAL LASTZ_NET LASTZ_PATCH EPO_EXTENDED);
   my @mlsses;
   
   # The tests are excluded from the EPO methods because these have ancestral sequences in


### PR DESCRIPTION
This PR adds support for `CACTUS_DB` alignments to relevant datachecks.

Unlike with `CACTUS_HAL`, a `CACTUS_DB` MLSS can have alignment data in the database.

All the updated datachecks passed on `mysql-ens-compara-prod-8:4618/ensembl_compara_metazoa_60_113`. 