### PR TITLE
Skip repeat DC on imported vert data

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/RepeatFeatures.pm
@@ -54,6 +54,10 @@ sub tests {
 	skip "Repeat features not mandatory for viruses/ protists/ fungi", 1;
     }
 
+    if ( $div eq 'EnsemblVertebrates' && $mca->single_value_by_key('genebuild.method') eq 'import' ){
+	skip "Repeat features not mandatory for imported vertebrate annotations", 1;
+    }
+    
     if($mca->single_value_by_key('genebuild.method') eq 'projection_build') {
       skip "Repeat features not mandatory for projection builds", 1;
     }


### PR DESCRIPTION
We need to meet a grant deliverable whereby we deliver imported community annotation on a genome in beta. The community annotation that has been provided is lacking repeat features and therefore we will need to skip the data check.

We cannot guarantee that repeats will be provided as part of an imported annotation and do not have the capacity to run additional analyses, so all imported vertebrate data should be exempt from this check.

Tested on the import db:
```
perl /hps/software/users/ensembl/genebuild/leanne/repositories_tmp/ensembl-datacheck/scripts/run_datachecks.pl -host mysql-ens-genebuild-prod-1 -port 4527 -user ensro -dbname acomys_minous_gca964271855v1cm_core_114_1 -dbtype core -n RepeatFeatures
RepeatFeatures ..
# Subtest: RepeatFeatures
    # Subtest: acomys_minous_gca964271855v1cm, core, acomys_minous_gca964271855v1cm_core_114_1, EnsemblVertebrates
        ok 1 # skip Repeat features not mandatory for imported vertebrate annotations
        ok 2 - Repeat start <= repeat end
        ok 3 - Repeat start > 0
        1..3
    ok 1 - acomys_minous_gca964271855v1cm, core, acomys_minous_gca964271855v1cm_core_114_1, EnsemblVertebrates
    1..1
ok 1 - RepeatFeatures
1..1
ok
All tests successful.
Files=1, Tests=1,  0 wallclock secs ( 0.02 usr +  0.02 sys =  0.04 CPU)
Result: PASS
```