### PR TITLE
Add StrainGeneTreeSpeciesSets datacheck

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/StrainGeneTreeSpeciesSets.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/StrainGeneTreeSpeciesSets.pm
@@ -85,7 +85,7 @@ sub tests {
   my @known_strain_types = ('strain', 'breed', 'cultivar');
   my $known_strain_type_patt = join('|', @known_strain_types);
 
-  my %gdb_to_species_set_names;
+  my %gdb_to_collection_name_set;
   while (my ($species_set_id, $gene_tree_species_set) = each %strain_species_sets_by_id) {
 
     my $species_set_name = $gene_tree_species_set->name =~ s/^collection-//r;
@@ -100,12 +100,12 @@ sub tests {
     }
 
     foreach my $gdb (@{$gene_tree_species_set->genome_dbs}) {
-      push(@{$gdb_to_species_set_names{$gdb->name}}, $gene_tree_species_set->name);
+      $gdb_to_collection_name_set{$gdb->name}{$gene_tree_species_set->name} = 1;
     }
   }
 
-  foreach my $gdb_name (sort keys %gdb_to_species_set_names) {
-    my @species_sets_with_gdb = @{$gdb_to_species_set_names{$gdb_name}};
+  foreach my $gdb_name (sort keys %gdb_to_collection_name_set) {
+    my @species_sets_with_gdb = keys %{$gdb_to_collection_name_set{$gdb_name}};
     my $desc_3 = "Genome $gdb_name is in one strain gene-tree species set";
     is(scalar(@species_sets_with_gdb), 1, $desc_3);
   }

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/StrainGeneTreeSpeciesSets.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/StrainGeneTreeSpeciesSets.pm
@@ -85,6 +85,7 @@ sub tests {
   my @known_strain_types = ('strain', 'breed', 'cultivar');
   my $known_strain_type_patt = join('|', @known_strain_types);
 
+  my %gdb_to_species_set_names;
   while (my ($species_set_id, $gene_tree_species_set) = each %strain_species_sets_by_id) {
 
     my $species_set_name = $gene_tree_species_set->name =~ s/^collection-//r;
@@ -97,6 +98,15 @@ sub tests {
       my $strain_type = $gene_tree_species_set->get_value_for_tag('strain_type');
       ok($strain_type =~ /^${known_strain_type_patt}$/, $desc_2);
     }
+
+    foreach my $gdb (@{$gene_tree_species_set->genome_dbs}) {
+      push(@{$gdb_to_species_set_names{$gdb->name}}, $gene_tree_species_set->name);
+    }
+  }
+
+  while (my ($gdb_name, $species_set_names) = each %gdb_to_species_set_names) {
+    my $desc_3 = "Genome $gdb_name is in one strain gene-tree species set";
+    is(scalar(@{$species_set_names}), 1, $desc_3);
   }
 }
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/StrainGeneTreeSpeciesSets.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/StrainGeneTreeSpeciesSets.pm
@@ -104,9 +104,10 @@ sub tests {
     }
   }
 
-  while (my ($gdb_name, $species_set_names) = each %gdb_to_species_set_names) {
+  foreach my $gdb_name (sort keys %gdb_to_species_set_names) {
+    my @species_sets_with_gdb = @{$gdb_to_species_set_names{$gdb_name}};
     my $desc_3 = "Genome $gdb_name is in one strain gene-tree species set";
-    is(scalar(@{$species_set_names}), 1, $desc_3);
+    is(scalar(@species_sets_with_gdb), 1, $desc_3);
   }
 }
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/StrainGeneTreeSpeciesSets.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/StrainGeneTreeSpeciesSets.pm
@@ -1,0 +1,103 @@
+=head1 LICENSE
+
+Copyright [2018-2024] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::StrainGeneTreeSpeciesSets;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'StrainGeneTreeSpeciesSets',
+  DESCRIPTION    => 'Strain-level gene-tree species sets are as expected',
+  GROUPS         => ['compara', 'compara_gene_tree_pipelines', 'compara_gene_trees', 'compara_master'],
+  DATACHECK_TYPE => 'critical',
+  DB_TYPES       => ['compara'],
+  TABLES         => ['genome_db', 'method_link', 'method_link_species_set', 'species_set', 'species_set_header', 'species_set_tag']
+};
+
+
+sub tests {
+  my ($self) = @_;
+
+  my $compara_dba = $self->dba;
+  my $mlss_dba = $compara_dba->get_MethodLinkSpeciesSetAdaptor();
+  my $species_set_dba = $compara_dba->get_SpeciesSetAdaptor();
+
+  my @gene_tree_mlsses;
+  foreach my $method_type ('PROTEIN_TREES', 'NC_TREES') {
+    my $mlsses_of_type = $mlss_dba->fetch_all_by_method_link_type($method_type);
+    push(@gene_tree_mlsses, @{$mlsses_of_type});
+  }
+
+  my %species_sets_by_id;
+  foreach my $gene_tree_mlss (@gene_tree_mlsses) {
+    my $gene_tree_species_set = $species_set_dba->fetch_by_dbID($gene_tree_mlss->species_set->dbID);
+    $species_sets_by_id{$gene_tree_species_set->dbID} = $gene_tree_species_set;
+  }
+
+  my %strain_species_sets_by_id;
+  while (my ($species_set_id, $gene_tree_species_set) = each %species_sets_by_id) {
+    my @gdbs = @{$gene_tree_species_set->genome_dbs};
+    my %gdb_name_set = map { $_->name => 1 } @gdbs;
+
+    my %strain_group_breakdown;
+    foreach my $gdb (@gdbs) {
+      my $core_dba = $self->get_dba($gdb->name, 'core');
+      my $meta_container = $core_dba->get_adaptor('MetaContainer');
+      my $ref_gdb_name = $meta_container->single_value_by_key('species.strain_group', 0);
+      next unless defined $ref_gdb_name && exists $gdb_name_set{$ref_gdb_name};
+      $strain_group_breakdown{$ref_gdb_name} += 1;
+    }
+
+    my @ref_gdb_names = sort { $strain_group_breakdown{$b} <=> $strain_group_breakdown{$a} } keys %strain_group_breakdown;
+
+    if (scalar(@ref_gdb_names) > 0) {
+      my $consensus_ref_gdb_name = $ref_gdb_names[0];
+      my $strain_count = $strain_group_breakdown{$consensus_ref_gdb_name};
+      my $strain_count_threshold = 0.5 * $gene_tree_species_set->size;
+
+      if ($strain_count >= $strain_count_threshold) {
+        $strain_species_sets_by_id{$gene_tree_species_set->dbID} = $gene_tree_species_set;
+      }
+    }
+  }
+
+  my @known_strain_types = ('strain', 'breed', 'cultivar');
+  my $known_strain_type_patt = join('|', @known_strain_types);
+
+  while (my ($species_set_id, $gene_tree_species_set) = each %strain_species_sets_by_id) {
+
+    my $species_set_name = $gene_tree_species_set->name =~ s/^collection-//r;
+    my $desc_1 = "Gene-tree species set $species_set_name has a strain_type tag";
+    my $has_strain_type_tag = $gene_tree_species_set->has_tag('strain_type');
+    ok($has_strain_type_tag, $desc_1);
+
+    if ($has_strain_type_tag) {
+      my $desc_2 = "Gene-tree species set $species_set_name has a known strain type";
+      my $strain_type = $gene_tree_species_set->get_value_for_tag('strain_type');
+      ok($strain_type =~ /^${known_strain_type_patt}$/, $desc_2);
+    }
+  }
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2559,6 +2559,18 @@
       "name" : "StableIdDisplayXref",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::StableIdDisplayXref"
    },
