### PR TITLE
Add prefix consistency check

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneStableID.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneStableID.pm
@@ -1,21 +1,3 @@
-=head1 LICENSE
-
-Copyright [2018-2024] EMBL-European Bioinformatics Institute
-
-Licensed under the Apache License, Version 2.0 (the 'License');
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an 'AS IS' BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-=cut
-
 package Bio::EnsEMBL::DataCheck::Checks::GeneStableID;
 
 use warnings;
@@ -28,42 +10,44 @@ use Bio::EnsEMBL::DataCheck::Test::DataCheck;
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
-  NAME        => 'GeneStableID',
-  DESCRIPTION => 'Genes, transcripts, exons and translations have non-NULL, unique stable IDs',
-  GROUPS      => ['core', 'brc4_core', 'geneset'],
-  DB_TYPES    => ['core'],
-  TABLES      => ['coord_system', 'exon', 'gene', 'seq_region', 'transcript', 'translation']
+    NAME        => 'GeneStableID',
+    DESCRIPTION => 'Genes, transcripts, exons and translations have non-NULL, unique stable IDs and consistent ID base prefixes',
+    GROUPS      => ['core', 'brc4_core', 'geneset'],
+    DB_TYPES    => ['core'],
+    TABLES      => ['coord_system', 'exon', 'gene', 'seq_region', 'transcript', 'translation']
 };
 
 sub tests {
-  my ($self) = @_;
-  my $species_id = $self->dba->species_id;
+    my ($self) = @_;
+    my $species_id = $self->dba->species_id;
 
-  $self->stable_id_check('gene',       $species_id);
-  $self->stable_id_check('transcript', $species_id);
-  $self->stable_id_check('exon',       $species_id);
+    $self->stable_id_check('gene',       $species_id);
+    $self->stable_id_check('transcript', $species_id);
+    $self->stable_id_check('exon',       $species_id);
+    $self->translation_stable_id_check($species_id);
 
-  $self->translation_stable_id_check($species_id);
+    # NEW: check base prefix consistency across feature types
+    $self->stable_id_prefix_consistency_check($species_id);
 }
 
 sub stable_id_check {
-  my ($self, $table, $species_id) = @_;
+    my ($self, $table, $species_id) = @_;
 
-  my $desc_1 = $table.' table has non-NULL stable IDs';
-  my $diag_1 = "Null $table.stable_id";
-  my $sql_1  = qq/
+    my $desc_1 = $table.' table has non-NULL stable IDs';
+    my $diag_1 = "Null $table.stable_id";
+      my $sql_1  = qq/
     SELECT $table.stable_id FROM
       $table INNER JOIN
       seq_region sr USING (seq_region_id) INNER JOIN
       coord_system cs USING (coord_system_id)
     WHERE cs.species_id = $species_id
       AND $table.stable_id IS NULL
-  /;
-  is_rows_zero($self->dba, $sql_1, $desc_1, $diag_1);
+	  /;
+    is_rows_zero($self->dba, $sql_1, $desc_1, $diag_1);
 
-  my $desc_2 = $table.' table has unique stable IDs';
-  my $diag_2 = "Duplicate $table.stable_id";
-  my $sql_2  = qq/
+    my $desc_2 = $table.' table has unique stable IDs';
+    my $diag_2 = "Duplicate $table.stable_id";
+      my $sql_2  = qq/
     SELECT $table.stable_id FROM
       $table INNER JOIN
       seq_region sr USING (seq_region_id) INNER JOIN
@@ -71,16 +55,16 @@ sub stable_id_check {
     WHERE cs.species_id = $species_id
     GROUP BY $table.stable_id
     HAVING COUNT(*) > 1
-  /;
-  is_rows_zero($self->dba, $sql_2, $desc_2, $diag_2);
+	  /;
+    is_rows_zero($self->dba, $sql_2, $desc_2, $diag_2);
 }
 
 sub translation_stable_id_check {
-  my ($self, $species_id) = @_;
+    my ($self, $species_id) = @_;
 
-  my $desc_1 = 'translation table has non-NULL stable IDs';
-  my $diag_1 = "Null translation.stable_id";
-  my $sql_1  = qq/
+    my $desc_1 = 'translation table has non-NULL stable IDs';
+    my $diag_1 = "Null translation.stable_id";
+      my $sql_1  = qq/
     SELECT tn.stable_id FROM
       translation tn INNER JOIN
       transcript tt USING (transcript_id) INNER JOIN
@@ -88,12 +72,12 @@ sub translation_stable_id_check {
       coord_system cs USING (coord_system_id)
     WHERE cs.species_id = $species_id
       AND tn.stable_id IS NULL
-  /;
-  is_rows_zero($self->dba, $sql_1, $desc_1, $diag_1);
+	  /;
+    is_rows_zero($self->dba, $sql_1, $desc_1, $diag_1);
 
-  my $desc_2 = 'translation table has unique stable IDs';
-  my $diag_2 = "Duplicate translation.stable_id";
-  my $sql_2  = qq/
+    my $desc_2 = 'translation table has unique stable IDs';
+    my $diag_2 = "Duplicate translation.stable_id";
+      my $sql_2  = qq/
     SELECT tn.stable_id FROM
       translation tn INNER JOIN
       transcript tt USING (transcript_id) INNER JOIN
@@ -103,8 +87,99 @@ sub translation_stable_id_check {
       AND cs.name <> 'lrg'
     GROUP BY tn.stable_id
     HAVING COUNT(*) > 1
-  /;
-  is_rows_zero($self->dba, $sql_2, $desc_2, $diag_2);
+	  /;
+    is_rows_zero($self->dba, $sql_2, $desc_2, $diag_2);
 }
+
+# -------------------------------
+# NEW: prefix consistency checker
+# -------------------------------
+sub stable_id_prefix_consistency_check {
+    my ($self, $species_id) = @_;
+
+    my %tables = (
+	gene       => 'G',
+	transcript => 'T',
+	exon       => 'E',
+	translation=> 'P',
+	);
+
+    my %prefixes_by_table;
+    for my $table (keys %tables) {
+	$prefixes_by_table{$table} = $self->get_base_prefixes_for_table($table, $species_id, $tables{$table});
+    }
+
+    # Union of all base prefixes observed across all feature types
+    my %union;
+    for my $table (keys %prefixes_by_table) {
+	$union{$_}++ for @{$prefixes_by_table{$table}};
+    }
+    my @all_prefixes = sort keys %union;
+
+    my $desc = 'Stable ID base prefix is consistent across genes, transcripts, exons and translations';
+    my $ok = @all_prefixes <= 1;
+
+    # If not OK, provide diagnostics by table
+    unless ($ok) {
+	my $diag = "Observed base prefixes per table:\n";
+	for my $table (sort keys %prefixes_by_table) {
+	    my @vals = @{$prefixes_by_table{$table}};
+	    @vals = ('<none>') unless @vals;
+	    $diag .= sprintf("  %-12s : %s\n", $table, join(', ', sort @vals));
+	}
+	diag($diag);
+    }
+
+    ok($ok, $desc);
+}
+
+# Helper: collect DISTINCT base prefixes for a table.
+# Base prefix: (letters/underscore)* BEFORE the feature-type letter (G/T/E/P) that precedes the numeric part.
+# We strip any ".version" first (in SQL), then use Perl regex to normalise.
+sub get_base_prefixes_for_table {
+    my ($self, $table, $species_id, $feature_letter) = @_;
+
+    my $sql;
+    if ($table eq 'translation') {
+	# translation -> transcript -> seq_region -> coord_system
+	    $sql = qq/
+      SELECT DISTINCT SUBSTRING_INDEX(tn.stable_id, '.', 1) AS sid
+      FROM translation tn
+        INNER JOIN transcript tt USING (transcript_id)
+        INNER JOIN seq_region sr USING (seq_region_id)
+        INNER JOIN coord_system cs USING (coord_system_id)
+      WHERE cs.species_id = $species_id
+        AND tn.stable_id IS NOT NULL
+		/;
+    } else {
+	# gene, transcript, exon all carry seq_region_id
+	    $sql = qq/
+      SELECT DISTINCT SUBSTRING_INDEX($table.stable_id, '.', 1) AS sid
+      FROM $table
+        INNER JOIN seq_region sr USING (seq_region_id)
+        INNER JOIN coord_system cs USING (coord_system_id)
+      WHERE cs.species_id = $species_id
+        AND $table.stable_id IS NOT NULL
+		/;
+    }
+
+    my $dbh = $self->dba->dbc->db_handle;
+    my $sth = $dbh->prepare($sql);
+    $sth->execute();
+
+    my %seen;
+    while (my ($sid) = $sth->fetchrow_array) {
+	next unless defined $sid && $sid ne '';
+
+	# drop trailing digits and optional feature-type letter; ignore version (already stripped in SQL)
+	$sid =~ s/\d+$//;       # ENSG00000123 -> ENSG
+	$sid =~ s/[GTEP]$//i;   # remove trailing feature-type letter (G/T/E/P), if present
+
+	$seen{$sid}++ if $sid ne '';
+    }
+
+    return [ sort keys %seen ];
+}
+
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneStableID.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneStableID.pm
@@ -32,20 +32,43 @@ use constant {
     DESCRIPTION => 'Genes, transcripts, exons and translations have non-NULL, unique stable IDs and consistent ID base prefixes',
     GROUPS      => ['core', 'brc4_core', 'geneset'],
     DB_TYPES    => ['core'],
-    TABLES      => ['coord_system', 'exon', 'gene', 'seq_region', 'transcript', 'translation']
+    TABLES => ['coord_system','exon','gene','seq_region','transcript','translation','meta']
 };
 
 sub tests {
-    my ($self) = @_;
-    my $species_id = $self->dba->species_id;
+  my ($self) = @_;
+  my $species_id = $self->dba->species_id;
 
-    $self->stable_id_check('gene',       $species_id);
-    $self->stable_id_check('transcript', $species_id);
-    $self->stable_id_check('exon',       $species_id);
-    $self->translation_stable_id_check($species_id);
+  $self->stable_id_check('gene',       $species_id);
+  $self->stable_id_check('transcript', $species_id);
+  $self->stable_id_check('exon',       $species_id);
+  $self->translation_stable_id_check($species_id);
 
-    # NEW: check base prefix consistency across feature types
+  # Run the prefix check only for the allowed genebuild.method values
+  SKIP: {
+    unless ($self->prefix_check_is_applicable) {
+      skip 'Skipping prefix consistency check: genebuild.method not in {anno, full_genebuild, braker, helixer}', 1;
+    }
     $self->stable_id_prefix_consistency_check($species_id);
+  }
+}
+
+sub genebuild_method {
+  my ($self) = @_;
+  my $mc = $self->dba->get_MetaContainer();
+  my $method;
+  if ($mc->can('single_value_by_key')) {
+    $method = $mc->single_value_by_key('genebuild.method');
+  } else {
+    ($method) = @{ $mc->list_value_by_key('genebuild.method') || [] };
+  }
+  return $method;
+}
+
+sub prefix_check_is_applicable {
+  my ($self) = @_;
+  my $method = lc( $self->genebuild_method // '' );
+  return $method =~ /^(anno|full_genebuild|braker|helixer)$/;
 }
 
 sub stable_id_check {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GeneStableID.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GeneStableID.pm
@@ -1,3 +1,21 @@
+=head1 LICENSE
+
+Copyright [2018-2024] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
 package Bio::EnsEMBL::DataCheck::Checks::GeneStableID;
 
 use warnings;


### PR DESCRIPTION
@Ensembl/plantazoa can you please check that this new consistency check works for your stable IDs? If not, I can update so that it only runs on genebuild cores.

Updated Stable ID check to check that all prefixes per features are consistent.

Tested:
changed prefix for one gene from ENSIMR -> ENSXXX, then test fails
```
 perl $ENSCODE/ensembl-datacheck/scripts/run_datachecks.pl -host mysql-ens-genebuild-prod-6 -port 4532 -user ensro -dbname leanne_gca964332325v1_core_113_1 -dbtype core -n GeneStableID
GeneStableID ..
# Subtest: GeneStableID
    # Subtest: acropora_muricata_gca964332325v1, core, leanne_gca964332325v1_core_113_1, EnsemblMetazoa
        ok 1 - gene table has non-NULL stable IDs
        ok 2 - gene table has unique stable IDs
        ok 3 - transcript table has non-NULL stable IDs
        ok 4 - transcript table has unique stable IDs
        ok 5 - exon table has non-NULL stable IDs
        ok 6 - exon table has unique stable IDs
        ok 7 - translation table has non-NULL stable IDs
        ok 8 - translation table has unique stable IDs
        # Observed base prefixes per table:
        #   exon         : ENSIMR
        #   gene         : ENSIMR, ENSXXX
        #   transcript   : ENSIMR
        #   translation  : ENSIMR
        not ok 9 - Stable ID base prefix is consistent across genes, transcripts, exons and translations

        #   Failed test 'Stable ID base prefix is consistent across genes, transcripts, exons and translations'
        #   at /hps/software/users/ensembl/genebuild/leanne/repositories_tmp/ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/Checks/GeneStableID.pm line 133.
        1..9
        # Looks like you failed 1 test of 9.
    not ok 1 - acropora_muricata_gca964332325v1, core, leanne_gca964332325v1_core_113_1, EnsemblMetazoa

    #   Failed test 'acropora_muricata_gca964332325v1, core, leanne_gca964332325v1_core_113_1, EnsemblMetazoa'
    #   at /hps/software/users/ensembl/genebuild/leanne/repositories_tmp//ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/DbCheck.pm line 737.
    1..1
    # Looks like you failed 1 test of 1.
not ok 1 - GeneStableID

#   Failed test 'GeneStableID'
#   at /hps/software/users/ensembl/genebuild/leanne/repositories_tmp//ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/BaseCheck.pm line 170.
1..1
Failed 1/1 subtests

Test Summary Report
-------------------
GeneStableID (Wstat: 0 Tests: 1 Failed: 1)
  Failed test:  1
Files=1, Tests=1,  4 wallclock secs ( 0.23 usr +  0.03 sys =  0.26 CPU)
Result: FAIL
```


Info about the new check:
Given a stable_id, we first drop any .version, then we strip trailing digits. From the remaining letters/underscores, if the last character is one of G T E P (the feature-type letter), we remove that one letter to get the base prefix. Examples:

- ENSG00000123456.3 → ENSG00000123456 → remove digits → ENSG → remove feature letter G → ENS
- ENSMUST00000123456 → remove digits → ENSMUST → remove T → ENSMUS
- BRAKERXXXT00001234 → remove digits → BRAKERXXXT → remove T → BRAKER 
