### PR TITLE
New DCs for Xref

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareGeneNames.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareGeneNames.pm
@@ -1,0 +1,99 @@
+=head1 LICENSE
+
+Copyright [2018-2024] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::CompareGeneNames;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+use Bio::EnsEMBL::DataCheck::Utils qw(same_assembly same_geneset);
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'CompareGeneNames',
+  DESCRIPTION    => 'Compare Gene Name counts between two databases, categorised by external_db.',
+  GROUPS         => ['xref_mapping'],
+  DATACHECK_TYPE => 'advisory',
+  DB_TYPES       => ['core'],
+  TABLES         => ['xref', 'gene', 'object_xref', 'seq_region', 'coord_system', 'external_db']
+};
+
+sub tests {
+  my ($self) = @_;
+
+  SKIP: {
+    my $old_dba = $self->get_old_dba();
+
+    skip 'No old version of database', 1 unless defined $old_dba;
+
+    $self->gene_name_counts($old_dba);
+  }
+}
+
+sub gene_name_counts {
+  my ($self, $old_dba) = @_;
+
+  my $threshold = 0.33;
+
+  my $desc = "Consistent number of genes with names between ".
+             $self->dba->dbc->dbname.
+             ' (species_id '.$self->dba->species_id.') and '.
+             $old_dba->dbc->dbname.
+             ' (species_id '.$old_dba->species_id.')';
+
+  my $sql = qq/
+    SELECT count(gene_id) FROM gene 
+    WHERE display_xref_id IS NOT NULL
+  /;
+
+  my $sql1 = sprintf($sql);
+  my $sql2 = sprintf($sql);
+
+  row_totals($self->dba, $old_dba, $sql1, $sql2, $threshold, $desc);
+
+  $desc = "Consistent gene name counts between ".
+             $self->dba->dbc->dbname.
+             ' (species_id '.$self->dba->species_id.') and '.
+             $old_dba->dbc->dbname.
+             ' (species_id '.$old_dba->species_id.')';
+  $sql  = qq/
+    SELECT db_name, COUNT(*) FROM
+      gene g INNER JOIN 
+      xref x ON g.display_xref_id = x.xref_id INNER JOIN 
+      external_db USING (external_db_id) INNER JOIN 
+      seq_region USING (seq_region_id) INNER JOIN 
+      coord_system USING (coord_system_id) INNER JOIN
+      object_xref USING (xref_id)
+    WHERE
+      db_name <> 'GO' AND
+      info_type <> 'PROJECTION' AND
+      ensembl_object_type = 'Gene' AND
+      ensembl_id = gene_id AND
+      species_id = %d
+    GROUP BY db_name
+  /;
+
+  $sql1 = sprintf($sql, $self->dba->species_id);
+  $sql2 = sprintf($sql, $old_dba->species_id);
+  row_subtotals($self->dba, $old_dba, $sql1, $sql2, $threshold, $desc);
+}
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2929,5 +2929,14 @@
       ],
       "name" : "XrefTypes",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::XrefTypes"
+   },
+   "CompareGeneNames" : {
+      "datacheck_type" : "advisory",
+      "description" : "Compare Gene Name counts between two databases, categorised by external_db.",
+      "groups" : [
+         "xref_mapping"
+      ],
+      "name" : "CompareGeneNames",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareGeneNames"
    }
 }

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2566,7 +2566,7 @@
          "compara",
          "compara_gene_tree_pipelines",
          "compara_gene_trees",
-         "compara_master",
+         "compara_master"
       ],
       "name" : "StrainGeneTreeSpeciesSets",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::StrainGeneTreeSpeciesSets"
@@ -2938,5 +2938,14 @@
       ],
       "name" : "CompareGeneNames",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareGeneNames"
+   },
+   "CompareProteinCodingGeneNames" : {
+      "datacheck_type" : "critical",
+      "description" : "Compare Protein Coding Gene Name counts between two databases.",
+      "groups" : [
+         "xref_mapping"
+      ],
+      "name" : "CompareProteinCodingGeneNames",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::CompareProteinCodingGeneNames"
    }
 }


### PR DESCRIPTION
During recent releases, we've been receiving user queries about missing gene names as well as things we have noticed while investigating issues. Due to this, we've decided to add a new DC that compares the number of genes that have names (have a set display xref) and the sources that these names are coming from between 2 releases. This DC is part of the advisory checks that run at the end of the xref pipeline run.

This check will fail if the number of gene names decrease by more than 33%. The threshold can be increased or decreased as needed later on, when we have more of an idea on how this check performs among many species.