### PR TITLE
Fix/beta human

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/TranscriptSupport.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/TranscriptSupport.pm
@@ -54,13 +54,22 @@ sub tests {
     WHERE biotype NOT IN ('LRG_gene')
   /;
   my $sql_1b = q/
-      SELECT COUNT(distinct gene_id), attrib_type.code
+      SELECT COUNT(DISTINCT gene_id) AS `COUNT(distinct gene_id)`, 'gencode_basic' AS code
       FROM attrib_type
-        LEFT JOIN transcript_attrib ta USING (attrib_type_id)
-        LEFT JOIN transcript t on t.transcript_id = ta.transcript_id AND biotype NOT IN ('LRG_gene')
-      WHERE
-        attrib_type.code in ('gencode_basic', 'is_canonical')
-      GROUP BY attrib_type.code;
+      LEFT JOIN transcript_attrib ta USING (attrib_type_id)
+      LEFT JOIN transcript t ON t.transcript_id = ta.transcript_id
+      WHERE attrib_type.code IN ('gencode_basic', 'gencode_primary')
+      AND (biotype NOT IN ('LRG_gene') OR biotype IS NULL)
+      
+      UNION ALL
+      
+      SELECT COUNT(DISTINCT gene_id) AS `COUNT(distinct gene_id)`, 'is_canonical' AS code
+      FROM attrib_type
+      LEFT JOIN transcript_attrib ta USING (attrib_type_id)
+      LEFT JOIN transcript t ON t.transcript_id = ta.transcript_id
+      WHERE attrib_type.code = 'is_canonical'
+      AND (biotype NOT IN ('LRG_gene') OR biotype IS NULL);
+
   /;
 
   my $desc_1c = "Transcript attrib all match gene canonical_transcript_id";

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/VersionedGenes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/VersionedGenes.pm
@@ -47,7 +47,7 @@ sub tests {
   # full_genebuild, projection_build, mixed_strategy_build, maker_genebuild
   my $version_expected = 0;
   foreach my $method (@$methods) {
-     if ($method =~ /build/ or $method eq 'anno' or $method eq 'braker' or $method eq 'standard') {
+     if ($method =~ /build/ or $method eq 'anno' or $method eq 'braker' or $method eq 'standard' or $method eq 'manual_annotation') {
         $version_expected = 1;
     }
   }


### PR DESCRIPTION
The latest human update for beta breaks some DCs, these update will fix things:

1. "[Allow for 'manual_annotation' method in VersionedGenes check](https://github.com/Ensembl/ensembl-datacheck/commit/7c9d407f4c69a2f417d29abd98de7156a7ced94d)" - the genebuild.method meta key has been set to 'manual_annotation' which was not previously used and thus not include in the DC, I've added this method.
2. [Count genecode_basic and gencode_primary attribs per transcript](https://github.com/Ensembl/ensembl-datacheck/commit/c953ebb18c084b3266154911dac162276ab219dd) - this DC checks that all transcripts have the 'gencode_basic' attrib, we have now introduced the 'gencode_primary' attrib and so I am allowing for transcripts to have either or both attribs to pass. 