### PR TITLE
New DC to check for required meta keys

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyRequired.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyRequired.pm
@@ -16,7 +16,7 @@ limitations under the License.
 
 =cut
 
-package Bio::EnsEMBL::DataCheck::Checks::MetaKeyOptional;
+package Bio::EnsEMBL::DataCheck::Checks::MetaKeyRequired;
 
 use warnings;
 use strict;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyRequired.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MetaKeyRequired.pm
@@ -1,0 +1,70 @@
+=head1 LICENSE
+
+Copyright [2018-2024] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::MetaKeyOptional;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'MetaKeyRequired',
+  DESCRIPTION    => 'Required meta keys exist',
+  GROUPS         => ['core', 'meta'],
+  DATACHECK_TYPE => 'critical',
+  DB_TYPES       => ['core'],
+  TABLES         => ['meta']
+};
+
+sub tests {
+  my ($self) = @_;
+
+  my @required = qw/
+        organism.production_name
+        organism.taxonomy_id
+        organism.scientific_name
+        assembly.accession
+        assembly.name
+        genebuild.version
+        genebuild.method
+        genebuild.method_display
+        genebuild.start_date
+        genebuild.annotation_source
+        genebuild.provider_name
+        genebuild.provider_url
+        genebuild.sample_gene
+        genebuild.sample_location
+        genebuild.last_geneset_update
+        organism.biosample_id
+  /;
+
+  my $mca = $self->dba->get_adaptor("MetaContainer");
+
+  foreach my $meta_key (@required) {
+    my $values = $mca->list_value_by_key($meta_key);
+
+    my $desc = "Value exists for meta_key $meta_key";
+    ok(scalar @$values, $desc);
+  }
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2009,6 +2009,16 @@
       "name" : "MetaKeyOptional",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MetaKeyOptional"
    },
+    "MetaKeyRequired" : {
+      "datacheck_type" : "critical",
+      "description" : "Required meta keys exist",
+      "groups" : [
+         "core",
+         "meta"
+      ],
+      "name" : "MetaKeyRequired",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::MetaKeyRequired"
+   }, 
    "MitochondriaAnnotated" : {
       "datacheck_type" : "critical",
       "description" : "Mitochondrial seq_regions have appropriate attribute",


### PR DESCRIPTION
Tested with
` perl $ENSCODE/ensembl-datacheck/scripts/run_datachecks.pl -host mysql-ens-genebuild-prod-1 -port 4527 -u ensro -dbn aspergillus_fumigatus_gca000150145v1_core_114_1 -dbt core -n MetaKeyRequired`
Data check fails
`Failed test 'Value exists for meta_key genebuild.method_display'`

The fixed db with
`insert into meta (species_id, meta_key, meta_value) VALUES (1, genebuild.method_display, Import);`
and ran DC again
`All tests successful.`
