### PR TITLE
fix keyword capitalisation in column definitions for CompareSchema DC

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSchema.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSchema.pm
@@ -110,7 +110,7 @@ sub normalise_table_def {
   $table =~ s/ IF NOT EXISTS//gm;
 
   # Normalise case: everything after column name is upper-cased.
-  $table =~ s/^([a-z]\w+\s)(.+)/$1\U$2/gm;
+  $table =~ s/^([a-zA-Z]\w+\s)(.+)/$1\U$2/gm;
 
   # Use KEY rather than INDEX.
   $table =~ s/^INDEX /KEY /gm;


### PR DESCRIPTION
Fixing capitalisation in the case of the column names starting with `[A-Z]`
I.e., fixes capitalisation for the variation `phenotype_feature` `DNA_type` column