### PR TITLE
added method helixer

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyFormat.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyFormat.pm
@@ -51,7 +51,7 @@ sub tests {
     'genebuild.id'                   => '\d+',
     'genebuild.initial_release_date' => '\d{4}-\d{2}',
     'genebuild.last_geneset_update'  => '\d{4}-\d{2}',
-    'genebuild.method'               => '(manual_annotation|full_genebuild|projection_build|import|mixed_strategy_build|external_annotation_import|maker_genebuild|curated|import_build|anno|braker|standard|prokka)',
+    'genebuild.method'               => '(manual_annotation|full_genebuild|projection_build|import|mixed_strategy_build|external_annotation_import|maker_genebuild|curated|import_build|anno|braker|helixer|standard|prokka)',
     'genebuild.start_date'           => '\d{4}\-\d{2}\-\S+',
     'patch'                          => '[^\n]+',
     'sample.location_param'          => '[\w\.\-]+:\d+\-\d+',

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/VersionedGenes.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/VersionedGenes.pm
@@ -47,7 +47,7 @@ sub tests {
   # full_genebuild, projection_build, mixed_strategy_build, maker_genebuild
   my $version_expected = 0;
   foreach my $method (@$methods) {
-     if ($method =~ /build/ or $method eq 'anno' or $method eq 'braker' or $method eq 'standard' or $method eq 'manual_annotation') {
+     if ($method =~ /build/ or $method eq 'anno' or $method eq 'braker' or $method eq 'standard' or $method eq 'manual_annotation' or $method eq 'helixer') {
         $version_expected = 1;
     }
   }


### PR DESCRIPTION
We will release cores where the annotation is done using an ab-initio method HELIXER (just like previously we used braker cores). In oreder to make this work, I have added the method helixer in two required scripts.