### PR TITLE
Revert to stricter homology redundancy check

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomology.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CheckHomology.pm
@@ -58,7 +58,7 @@ sub tests {
       homology_member hm2 USING (homology_id)
     WHERE
       hm1.gene_member_id < hm2.gene_member_id
-    GROUP BY h1.gene_tree_root_id, hm1.gene_member_id, hm2.gene_member_id
+    GROUP BY hm1.gene_member_id, hm2.gene_member_id
     HAVING COUNT(*) > 1
   /;
 


### PR DESCRIPTION
During Ensembl 105, the homology redundancy check in `CheckHomology` was changed to allow for redundant homologies between two gene members if those homologies were in a different gene tree (and consequently had a different `gene_tree_root_id`).

This change was understandable in the context of Ensembl 105 production. Since then, Compara pipelines have been updated to more effectively deal with redundant homology data, and so the stricter homology redundancy check has become more appropriate again.

This PR would revert to using the stricter homology redundancy check.