### PR TITLE
Adapt StrainGeneTreeSpeciesSets for Compara master DBs

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/StrainGeneTreeSpeciesSets.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/StrainGeneTreeSpeciesSets.pm
@@ -46,7 +46,8 @@ sub tests {
   my @gene_tree_mlsses;
   foreach my $method_type ('PROTEIN_TREES', 'NC_TREES') {
     my $mlsses_of_type = $mlss_dba->fetch_all_by_method_link_type($method_type);
-    push(@gene_tree_mlsses, @{$mlsses_of_type});
+    my @curr_mlsses_of_type = grep { $_->is_current } @{$mlsses_of_type};
+    push(@gene_tree_mlsses, @curr_mlsses_of_type);
   }
 
   my %species_sets_by_id;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/StrainGeneTreeSpeciesSets.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/StrainGeneTreeSpeciesSets.pm
@@ -36,6 +36,24 @@ use constant {
 };
 
 
+sub skip_tests {
+  my ($self) = @_;
+  my $compara_dba = $self->dba;
+  my $mlss_dba = $compara_dba->get_MethodLinkSpeciesSetAdaptor();
+
+  my @gene_tree_mlsses;
+  foreach my $method_type ('PROTEIN_TREES', 'NC_TREES') {
+    my $mlsses_of_type = $mlss_dba->fetch_all_by_method_link_type($method_type);
+    my @curr_mlsses_of_type = grep { $_->is_current } @{$mlsses_of_type};
+    push(@gene_tree_mlsses, @curr_mlsses_of_type);
+  }
+
+  if (scalar(@gene_tree_mlsses) == 0) {
+    return( 1, sprintf("There are no current gene-tree MLSSes in %s", $compara_dba->dbc->dbname) );
+  }
+}
+
+
 sub tests {
   my ($self) = @_;
 


### PR DESCRIPTION
This PR fixes issues affecting the use of datacheck `StrainGeneTreeSpeciesSets` with some Compara master databases:
- it skips the datacheck if no current gene-tree collections are found;
- it filters outdated gene-tree MLSSes, so only current gene-tree collections are checked; and
- it adds a subtest for non-strain collections, to ensure that they are free of `strain_type` tags.

Example output of the updated datacheck on the Pan Compara master database:
```
StrainGeneTreeSpeciesSets ..
# Subtest: StrainGeneTreeSpeciesSets
    # Subtest: multi, compara, ensembl_compara_master_pan, multi
        ok 1 - Non-strain gene-tree species set default is free of strain_type tags
        1..1
    ok 1 - multi, compara, ensembl_compara_master_pan, multi
    1..1
ok 1 - StrainGeneTreeSpeciesSets
1..1
ok
All tests successful.
Files=1, Tests=1,  7 wallclock secs ( 3.36 usr  0.23 sys +  0.01 cusr  0.04 csys =  3.64 CPU)
Result: PASS
```