### PR TITLE
Force Compara core-sync datachecks

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/CanonicalMemberCore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/CanonicalMemberCore.pm
@@ -34,7 +34,8 @@ use constant {
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
   TABLES         => ['gene_member', 'seq_member'],
-  PER_DB         => 1
+  PER_DB         => 1,
+  FORCE          => 1,
 };
 
 sub skip_tests {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DNAFragCore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DNAFragCore.pm
@@ -35,7 +35,8 @@ use constant {
   GROUPS      => ['compara', 'compara_gene_trees', 'compara_genome_alignments', 'compara_master', 'compara_syntenies', 'core_sync'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES    => ['compara'],
-  TABLES      => ['dnafrag', 'genome_db']
+  TABLES      => ['dnafrag', 'genome_db'],
+  FORCE       => 1,
 };
 
 sub tests {

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GenomeDBCore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GenomeDBCore.pm
@@ -33,6 +33,7 @@ use constant {
   DATACHECK_TYPE => 'critical',
   DB_TYPES    => ['compara'],
   TABLES      => ['genome_db'],
+  FORCE       => 1,
 };
 
 sub tests {


### PR DESCRIPTION
This PR would force rerun of Compara core-sync datachecks, even if nothing has changed in Compara database tables, because something may have changed in a core database.