### PR TITLE
changed display xref exists from advisory to critical (for Vert genomes)

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExists.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExists.pm
@@ -31,7 +31,7 @@ use constant {
   NAME           => 'DisplayXrefExists',
   DESCRIPTION    => 'At least one gene name exists',
   GROUPS         => ['core', 'xref', 'xref_gene_symbol_transformer', 'xref_name_projection'],
-  DATACHECK_TYPE => 'critical',
+  DATACHECK_TYPE => 'advisory',
   TABLES         => ['coord_system', 'gene', 'seq_region', 'transcript', 'xref'],
 };
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExists.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExists.pm
@@ -31,7 +31,7 @@ use constant {
   NAME           => 'DisplayXrefExists',
   DESCRIPTION    => 'At least one gene name exists',
   GROUPS         => ['core', 'xref', 'xref_gene_symbol_transformer', 'xref_name_projection'],
-  DATACHECK_TYPE => 'advisory',
+  DATACHECK_TYPE => 'critical',
   TABLES         => ['coord_system', 'gene', 'seq_region', 'transcript', 'xref'],
 };
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsGene.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsGene.pm
@@ -48,17 +48,15 @@ sub tests {
   # Use CASE to return 1 (pass) for teams not responsible for display xrefs,
   # but actual count for responsible teams
   my $sql  = qq/
-    SELECT CASE
-      WHEN (SELECT meta_value FROM meta WHERE meta_key = 'genebuild.team_responsible') IN ('$teams_list')
-      THEN (
-        SELECT COUNT(*) FROM gene t
-          INNER JOIN seq_region sr USING (seq_region_id)
-          INNER JOIN coord_system cs USING (coord_system_id)
-        WHERE cs.species_id = $species_id
-          AND t.display_xref_id IS NOT NULL
-      )
-      ELSE 1
-    END
+  SELECT COUNT(*) 
+    FROM gene t
+    JOIN seq_region sr USING (seq_region_id)
+    JOIN coord_system cs USING (coord_system_id)
+    JOIN meta m 
+      ON m.meta_key = 'genebuild.team_responsible'
+    WHERE cs.species_id = $species_id
+      AND t.display_xref_id IS NOT NULL
+      AND m.meta_value IN ('$teams_list')
   /;
 
   is_rows_nonzero($self->dba, $sql, $desc);

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsGene.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsGene.pm
@@ -30,7 +30,7 @@ extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 use constant {
   NAME           => 'DisplayXrefExistsGene',
   DESCRIPTION    => 'At least one gene name exists',
-  GROUPS         => ['core', 'xref', 'xref_gene_symbol_transformer', 'xref_name_projection'],
+  GROUPS         => ['rapid_release'],
   DATACHECK_TYPE => 'critical',
   TABLES         => ['coord_system', 'gene', 'seq_region', 'xref'],
 };
@@ -48,21 +48,25 @@ sub tests {
   # Use CASE to return 1 (pass) for teams not responsible for display xrefs,
   # but actual count for responsible teams
   my $sql  = qq/
-    SELECT CASE
-      WHEN EXISTS (
-        SELECT 1 FROM meta
-        WHERE meta_key = 'genebuild.team_responsible'
-          AND meta_value IN ('$teams_list')
-      )
-      THEN (
-        SELECT COUNT(*) FROM gene t
-          JOIN seq_region sr USING (seq_region_id)
-          JOIN coord_system cs USING (coord_system_id)
-        WHERE cs.species_id = $species_id
-          AND t.display_xref_id IS NOT NULL
-      )
-      ELSE 1
-    END
+    SELECT COUNT(*) FROM (
+      SELECT CASE
+        WHEN EXISTS (
+          SELECT 1 FROM meta
+          WHERE meta_key = 'genebuild.team_responsible'
+            AND meta_value IN ('$teams_list')
+            AND (species_id IS NULL OR species_id = $species_id)
+        )
+        THEN (
+          SELECT COUNT(*) FROM gene t
+            JOIN seq_region sr USING (seq_region_id)
+            JOIN coord_system cs USING (coord_system_id)
+          WHERE cs.species_id = $species_id
+            AND t.display_xref_id IS NOT NULL
+        )
+        ELSE 1
+      END AS count_result
+    ) AS subquery
+    WHERE count_result > 0
   /;
 
   is_rows_nonzero($self->dba, $sql, $desc);

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsGene.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsGene.pm
@@ -28,11 +28,11 @@ use Bio::EnsEMBL::DataCheck::Test::DataCheck;
 extends 'Bio::EnsEMBL::DataCheck::DbCheck';
 
 use constant {
-  NAME           => 'DisplayXrefExists',
+  NAME           => 'DisplayXrefExistsGene',
   DESCRIPTION    => 'At least one gene name exists',
   GROUPS         => ['core', 'xref', 'xref_gene_symbol_transformer', 'xref_name_projection'],
-  DATACHECK_TYPE => 'advisory',
-  TABLES         => ['coord_system', 'gene', 'seq_region', 'transcript', 'xref'],
+  DATACHECK_TYPE => 'critical',
+  TABLES         => ['coord_system', 'gene', 'seq_region', 'xref'],
 };
 
 sub skip_tests {
@@ -50,18 +50,16 @@ sub tests {
 
   my $species_id = $self->dba->species_id;
 
-  foreach my $type ("gene", "transcript") {
-    my $desc = "${type}s have names set via display_xref_id";
-    my $sql  = qq/
-      SELECT COUNT(*) FROM $type t
-        INNER JOIN seq_region sr USING (seq_region_id) 
-        INNER JOIN coord_system cs USING (coord_system_id)   
-      WHERE cs.species_id = $species_id
-        AND t.display_xref_id IS NOT NULL 
-    /;
+  my $desc = "Genes have names set via display_xref_id";
+  my $sql  = qq/
+    SELECT COUNT(*) FROM gene t
+      INNER JOIN seq_region sr USING (seq_region_id) 
+      INNER JOIN coord_system cs USING (coord_system_id)   
+    WHERE cs.species_id = $species_id
+      AND t.display_xref_id IS NOT NULL 
+  /;
 
-    is_rows_nonzero($self->dba, $sql, $desc);
-  }
+  is_rows_nonzero($self->dba, $sql, $desc);
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsGene.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsGene.pm
@@ -35,28 +35,30 @@ use constant {
   TABLES         => ['coord_system', 'gene', 'seq_region', 'xref'],
 };
 
-sub skip_tests {
-  my ($self) = @_;
-
-  my $mca = $self->dba->get_adaptor('MetaContainer');
-  my $division = $mca->get_division;
-  if ($division ne 'EnsemblVertebrates') {
-    return( 1, "Display xrefs are not typically expected for non-vertebrates" );
-  }
-}
-
 sub tests {
   my ($self) = @_;
 
   my $species_id = $self->dba->species_id;
 
+  # Teams responsible for ensuring display xrefs exist
+  my @responsible_teams = ('Genebuild');
+  my $teams_list = join("', '", @responsible_teams);
+
   my $desc = "Genes have names set via display_xref_id";
+  # Use CASE to return 1 (pass) for teams not responsible for display xrefs,
+  # but actual count for responsible teams
   my $sql  = qq/
-    SELECT COUNT(*) FROM gene t
-      INNER JOIN seq_region sr USING (seq_region_id) 
-      INNER JOIN coord_system cs USING (coord_system_id)   
-    WHERE cs.species_id = $species_id
-      AND t.display_xref_id IS NOT NULL 
+    SELECT CASE
+      WHEN (SELECT meta_value FROM meta WHERE meta_key = 'genebuild.team_responsible') IN ('$teams_list')
+      THEN (
+        SELECT COUNT(*) FROM gene t
+          INNER JOIN seq_region sr USING (seq_region_id)
+          INNER JOIN coord_system cs USING (coord_system_id)
+        WHERE cs.species_id = $species_id
+          AND t.display_xref_id IS NOT NULL
+      )
+      ELSE 1
+    END
   /;
 
   is_rows_nonzero($self->dba, $sql, $desc);

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsGene.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsGene.pm
@@ -48,15 +48,21 @@ sub tests {
   # Use CASE to return 1 (pass) for teams not responsible for display xrefs,
   # but actual count for responsible teams
   my $sql  = qq/
-  SELECT COUNT(*) 
-    FROM gene t
-    JOIN seq_region sr USING (seq_region_id)
-    JOIN coord_system cs USING (coord_system_id)
-    JOIN meta m 
-      ON m.meta_key = 'genebuild.team_responsible'
-    WHERE cs.species_id = $species_id
-      AND t.display_xref_id IS NOT NULL
-      AND m.meta_value IN ('$teams_list')
+    SELECT CASE
+      WHEN EXISTS (
+        SELECT 1 FROM meta
+        WHERE meta_key = 'genebuild.team_responsible'
+          AND meta_value IN ('$teams_list')
+      )
+      THEN (
+        SELECT COUNT(*) FROM gene t
+          JOIN seq_region sr USING (seq_region_id)
+          JOIN coord_system cs USING (coord_system_id)
+        WHERE cs.species_id = $species_id
+          AND t.display_xref_id IS NOT NULL
+      )
+      ELSE 1
+    END
   /;
 
   is_rows_nonzero($self->dba, $sql, $desc);

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsGene.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsGene.pm
@@ -35,38 +35,39 @@ use constant {
   TABLES         => ['coord_system', 'gene', 'seq_region', 'xref'],
 };
 
+sub skip_tests {
+  my ($self) = @_;
+
+  # Teams responsible for ensuring display xrefs exist
+  my @responsible_teams = ('Genebuild');
+
+  my $mca = $self->dba->get_adaptor("MetaContainer");
+  my $teams = $mca->list_value_by_key('genebuild.team_responsible');
+
+  if (!defined $teams) {
+    return (1, 'genebuild.team_responsible not defined, skipping the test');
+  }
+
+  my %lookup = map { $_ => 1 } @$teams;
+  if (!grep { exists $lookup{$_} } @responsible_teams) {
+    return (1, "genebuild.team_responsible does not match responsible teams (" . join(', ', @responsible_teams) . "), skipping the test");
+  }
+
+  return 0;
+}
+
 sub tests {
   my ($self) = @_;
 
   my $species_id = $self->dba->species_id;
 
-  # Teams responsible for ensuring display xrefs exist
-  my @responsible_teams = ('Genebuild');
-  my $teams_list = join("', '", @responsible_teams);
-
   my $desc = "Genes have names set via display_xref_id";
-  # Use CASE to return 1 (pass) for teams not responsible for display xrefs,
-  # but actual count for responsible teams
   my $sql  = qq/
-    SELECT COUNT(*) FROM (
-      SELECT CASE
-        WHEN EXISTS (
-          SELECT 1 FROM meta
-          WHERE meta_key = 'genebuild.team_responsible'
-            AND meta_value IN ('$teams_list')
-            AND (species_id IS NULL OR species_id = $species_id)
-        )
-        THEN (
-          SELECT COUNT(*) FROM gene t
-            JOIN seq_region sr USING (seq_region_id)
-            JOIN coord_system cs USING (coord_system_id)
-          WHERE cs.species_id = $species_id
-            AND t.display_xref_id IS NOT NULL
-        )
-        ELSE 1
-      END AS count_result
-    ) AS subquery
-    WHERE count_result > 0
+    SELECT COUNT(*) FROM gene t
+      INNER JOIN seq_region sr USING (seq_region_id)
+      INNER JOIN coord_system cs USING (coord_system_id)
+    WHERE cs.species_id = $species_id
+      AND t.display_xref_id IS NOT NULL
   /;
 
   is_rows_nonzero($self->dba, $sql, $desc);

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsGene.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsGene.pm
@@ -16,7 +16,7 @@ limitations under the License.
 
 =cut
 
-package Bio::EnsEMBL::DataCheck::Checks::DisplayXrefExists;
+package Bio::EnsEMBL::DataCheck::Checks::DisplayXrefExistsGene;
 
 use warnings;
 use strict;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsTranscript.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsTranscript.pm
@@ -16,7 +16,7 @@ limitations under the License.
 
 =cut
 
-package Bio::EnsEMBL::DataCheck::Checks::DisplayXrefExists;
+package Bio::EnsEMBL::DataCheck::Checks::DisplayXrefExistsTranscript;
 
 use warnings;
 use strict;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsTranscript.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsTranscript.pm
@@ -48,15 +48,21 @@ sub tests {
   # Use CASE to return 1 (pass) for teams not responsible for display xrefs,
   # but actual count for responsible teams
   my $sql  = qq/
-  SELECT COUNT(*) 
-    FROM transcript t
-    JOIN seq_region sr USING (seq_region_id)
-    JOIN coord_system cs USING (coord_system_id)
-    JOIN meta m 
-      ON m.meta_key = 'genebuild.team_responsible'
-    WHERE cs.species_id = $species_id
-      AND t.display_xref_id IS NOT NULL
-      AND m.meta_value IN ('$teams_list')
+    SELECT CASE
+      WHEN EXISTS (
+        SELECT 1 FROM meta
+        WHERE meta_key = 'genebuild.team_responsible'
+          AND meta_value IN ('$teams_list')
+      )
+      THEN (
+        SELECT COUNT(*) FROM transcript t
+          JOIN seq_region sr USING (seq_region_id)
+          JOIN coord_system cs USING (coord_system_id)
+        WHERE cs.species_id = $species_id
+          AND t.display_xref_id IS NOT NULL
+      )
+      ELSE 1
+    END
   /;
 
   is_rows_nonzero($self->dba, $sql, $desc);

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsTranscript.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsTranscript.pm
@@ -35,38 +35,39 @@ use constant {
   TABLES         => ['coord_system', 'seq_region', 'transcript', 'xref'],
 };
 
+sub skip_tests {
+  my ($self) = @_;
+
+  # Teams responsible for ensuring display xrefs exist
+  my @responsible_teams = ('Genebuild');
+
+  my $mca = $self->dba->get_adaptor("MetaContainer");
+  my $teams = $mca->list_value_by_key('genebuild.team_responsible');
+
+  if (!defined $teams) {
+    return (1, 'genebuild.team_responsible not defined, skipping the test');
+  }
+
+  my %lookup = map { $_ => 1 } @$teams;
+  if (!grep { exists $lookup{$_} } @responsible_teams) {
+    return (1, "genebuild.team_responsible does not match responsible teams (" . join(', ', @responsible_teams) . "), skipping the test");
+  }
+
+  return 0;
+}
+
 sub tests {
   my ($self) = @_;
 
   my $species_id = $self->dba->species_id;
 
-  # Teams responsible for ensuring display xrefs exist
-  my @responsible_teams = ('Genebuild');
-  my $teams_list = join("', '", @responsible_teams);
-
   my $desc = "Transcripts have names set via display_xref_id";
-  # Use CASE to return 1 (pass) for teams not responsible for display xrefs,
-  # but actual count for responsible teams
   my $sql  = qq/
-    SELECT COUNT(*) FROM (
-      SELECT CASE
-        WHEN EXISTS (
-          SELECT 1 FROM meta
-          WHERE meta_key = 'genebuild.team_responsible'
-            AND meta_value IN ('$teams_list')
-            AND (species_id IS NULL OR species_id = $species_id)
-        )
-        THEN (
-          SELECT COUNT(*) FROM transcript t
-            JOIN seq_region sr USING (seq_region_id)
-            JOIN coord_system cs USING (coord_system_id)
-          WHERE cs.species_id = $species_id
-            AND t.display_xref_id IS NOT NULL
-        )
-        ELSE 1
-      END AS count_result
-    ) AS subquery
-    WHERE count_result > 0
+    SELECT COUNT(*) FROM transcript t
+      INNER JOIN seq_region sr USING (seq_region_id)
+      INNER JOIN coord_system cs USING (coord_system_id)
+    WHERE cs.species_id = $species_id
+      AND t.display_xref_id IS NOT NULL
   /;
 
   is_rows_nonzero($self->dba, $sql, $desc);

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsTranscript.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsTranscript.pm
@@ -1,0 +1,66 @@
+=head1 LICENSE
+
+Copyright [2018-2024] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::DisplayXrefExists;
+
+use warnings;
+use strict;
+
+use Moose;
+use Test::More;
+use Bio::EnsEMBL::DataCheck::Test::DataCheck;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'DisplayXrefExistsTranscript',
+  DESCRIPTION    => 'At least one transcript name exists',
+  GROUPS         => ['core', 'xref', 'xref_gene_symbol_transformer', 'xref_name_projection'],
+  DATACHECK_TYPE => 'advisory',
+  TABLES         => ['coord_system', 'seq_region', 'transcript', 'xref'],
+};
+
+sub skip_tests {
+  my ($self) = @_;
+
+  my $mca = $self->dba->get_adaptor('MetaContainer');
+  my $division = $mca->get_division;
+  if ($division ne 'EnsemblVertebrates') {
+    return( 1, "Display xrefs are not typically expected for non-vertebrates" );
+  }
+}
+
+sub tests {
+  my ($self) = @_;
+
+  my $species_id = $self->dba->species_id;
+
+  my $desc = "Transcripts have names set via display_xref_id";
+  my $sql  = qq/
+    SELECT COUNT(*) FROM transcript t
+      INNER JOIN seq_region sr USING (seq_region_id) 
+      INNER JOIN coord_system cs USING (coord_system_id)   
+    WHERE cs.species_id = $species_id
+      AND t.display_xref_id IS NOT NULL 
+  /;
+
+  is_rows_nonzero($self->dba, $sql, $desc);
+  
+}
+
+1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsTranscript.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsTranscript.pm
@@ -35,32 +35,34 @@ use constant {
   TABLES         => ['coord_system', 'seq_region', 'transcript', 'xref'],
 };
 
-sub skip_tests {
-  my ($self) = @_;
-
-  my $mca = $self->dba->get_adaptor('MetaContainer');
-  my $division = $mca->get_division;
-  if ($division ne 'EnsemblVertebrates') {
-    return( 1, "Display xrefs are not typically expected for non-vertebrates" );
-  }
-}
-
 sub tests {
   my ($self) = @_;
 
   my $species_id = $self->dba->species_id;
 
+  # Teams responsible for ensuring display xrefs exist
+  my @responsible_teams = ('Genebuild');
+  my $teams_list = join("', '", @responsible_teams);
+
   my $desc = "Transcripts have names set via display_xref_id";
+  # Use CASE to return 1 (pass) for teams not responsible for display xrefs,
+  # but actual count for responsible teams
   my $sql  = qq/
-    SELECT COUNT(*) FROM transcript t
-      INNER JOIN seq_region sr USING (seq_region_id) 
-      INNER JOIN coord_system cs USING (coord_system_id)   
-    WHERE cs.species_id = $species_id
-      AND t.display_xref_id IS NOT NULL 
+    SELECT CASE
+      WHEN (SELECT meta_value FROM meta WHERE meta_key = 'genebuild.team_responsible') IN ('$teams_list')
+      THEN (
+        SELECT COUNT(*) FROM transcript t
+          INNER JOIN seq_region sr USING (seq_region_id)
+          INNER JOIN coord_system cs USING (coord_system_id)
+        WHERE cs.species_id = $species_id
+          AND t.display_xref_id IS NOT NULL
+      )
+      ELSE 1
+    END
   /;
 
   is_rows_nonzero($self->dba, $sql, $desc);
-  
+
 }
 
 1;

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsTranscript.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsTranscript.pm
@@ -48,17 +48,15 @@ sub tests {
   # Use CASE to return 1 (pass) for teams not responsible for display xrefs,
   # but actual count for responsible teams
   my $sql  = qq/
-    SELECT CASE
-      WHEN (SELECT meta_value FROM meta WHERE meta_key = 'genebuild.team_responsible') IN ('$teams_list')
-      THEN (
-        SELECT COUNT(*) FROM transcript t
-          INNER JOIN seq_region sr USING (seq_region_id)
-          INNER JOIN coord_system cs USING (coord_system_id)
-        WHERE cs.species_id = $species_id
-          AND t.display_xref_id IS NOT NULL
-      )
-      ELSE 1
-    END
+  SELECT COUNT(*) 
+    FROM transcript t
+    JOIN seq_region sr USING (seq_region_id)
+    JOIN coord_system cs USING (coord_system_id)
+    JOIN meta m 
+      ON m.meta_key = 'genebuild.team_responsible'
+    WHERE cs.species_id = $species_id
+      AND t.display_xref_id IS NOT NULL
+      AND m.meta_value IN ('$teams_list')
   /;
 
   is_rows_nonzero($self->dba, $sql, $desc);

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsTranscript.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExistsTranscript.pm
@@ -48,21 +48,25 @@ sub tests {
   # Use CASE to return 1 (pass) for teams not responsible for display xrefs,
   # but actual count for responsible teams
   my $sql  = qq/
-    SELECT CASE
-      WHEN EXISTS (
-        SELECT 1 FROM meta
-        WHERE meta_key = 'genebuild.team_responsible'
-          AND meta_value IN ('$teams_list')
-      )
-      THEN (
-        SELECT COUNT(*) FROM transcript t
-          JOIN seq_region sr USING (seq_region_id)
-          JOIN coord_system cs USING (coord_system_id)
-        WHERE cs.species_id = $species_id
-          AND t.display_xref_id IS NOT NULL
-      )
-      ELSE 1
-    END
+    SELECT COUNT(*) FROM (
+      SELECT CASE
+        WHEN EXISTS (
+          SELECT 1 FROM meta
+          WHERE meta_key = 'genebuild.team_responsible'
+            AND meta_value IN ('$teams_list')
+            AND (species_id IS NULL OR species_id = $species_id)
+        )
+        THEN (
+          SELECT COUNT(*) FROM transcript t
+            JOIN seq_region sr USING (seq_region_id)
+            JOIN coord_system cs USING (coord_system_id)
+          WHERE cs.species_id = $species_id
+            AND t.display_xref_id IS NOT NULL
+        )
+        ELSE 1
+      END AS count_result
+    ) AS subquery
+    WHERE count_result > 0
   /;
 
   is_rows_nonzero($self->dba, $sql, $desc);

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1325,7 +1325,7 @@
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DensitySNPs"
    },
    "DisplayXrefExists" : {
-      "datacheck_type" : "critical",
+      "datacheck_type" : "advisory",
       "description" : "At least one gene name exists",
       "groups" : [
          "core",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1325,7 +1325,7 @@
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DensitySNPs"
    },
    "DisplayXrefExists" : {
-      "datacheck_type" : "advisory",
+      "datacheck_type" : "critical",
       "description" : "At least one gene name exists",
       "groups" : [
          "core",

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1324,8 +1324,8 @@
       "name" : "DensitySNPs",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DensitySNPs"
    },
-   "DisplayXrefExists" : {
-      "datacheck_type" : "advisory",
+   "DisplayXrefExistsGene" : {
+      "datacheck_type" : "critical",
       "description" : "At least one gene name exists",
       "groups" : [
          "core",
@@ -1333,8 +1333,20 @@
          "xref_gene_symbol_transformer",
          "xref_name_projection"
       ],
-      "name" : "DisplayXrefExists",
-      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DisplayXrefExists"
+      "name" : "DisplayXrefExistsGene",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DisplayXrefExistsGene"
+   },
+      "DisplayXrefExistsTranscript" : {
+      "datacheck_type" : "advisory",
+      "description" : "At least one transcript name exists",
+      "groups" : [
+         "core",
+         "xref",
+         "xref_gene_symbol_transformer",
+         "xref_name_projection"
+      ],
+      "name" : "DisplayXrefExistsTranscript",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DisplayXrefExistsTranscript"
    },
    "DisplayXrefFormat" : {
       "datacheck_type" : "critical",


### PR DESCRIPTION
We expect all handed over cores from Genebuild pipelines to have gene symbols that come from the gene symbol transformer pipeline. 

I am opening this PR to propose moving this DC from `advisory` to `critical` but we need to ensure that the `skip_tests` is skipping what we wish it to skip. 

[Related Bug ticket](https://embl.atlassian.net/browse/EBD-73)