### PR TITLE
Fix StrainGeneTreeSpeciesSets groups in index.json

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2564,7 +2564,6 @@
       "description" : "Strain-level gene-tree species sets are as expected",
       "groups" : [
          "compara",
-         "compara_gene_tree_pipelines",
          "compara_gene_trees",
          "compara_master"
       ],


### PR DESCRIPTION
With my apologies again, this is yet another fix of the `StrainGeneTreeSpeciesSets` datacheck.

[ensembl-datacheck PR 606](https://github.com/Ensembl/ensembl-datacheck/pull/606) removed `compara_gene_tree_pipelines` from the group list of the  `StrainGeneTreeSpeciesSets` datacheck.

This PR would remove the `StrainGeneTreeSpeciesSets` datacheck from the `compara_gene_tree_pipelines` group in the `index.json`.