+   "StrainGeneTreeSpeciesSets" : {
+      "datacheck_type" : "critical",
+      "description" : "Strain-level gene-tree species sets are as expected",
+      "groups" : [
+         "compara",
+         "compara_gene_tree_pipelines",
+         "compara_gene_trees",
+         "compara_master",
+      ],
+      "name" : "StrainGeneTreeSpeciesSets",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::StrainGeneTreeSpeciesSets"
+   },
    "StrainType" : {
       "datacheck_type" : "critical",
       "description" : "The strain type must be from an approved list",


### PR DESCRIPTION
This PR would add a `StrainGeneTreeSpeciesSets` datacheck, which would help ensure that strain-level gene-tree species sets are configured as expected.

The main practical consequence would be that the `strain_type` species-set tag would be required for strain-level collections (e.g. Murinae, Rice cultivars), allowing for code updates depending on this tag.

The datacheck also verifies that no genome is present in more than one strain-level gene-tree species set, an implicit assumption of Compara and Web code dealing with strain-level gene trees.

The datacheck was tested on Vertebrates and Plants Compara release 112 and 113 databases  in an Ensembl 113 environment.

Database `ensembl_compara_113` has valid strain-type tags for both Mouse strains and Pig breeds, and had this datacheck output:
```
StrainGeneTreeSpeciesSets .. 
# Subtest: StrainGeneTreeSpeciesSets
    # Subtest: multi, compara, ensembl_compara_113, multi
        ok 1 - Gene-tree species set pig_breeds has a strain_type tag
        ok 2 - Gene-tree species set pig_breeds has a known strain type
        ok 3 - Gene-tree species set murinae has a strain_type tag
        ok 4 - Gene-tree species set murinae has a known strain type
        ok 5 - Genome bos_taurus is in one strain gene-tree species set
        ok 6 - Genome equus_caballus is in one strain gene-tree species set
        ok 7 - Genome mus_caroli is in one strain gene-tree species set
        ok 8 - Genome mus_musculus is in one strain gene-tree species set
        ok 9 - Genome mus_musculus_129s1svimj is in one strain gene-tree species set
        ok 10 - Genome mus_musculus_aj is in one strain gene-tree species set
        ok 11 - Genome mus_musculus_akrj is in one strain gene-tree species set
        ok 12 - Genome mus_musculus_balbcj is in one strain gene-tree species set
        ok 13 - Genome mus_musculus_c3hhej is in one strain gene-tree species set
        ok 14 - Genome mus_musculus_c57bl6nj is in one strain gene-tree species set
        ok 15 - Genome mus_musculus_casteij is in one strain gene-tree species set
        ok 16 - Genome mus_musculus_cbaj is in one strain gene-tree species set
        ok 17 - Genome mus_musculus_dba2j is in one strain gene-tree species set
        ok 18 - Genome mus_musculus_fvbnj is in one strain gene-tree species set
        ok 19 - Genome mus_musculus_lpj is in one strain gene-tree species set
        ok 20 - Genome mus_musculus_nodshiltj is in one strain gene-tree species set
        ok 21 - Genome mus_musculus_nzohlltj is in one strain gene-tree species set
        ok 22 - Genome mus_musculus_pwkphj is in one strain gene-tree species set
        ok 23 - Genome mus_musculus_wsbeij is in one strain gene-tree species set
        ok 24 - Genome mus_pahari is in one strain gene-tree species set
        ok 25 - Genome mus_spicilegus is in one strain gene-tree species set
        ok 26 - Genome mus_spretus is in one strain gene-tree species set
        ok 27 - Genome ovis_aries_rambouillet is in one strain gene-tree species set
        ok 28 - Genome rattus_norvegicus is in one strain gene-tree species set
        ok 29 - Genome sus_scrofa is in one strain gene-tree species set
        ok 30 - Genome sus_scrofa_bamei is in one strain gene-tree species set
        ok 31 - Genome sus_scrofa_berkshire is in one strain gene-tree species set
        ok 32 - Genome sus_scrofa_gca007644095v1 is in one strain gene-tree species set
        ok 33 - Genome sus_scrofa_gca015776825v1 is in one strain gene-tree species set
        ok 34 - Genome sus_scrofa_gca018555405v1 is in one strain gene-tree species set
        ok 35 - Genome sus_scrofa_gca019290145v1 is in one strain gene-tree species set
        ok 36 - Genome sus_scrofa_gca020567905v1 is in one strain gene-tree species set
        ok 37 - Genome sus_scrofa_gca021656055v1 is in one strain gene-tree species set
        ok 38 - Genome sus_scrofa_gca024718415v1 is in one strain gene-tree species set
        ok 39 - Genome sus_scrofa_hampshire is in one strain gene-tree species set
        ok 40 - Genome sus_scrofa_jinhua is in one strain gene-tree species set
        ok 41 - Genome sus_scrofa_landrace is in one strain gene-tree species set
        ok 42 - Genome sus_scrofa_largewhite is in one strain gene-tree species set
        ok 43 - Genome sus_scrofa_meishan is in one strain gene-tree species set
        ok 44 - Genome sus_scrofa_pietrain is in one strain gene-tree species set
        ok 45 - Genome sus_scrofa_rongchang is in one strain gene-tree species set
        ok 46 - Genome sus_scrofa_tibetan is in one strain gene-tree species set
        ok 47 - Genome sus_scrofa_usmarc is in one strain gene-tree species set
        ok 48 - Genome sus_scrofa_wuzhishan is in one strain gene-tree species set
        1..48
    ok 1 - multi, compara, ensembl_compara_113, multi
    1..1
ok 1 - StrainGeneTreeSpeciesSets
1..1
ok
All tests successful.
Files=1, Tests=1,  4 wallclock secs ( 1.75 usr  0.19 sys +  0.12 cusr  0.13 csys =  2.19 CPU)
Result: PASS
```

Database `ensembl_compara_113` lacks strain-type tags, and had the following datacheck output:
```
StrainGeneTreeSpeciesSets .. 
# Subtest: StrainGeneTreeSpeciesSets
    # Subtest: multi, compara, ensembl_compara_112, multi
        not ok 1 - Gene-tree species set murinae has a strain_type tag

        #   Failed test 'Gene-tree species set murinae has a strain_type tag'
        #   at /hps/software/users/ensembl/compara/twalsh/repos/e113/ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/Checks/StrainGeneTreeSpeciesSets.pm line 94.
        not ok 2 - Gene-tree species set pig_breeds has a strain_type tag

        #   Failed test 'Gene-tree species set pig_breeds has a strain_type tag'
        #   at /hps/software/users/ensembl/compara/twalsh/repos/e113/ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/Checks/StrainGeneTreeSpeciesSets.pm line 94.
        ok 3 - Genome bos_taurus is in one strain gene-tree species set
        ok 4 - Genome equus_caballus is in one strain gene-tree species set
        ok 5 - Genome mus_caroli is in one strain gene-tree species set
        ok 6 - Genome mus_musculus is in one strain gene-tree species set
        ok 7 - Genome mus_musculus_129s1svimj is in one strain gene-tree species set
        ok 8 - Genome mus_musculus_aj is in one strain gene-tree species set
        ok 9 - Genome mus_musculus_akrj is in one strain gene-tree species set
        ok 10 - Genome mus_musculus_balbcj is in one strain gene-tree species set
        ok 11 - Genome mus_musculus_c3hhej is in one strain gene-tree species set
        ok 12 - Genome mus_musculus_c57bl6nj is in one strain gene-tree species set
        ok 13 - Genome mus_musculus_casteij is in one strain gene-tree species set
        ok 14 - Genome mus_musculus_cbaj is in one strain gene-tree species set
        ok 15 - Genome mus_musculus_dba2j is in one strain gene-tree species set
        ok 16 - Genome mus_musculus_fvbnj is in one strain gene-tree species set
        ok 17 - Genome mus_musculus_lpj is in one strain gene-tree species set
        ok 18 - Genome mus_musculus_nodshiltj is in one strain gene-tree species set
        ok 19 - Genome mus_musculus_nzohlltj is in one strain gene-tree species set
        ok 20 - Genome mus_musculus_pwkphj is in one strain gene-tree species set
        ok 21 - Genome mus_musculus_wsbeij is in one strain gene-tree species set
        ok 22 - Genome mus_pahari is in one strain gene-tree species set
        ok 23 - Genome mus_spicilegus is in one strain gene-tree species set
        ok 24 - Genome mus_spretus is in one strain gene-tree species set
        ok 25 - Genome ovis_aries_rambouillet is in one strain gene-tree species set
        ok 26 - Genome rattus_norvegicus is in one strain gene-tree species set
        ok 27 - Genome sus_scrofa is in one strain gene-tree species set
        ok 28 - Genome sus_scrofa_bamei is in one strain gene-tree species set
        ok 29 - Genome sus_scrofa_berkshire is in one strain gene-tree species set
        ok 30 - Genome sus_scrofa_hampshire is in one strain gene-tree species set
        ok 31 - Genome sus_scrofa_jinhua is in one strain gene-tree species set
        ok 32 - Genome sus_scrofa_landrace is in one strain gene-tree species set
        ok 33 - Genome sus_scrofa_largewhite is in one strain gene-tree species set
        ok 34 - Genome sus_scrofa_meishan is in one strain gene-tree species set
        ok 35 - Genome sus_scrofa_pietrain is in one strain gene-tree species set
        ok 36 - Genome sus_scrofa_rongchang is in one strain gene-tree species set
        ok 37 - Genome sus_scrofa_tibetan is in one strain gene-tree species set
        ok 38 - Genome sus_scrofa_usmarc is in one strain gene-tree species set
        ok 39 - Genome sus_scrofa_wuzhishan is in one strain gene-tree species set
        1..39
        # Looks like you failed 2 tests of 39.
    not ok 1 - multi, compara, ensembl_compara_112, multi

    #   Failed test 'multi, compara, ensembl_compara_112, multi'
    #   at /hps/software/users/ensembl/compara/twalsh/repos/e113/ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm line 728.
    1..1
    # Looks like you failed 1 test of 1.
not ok 1 - StrainGeneTreeSpeciesSets

#   Failed test 'StrainGeneTreeSpeciesSets'
#   at /hps/software/users/ensembl/compara/twalsh/repos/e113/ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/BaseCheck.pm line 170.
1..1
Failed 1/1 subtests 

Test Summary Report
-------------------
StrainGeneTreeSpeciesSets (Wstat: 0 Tests: 1 Failed: 1)
  Failed test:  1
Files=1, Tests=1,  4 wallclock secs ( 1.75 usr  0.15 sys +  0.12 cusr  0.13 csys =  2.15 CPU)
Result: FAIL
```