### PR TITLE
Update CompareSchema for column name one

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSchema.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CompareSchema.pm
@@ -114,7 +114,7 @@ sub normalise_table_def {
   $table =~ s/ IF NOT EXISTS//gm;
 
   # Normalise case: everything after column name is upper-cased.
-  $table =~ s/^([a-z]\w+\s)(.+)/$1\U$2/gm;
+  $table =~ s/^([a-z]\w*\s)(.+)/$1\U$2/gm;
 
   # Use KEY rather than INDEX.
   $table =~ s/^INDEX /KEY /gm;


### PR DESCRIPTION
Existing Regex expect the column name to be greater than one which fails for compara homology table which contains column name `n` and `s` 

$table =~ s/^([a-z]\w+\s)(.+)/$1\U$2/gm; changed to $table =~ s/^([a-z]\w*\s)(.+)/$1\U$2/gm;