### PR TITLE
add ensembl to the list of allowed sources; previously was omitted as…

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/AnnotationSource.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/AnnotationSource.pm
@@ -38,7 +38,7 @@ sub tests{
   my $annotation_source = $mca->single_value_by_key('genebuild.annotation_source');
   ok($annotation_source, $desc);
 
-  my $sources = 'braker|genbank|refseq|community|flybase|wormbase|veupathdb|noninsdc|helixer';
+  my $sources = 'ensembl|braker|genbank|refseq|community|flybase|wormbase|veupathdb|noninsdc|helixer';
   my $source_desc = "Source is allowed";
 
  SKIP: {


### PR DESCRIPTION
… this was not required meta key for ensembl annotations

Without this patch no `ensembl` annotation can be handed over. 
