### PR TITLE
Bugdix/dc martdatasetname

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MartDatasetName.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MartDatasetName.pm
@@ -102,6 +102,7 @@ sub tests {
 
   my @name_clashes;
   foreach (@divisions) {
+    ### existing method $gia->fetch_all_by_division($_)  fetch all the genomes based on division with out considering the release version  replaced with $gia->fetch_division_databases($_)
     foreach my $genome_dbname (@{$gia->fetch_division_databases($_)}){
       next if ($dbname eq $genome_dbname);
        my $genome_mart_dataset = generate_dataset_name_from_db_name($genome_dbname);
@@ -111,22 +112,6 @@ sub tests {
        }
     }
   }
-
-  ####below code fetch all the genomes based on division with out considering the release version 
-  #foreach (@divisions) {
-  #  my $genomes = $gia->fetch_all_by_division($_);
-  #  foreach my $genome (@$genomes){
-  #    next if ($genome->name eq $production_name);
-  #
-  #    my $genome_mart_dataset = generate_dataset_name_from_db_name($genome->dbname);
-  #
-  #    if ($mart_dataset eq $genome_mart_dataset) {
-  #      push @name_clashes,
-  #        "\"$mart_dataset\" is used for ".$genome->name." (".$genome->dbname.")";
-  #    }
-  #  }
-  #}
-  ####################################################################################################
 
   is(scalar(@name_clashes), 0, $desc_2) || diag explain \@name_clashes;
 }

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MartDatasetName.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MartDatasetName.pm
@@ -102,18 +102,31 @@ sub tests {
 
   my @name_clashes;
   foreach (@divisions) {
-    my $genomes = $gia->fetch_all_by_division($_);
-    foreach my $genome (@$genomes){
-      next if ($genome->name eq $production_name);
-
-      my $genome_mart_dataset = generate_dataset_name_from_db_name($genome->dbname);
-
-      if ($mart_dataset eq $genome_mart_dataset) {
-        push @name_clashes,
-          "\"$mart_dataset\" is used for ".$genome->name." (".$genome->dbname.")";
-      }
+    foreach my $genome_dbname (@{$gia->fetch_division_databases($_)}){
+      next if ($dbname eq $genome_dbname);
+       my $genome_mart_dataset = generate_dataset_name_from_db_name($genome_dbname);
+       if ($mart_dataset eq $genome_mart_dataset) {
+         push @name_clashes,
+                  "\"$mart_dataset\" is used for  (".$genome_dbname.")";
+       }
     }
   }
+
+  ####below code fetch all the genomes based on division with out considering the release version 
+  #foreach (@divisions) {
+  #  my $genomes = $gia->fetch_all_by_division($_);
+  #  foreach my $genome (@$genomes){
+  #    next if ($genome->name eq $production_name);
+  #
+  #    my $genome_mart_dataset = generate_dataset_name_from_db_name($genome->dbname);
+  #
+  #    if ($mart_dataset eq $genome_mart_dataset) {
+  #      push @name_clashes,
+  #        "\"$mart_dataset\" is used for ".$genome->name." (".$genome->dbname.")";
+  #    }
+  #  }
+  #}
+  ####################################################################################################
 
   is(scalar(@name_clashes), 0, $desc_2) || diag explain \@name_clashes;
 }

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/PolyploidAttribs.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/PolyploidAttribs.pm
@@ -106,6 +106,7 @@ sub tests {
       seq_region_attrib sra2 USING (seq_region_id) INNER JOIN
       attrib_type at2 ON at2.attrib_type_id = sra2.attrib_type_id AND at2.code = 'genome_component'
     WHERE
+      sr.name <> 'Un' AND
       cs.species_id = $species_id
   /;
   my $num_subgenomes = sql_count($self->dba, $sql_3);


### PR DESCRIPTION
The fetch_all_by_division method retrieves all genomes from the metadata database without considering the Ensembl release version, which results in fetching deprecated genomes and subsequently causes the datachecks to fail.

This PR includes commits that are not added to the release/116 branch  (lib/Bio/EnsEMBL/DataCheck/Checks/PolyploidAttribs.pm)