### PR TITLE
Bugfix: exclude "synthetic" Un chromosomes in PolyploidAttribs

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/PolyploidAttribs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/PolyploidAttribs.pm
@@ -106,6 +106,7 @@ sub tests {
       seq_region_attrib sra2 USING (seq_region_id) INNER JOIN
       attrib_type at2 ON at2.attrib_type_id = sra2.attrib_type_id AND at2.code = 'genome_component'
     WHERE
+      sr.name <> 'Un' AND
       cs.species_id = $species_id
   /;
   my $num_subgenomes = sql_count($self->dba, $sql_3);


### PR DESCRIPTION
_T. aestivum_ and _T. turgidum_ have a "synthetic" chromosome named `Un` introduced to gather all the scaffolds not assigned to actual chromosomes so they belong to the same genome component, `U`. This produces the actual count to be +2 over the actual ploidy, causing this DC fail for the two aforementioned species.

The correction applied is to skip based on chromosome name rather than genome component, as it is possible for an actual genome component `U` to exist, but it would be very unusual to find a chromosome named `Un`.

_Note:_ Thank you @twalsh-ebi for spotting this issue!