### PR TITLE
Check genome and coding exon length in GenomicAlignStats

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/GenomicAlignStats.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/GenomicAlignStats.pm
@@ -24,6 +24,8 @@ use strict;
 use Moose;
 use Test::More;
 
+use Bio::EnsEMBL::Compara::Utils::Stats qw(get_coding_exon_regions);
+
 use Bio::EnsEMBL::DataCheck::Test::DataCheck;
 
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
@@ -34,7 +36,18 @@ use constant {
   GROUPS         => ['compara', 'compara_genome_alignments'],
   DATACHECK_TYPE => 'critical',
   DB_TYPES       => ['compara'],
-  TABLES         => ['genomic_align_block', 'method_link', 'method_link_species_set', 'method_link_species_set_tag']
+  TABLES         => [
+    'dnafrag',
+    'genome_db',
+    'genomic_align_block',
+    'method_link',
+    'method_link_species_set',
+    'method_link_species_set_tag',
+    'species_set',
+    'species_set_header',
+    'species_tree_node',
+    'species_tree_node_tag',
+  ],
 };
 
 sub skip_tests {
@@ -61,12 +74,45 @@ sub tests {
   my $mlss_adap = $dba->get_MethodLinkSpeciesSetAdaptor;
   my @method_types = qw (CACTUS_DB EPO EPO_EXTENDED LASTZ_NET LASTZ_PATCH PECAN POLYPLOID);
 
+  my %gdbs_by_id;
   my %mlsses_by_id;
   foreach my $method_type ( @method_types ) {
     my $mlsses_of_type = $mlss_adap->fetch_all_by_method_link_type($method_type);
     foreach my $mlss (@{$mlsses_of_type}) {
       $mlsses_by_id{$mlss->dbID} = $mlss;
+
+      foreach my $gdb (@{$mlss->species_set->genome_dbs}) {
+        $gdbs_by_id{$gdb->dbID} = $gdb;
+      }
     }
+  }
+
+  my $total_genome_length_sql = q/
+    SELECT SUM(length)
+    FROM dnafrag
+    WHERE is_reference = 1
+    AND genome_db_id = ?
+  /;
+
+  my %obs_genome_lengths;
+  my %obs_coding_exon_lengths;
+  while (my ($gdb_id, $gdb) = each %gdbs_by_id) {
+
+    $obs_genome_lengths{$gdb_id} = $helper->execute_single_result( -SQL => $total_genome_length_sql, -PARAMS => [$gdb_id] );
+
+    my $coding_exon_length = 0;
+    my $species_dba = $self->get_dba($gdb->name, 'core');
+    $species_dba->dbc->prevent_disconnect( sub {
+      my $slices_it = Bio::EnsEMBL::Compara::Utils::CoreDBAdaptor::iterate_toplevel_slices($species_dba);
+      while (my $slice = $slices_it->next()) {
+        my $coding_exons = get_coding_exon_regions($slice);
+        foreach my $coding_exon (@{$coding_exons}) {
+          my ($start, $end) = @{$coding_exon};
+          $coding_exon_length += ($end - $start + 1);
+        }
+      }
+    } );
+    $obs_coding_exon_lengths{$gdb_id} = $coding_exon_length;
   }
 
   my $block_count_tag_sql = q/
@@ -77,18 +123,53 @@ sub tests {
   /;
 
   my %exp_block_counts;
+  my %exp_genome_lengths;
+  my %exp_coding_exon_lengths;
   foreach my $mlss_id ( sort keys %mlsses_by_id ) {
+    my $mlss = $mlsses_by_id{$mlss_id};
     my $results = $helper->execute_simple( -SQL => $block_count_tag_sql, -PARAMS => [$mlss_id] );
 
     if (scalar(@{$results}) == 1) {
       my $block_count_tag = $results->[0];
-      my $mlss = $mlsses_by_id{$mlss_id};
       my $exp_block_count = $mlss->method->type eq 'EPO'
                           ? 2 * $block_count_tag
                           : $block_count_tag
                           ;
 
       $exp_block_counts{$mlss_id} = $exp_block_count;
+    }
+
+    if ($mlss->species_set->size > 2) {
+
+      my $gdb_id_2_node_hash = $mlss->species_tree && $mlss->species_tree->get_genome_db_id_2_node_hash;
+      foreach my $genome_db (@{$mlss->species_set->genome_dbs}) {
+        my $gdb_id = $genome_db->dbID;
+        my @gdb_tags = qw(genome_length coding_exon_length);
+        my %gdb_stats;
+        foreach my $tag (@gdb_tags) {
+          if ($gdb_id_2_node_hash
+              && exists $gdb_id_2_node_hash->{$gdb_id}
+              && $gdb_id_2_node_hash->{$gdb_id}->has_tag($tag)) {
+            $gdb_stats{$tag} = $gdb_id_2_node_hash->{$gdb_id}->get_value_for_tag($tag);
+          } elsif (defined $mlss->has_tag("${tag}_${gdb_id}")) {
+            $gdb_stats{$tag} = $mlss->get_value_for_tag("${tag}_${gdb_id}");
+          }
+        }
+
+        $exp_coding_exon_lengths{$mlss_id}{$gdb_id} = $gdb_stats{'coding_exon_length'} if (exists $gdb_stats{'coding_exon_length'});
+        $exp_genome_lengths{$mlss_id}{$gdb_id} = $gdb_stats{'genome_length'} if (exists $gdb_stats{'genome_length'});
+      }
+
+    } else {
+      my ($ref_gdb, $non_ref_gdb) = $mlss->find_pairwise_reference();
+
+      my %non_ref_stats = map { $_ => $mlss->get_value_for_tag($_) } ('non_ref_coding_exon_length', 'non_ref_genome_length');
+      $exp_coding_exon_lengths{$mlss_id}{$non_ref_gdb->dbID} = $non_ref_stats{'non_ref_coding_exon_length'} if (exists $non_ref_stats{'non_ref_coding_exon_length'});
+      $exp_genome_lengths{$mlss_id}{$non_ref_gdb->dbID} = $non_ref_stats{'non_ref_genome_length'} if (exists $non_ref_stats{'non_ref_genome_length'});
+
+      my %ref_stats = map { $_ => $mlss->get_value_for_tag($_) } ('ref_coding_exon_length', 'ref_genome_length');
+      $exp_coding_exon_lengths{$mlss_id}{$ref_gdb->dbID} = $ref_stats{'ref_coding_exon_length'} if (exists $ref_stats{'ref_coding_exon_length'});
+      $exp_genome_lengths{$mlss_id}{$ref_gdb->dbID} = $ref_stats{'ref_genome_length'} if (exists $ref_stats{'ref_genome_length'});
     }
   }
 
@@ -106,6 +187,25 @@ sub tests {
     is($obs_block_count, $exp_block_count, "$mlss_name (mlss_id:$mlss_id) block count consistency");
   }
 
+  foreach my $mlss_id ( sort keys %exp_genome_lengths ) {
+    my $mlss_name = $mlsses_by_id{$mlss_id}->name;
+    foreach my $gdb_id (sort keys %{$exp_genome_lengths{$mlss_id}} ) {
+      my $gdb_name = $gdbs_by_id{$gdb_id}->name;
+      my $exp_genome_length = $exp_genome_lengths{$mlss_id}{$gdb_id};
+      my $obs_genome_length = $obs_genome_lengths{$gdb_id};
+      is($obs_genome_length, $exp_genome_length, "genome length consistency of $gdb_name in MLSS '$mlss_name' (mlss_id:$mlss_id)");
+    }
+  }
+
+  foreach my $mlss_id ( sort keys %exp_coding_exon_lengths ) {
+    my $mlss_name = $mlsses_by_id{$mlss_id}->name;
+    foreach my $gdb_id (sort keys %{$exp_coding_exon_lengths{$mlss_id}} ) {
+      my $gdb_name = $gdbs_by_id{$gdb_id}->name;
+      my $exp_coding_exon_length = $exp_coding_exon_lengths{$mlss_id}{$gdb_id};
+      my $obs_coding_exon_length = $obs_coding_exon_lengths{$gdb_id};
+      is($obs_coding_exon_length, $exp_coding_exon_length, "coding exon length consistency of $gdb_name in MLSS '$mlss_name' (mlss_id:$mlss_id)");
+    }
+  }
 }
 
 1;


### PR DESCRIPTION
This PR would update the `GenomicAlignStats` datacheck with new subtests to compare stored `genome_length` and `coding_exon_length` statistics against the observed genome and coding-exon length (respectively) of each genome in a multiple or pairwise genomic alignment.

This is a draft PR, pending the resolution of [ensembl-compara PR 983](https://github.com/Ensembl/ensembl-compara/pull/983).

Here is an illustration of what the output of the additional subtests might look like in practice:
```
not ok 133 - coding exon length consistency of anopheles_sinensis in MLSS 'Agam-Asin LastZ (on Agam)' (mlss_id:9560)
#   Failed test 'coding exon length consistency of anopheles_sinensis in MLSS 'Agam-Asin LastZ (on Agam)' (mlss_id:9560)'
#   at /path/to/ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/Checks/GenomicAlignStats.pm line 206.
#          got: '17407694'
#     expected: '17380207'
not ok 134 - coding exon length consistency of anopheles_gambiae in MLSS 'Agam-Asin LastZ (on Agam)' (mlss_id:9560)
#   Failed test 'coding exon length consistency of anopheles_gambiae in MLSS 'Agam-Asin LastZ (on Agam)' (mlss_id:9560)'
#   at /path/to/ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/Checks/GenomicAlignStats.pm line 206.
#          got: '22502501'
#     expected: '22369942'
not ok 135 - coding exon length consistency of aedes_aegypti_lvpagwg in MLSS 'Aalv-Agam LastZ (on Agam)' (mlss_id:9706)
#   Failed test 'coding exon length consistency of aedes_aegypti_lvpagwg in MLSS 'Aalv-Agam LastZ (on Agam)' (mlss_id:9706)'
#   at /path/to/ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/Checks/GenomicAlignStats.pm line 206.
#          got: '24338150'
#     expected: '24304798'
not ok 136 - coding exon length consistency of anopheles_gambiae in MLSS 'Aalv-Agam LastZ (on Agam)' (mlss_id:9706)
#   Failed test 'coding exon length consistency of anopheles_gambiae in MLSS 'Aalv-Agam LastZ (on Agam)' (mlss_id:9706)'
#   at /path/to/ensembl-datacheck/lib/Bio/EnsEMBL/DataCheck/Checks/GenomicAlignStats.pm line 206.
#          got: '22502501'
#     expected: '22369942'
```