### PR TITLE
Validate prefer_for_genome MLSS tags, update known strain types

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/StrainGeneTreeSpeciesSets.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/StrainGeneTreeSpeciesSets.pm
@@ -116,7 +116,17 @@ sub tests {
     }
   }
 
-  my @known_strain_types = ('strain', 'breed', 'cultivar');
+  # This list of known strain types should be kept in
+  # sync with strain types in the StrainType datacheck.
+  my @known_strain_types = (
+      'strain',
+      'breed',
+      'cultivar',
+      'ecotype',
+      'haplotype',
+      'isolate',
+  );
+
   my $known_strain_type_patt = join('|', @known_strain_types);
 
   my %gdb_to_collection_name_set;


### PR DESCRIPTION
This PR updates the `StrainGeneTreeSpeciesSets` datacheck to support the `prefer_for_genome` gene-tree MLSS tag.

The `prefer_for_genome` tag will be used to make it possible for a small number of genomes to be present in both the Barley pangenome and Wheat cultivars protein tree collections. It allows such genomes to be assigned to one or the other protein-tree collection in those circumstances where we are constrained to choose one collection.

It adds the following tests:
- a test to ensure that all gene-tree MLSSes associated with a strain-level species set have consistent `prefer_for_genome` tags;
- a test to confirm that genomes listed in a `prefer_for_genome` attribute are in the associated species set; and
- a test to check that gene-tree MLSSes associated with a non-strain collection lack `prefer_for_genome` tags.

It also modifies the test that previously checked that a given genome is in one strain gene-tree species set. This test now passes if the given genome can be _assigned_ to one strain gene-tree species set, after taking account of `prefer_for_genome` tags.

---

As a secondary change, the list of known strain types is updated to match those expected to be in the `StrainType` datacheck.