### PR TITLE
Add advisory datacheck MemberStableIDClash

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MemberStableIDClash.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MemberStableIDClash.pm
@@ -1,0 +1,118 @@
+=head1 LICENSE
+
+Copyright [2018-2024] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::MemberStableIDClash;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'MemberStableIDClash',
+  DESCRIPTION    => 'Members should not have stable ID clashes',
+  GROUPS         => ['compara', 'compara_gene_trees'],
+  DATACHECK_TYPE => 'advisory',
+  DB_TYPES       => ['compara'],
+  TABLES         => ['gene_member', 'seq_member']
+};
+
+sub skip_tests {
+  my ($self) = @_;
+  my $dbc = $self->dba->dbc;
+
+  my $member_count_sql = q/SELECT COUNT(*) FROM gene_member/;
+  my $member_count = $dbc->sql_helper->execute_single_result( -SQL => $member_count_sql );
+  if ( $member_count == 0 ) {
+    return( 1, sprintf("There are no gene members in %s", $dbc->dbname) );
+  }
+}
+
+sub tests {
+  my ($self) = @_;
+
+  my $desc_1 = "Case-sensitive stable ID uniqueness among gene members";
+  my $sql_1 = q/
+    SELECT gene_stable_id
+    FROM (
+      SELECT CONVERT(stable_id USING BINARY) AS gene_stable_id
+      FROM gene_member
+      UNION ALL
+      SELECT CONVERT(CONCAT(stable_id, '.', version) USING BINARY) AS gene_stable_id
+      FROM gene_member
+      WHERE version > 0
+    ) gene_stable_ids
+    GROUP BY gene_stable_id
+    HAVING COUNT(*) > 1;
+  /;
+  is_rows_zero($self->dba, $sql_1, $desc_1);
+
+  my $desc_2 = "Case-sensitive stable ID uniqueness among sequence members";
+  my $sql_2 = q/
+    SELECT seq_stable_id
+    FROM (
+      SELECT CONVERT(stable_id USING BINARY) AS seq_stable_id
+      FROM seq_member
+      UNION ALL
+      SELECT CONVERT(CONCAT(stable_id, '.', version) USING BINARY) AS seq_stable_id
+      FROM seq_member
+      WHERE version > 0
+    ) seq_stable_ids
+    GROUP BY seq_stable_id
+    HAVING COUNT(*) > 1;
+  /;
+  is_rows_zero($self->dba, $sql_2, $desc_2);
+
+  my $desc_3 = "Case-insensitive stable ID uniqueness among gene members";
+  my $sql_3 = q/
+    SELECT gene_stable_id
+    FROM (
+      SELECT stable_id AS gene_stable_id
+      FROM gene_member
+      UNION ALL
+      SELECT CONCAT(stable_id, '.', version) AS gene_stable_id
+      FROM gene_member
+      WHERE version > 0
+    ) gene_stable_ids
+    GROUP BY gene_stable_id
+    HAVING COUNT(*) > 1;
+  /;
+  is_rows_zero($self->dba, $sql_3, $desc_3);
+
+  my $desc_4 = "Case-insensitive stable ID uniqueness among sequence members";
+  my $sql_4 = q/
+    SELECT seq_stable_id
+    FROM (
+      SELECT stable_id AS seq_stable_id
+      FROM seq_member
+      UNION ALL
+      SELECT CONCAT(stable_id, '.', version) AS seq_stable_id
+      FROM seq_member
+      WHERE version > 0
+    ) seq_stable_ids
+    GROUP BY seq_stable_id
+    HAVING COUNT(*) > 1;
+  /;
+  is_rows_zero($self->dba, $sql_4, $desc_4);
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1862,6 +1862,16 @@
       "name" : "MemberProductionCounts",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MemberProductionCounts"
    },
+   "MemberStableIDClash" : {
+      "datacheck_type" : "advisory",
+      "description" : "Members should not have stable ID clashes",
+      "groups" : [
+         "compara",
+         "compara_gene_trees"
+      ],
+      "name" : "MemberStableIDClash",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MemberStableIDClash"
+   },
    "MemberXrefAccessTime" : {
       "datacheck_type" : "critical",
       "description" : "Compara member xref data can be accessed in a timely manner",


### PR DESCRIPTION
Previous efforts have addressed the issue of case-insensitive member stable ID clashes within a Compara database (e.g. [ENSCOMPARASW-5270](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-5270), [ENSCOMPARASW-6258](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-6258)).

Some issues remain, particularly with case-_sensitive_ member stable ID clashes (see [here](https://www.ebi.ac.uk/panda/jira/issues/?jql=labels%20%3D%20stable_id_clash)), with the impact being moderate if the clash occurs between members in different gene-tree collections, and potentially significant if the clash affects members within the same gene-tree collection.

This PR introduces an advisory datacheck to flag stable ID clashes, both case-sensitive and case-insensitive.

When tested on `ensembl_compara_113`, it generated the following output:
```
MemberStableIDClash ..
# Subtest: MemberStableIDClash
    # Subtest: multi, compara, ensembl_compara_113, multi
        ok 1 - Case-sensitive stable ID uniqueness among gene members
        ok 2 - Case-sensitive stable ID uniqueness among sequence members
        ok 3 - Case-insensitive stable ID uniqueness among gene members
        ok 4 - Case-insensitive stable ID uniqueness among sequence members
        1..4
    ok 1 - multi, compara, ensembl_compara_113, multi
    1..1
ok 1 - MemberStableIDClash
1..1
ok
All tests successful.
Files=1, Tests=1,  1 wallclock secs ( 0.04 usr +  0.02 sys =  0.06 CPU)
Result: PASS
```

On `ensembl_compara_master` the output was:
```
MemberStableIDClash ..
# Subtest: MemberStableIDClash
    # Subtest: multi, compara, ensembl_compara_master, multi
        1..0 # SKIP There are no gene members in ensembl_compara_master
    ok 1 # skip There are no gene members in ensembl_compara_master
    1..1
ok 1 - MemberStableIDClash
1..1
ok
All tests successful.
Files=1, Tests=1,  4 wallclock secs ( 0.04 usr +  0.02 sys =  0.06 CPU)
Result: PASS
```

Here is a sample of output from running the datacheck on `ensembl_compara_protists_60_113`, which contains a pair of gene members with a clashing stable ID:
```
MemberStableIDClash ..
# Subtest: MemberStableIDClash
    # Subtest: multi, compara, ensembl_compara_protists_60_113, multi
        not ok 1 - Case-sensitive stable ID uniqueness among gene members

        #   Failed test 'Case-sensitive stable ID uniqueness among gene members'
        #   at /hps/software/users/ensembl/compara/twalsh/repos/e113/ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/Checks/MemberStableIDClash.pm line 67.
        #          got: '1'
        #     expected: '0'
        # Unexpected data: (gene_stable_id) = (AM587_10002931)
        ⋮
        ok 2 - Case-sensitive stable ID uniqueness among sequence members
        not ok 3 - Case-insensitive stable ID uniqueness among gene members

        #   Failed test 'Case-insensitive stable ID uniqueness among gene members'
        #   at /hps/software/users/ensembl/compara/twalsh/repos/e113/ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/Checks/MemberStableIDClash.pm line 99.
        #          got: '1'
        #     expected: '0'
        # Unexpected data: (gene_stable_id) = (AM587_10002931)
        ⋮
        ok 4 - Case-insensitive stable ID uniqueness among sequence members
        1..4
        # Looks like you failed 2 tests of 4.
    not ok 1 - multi, compara, ensembl_compara_protists_60_113, multi
```