### PR TITLE
Allow microbial databases to not have repeat features

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
@@ -45,8 +45,13 @@ sub tests {
     }
 
     my $mca = $self->dba->get_adaptor('MetaContainer');
-    if ($mca->get_division eq 'EnsemblViruses') {
-      skip "Repeat features not mandatory for viruses", 1;
+    my $div = $mca->get_division;
+
+    if ( $div eq 'EnsemblViruses'
+	 || $div eq 'EnsemblProtists'
+	 || $div eq 'EnsemblFungi'
+	)  {
+	skip "Repeat features not mandatory for viruses/ protists/ fungi", 1;
     }
 
     if($mca->single_value_by_key('genebuild.method') eq 'projection_build') {


### PR DESCRIPTION
This was failing on an EnsemblProtists migration handover - the data was imported so repeat features are present. Have updated check to skip Protists and Fungi.

Tested
`perl scripts/run_datachecks.pl -host mysql-ens-genebuild-prod-1 -port 4527 -user ensro -dbname dictyostelium_discoideum_gca000004695v1_core_114_1 -dbtype core -n RepeatFeatures`
RepeatFeatures ..
 Subtest: RepeatFeatures
     Subtest: dictyostelium_discoideum_gca000004695v1, core, dictyostelium_discoideum_gca000004695v1_core_114_1, EnsemblProtists
        ok 1  skip Repeat features not mandatory for viruses/ protists/ fungi
        ok 2 - Repeat start <= repeat end
        ok 3 - Repeat start > 0
        1..3
    ok 1 - dictyostelium_discoideum_gca000004695v1, core, dictyostelium_discoideum_gca000004695v1_core_114_1, EnsemblProtists
    1..1
ok 1 - RepeatFeatures
1..1
ok
All tests successful.
Files=1, Tests=1,  1 wallclock secs ( 0.03 usr +  0.02 sys =  0.05 CPU)
Result: PASS