### PR TITLE
Allow components in CACTUS_DB MLSSes

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/NoDataOnGenomeComponents.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/NoDataOnGenomeComponents.pm
@@ -46,10 +46,9 @@ sub tests {
       JOIN method_link_species_set 
         USING (species_set_id) 
     WHERE genome_component IS NOT NULL 
-      AND method_link_id NOT IN (401, 600);
+      AND method_link_id NOT IN (26, 401, 600);
   /;
-  #The only MLSSs that are allowed to have component GenomeDBs are protein-trees (401) and species-tree (600)
-  my $desc_1 = "The only MLSSs that are allowed to have component GenomeDBs are protein-trees (401) and species-tree (600)";
+  my $desc_1 = "The only MLSSs that are allowed to have component GenomeDBs are cactus-db (26), protein-trees (401) and species-tree (600)";
   is_rows_zero($self->dba, $sql_1, $desc_1);
   #The following tables have no exceptions when it comes to component_genome_dbs
   my @tables = qw(genomic_align dnafrag_region constrained_element gene_member seq_member);


### PR DESCRIPTION
This PR would allow a `CACTUS_DB` MLSS to be linked to a species set that includes component `GenomeDBs`.

It isn't expected that any `CACTUS_DB` data would be present on a genome component. In particular, this datacheck would continue to fail on a database with `CACTUS_DB` `genomic_align` entries linked to a `DnaFrag` on a  component `GenomeDB`.
