### PR TITLE
Fix/displayable location for multiple coord systems

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExists.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExists.pm
@@ -31,7 +31,7 @@ use constant {
   NAME           => 'DisplayXrefExists',
   DESCRIPTION    => 'At least one gene name exists',
   GROUPS         => ['core', 'xref', 'xref_gene_symbol_transformer', 'xref_name_projection'],
-  DATACHECK_TYPE => 'advisory',
+  DATACHECK_TYPE => 'critical',
   TABLES         => ['coord_system', 'gene', 'seq_region', 'transcript', 'xref'],
 };
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayableSampleLocation.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayableSampleLocation.pm
@@ -99,15 +99,16 @@ sub tests {
         FROM meta m
         JOIN seq_region sr
           ON SUBSTRING_INDEX(m.meta_value, ':', 1) = sr.name
+        JOIN coord_system cs USING (coord_system_id)
         LEFT JOIN gene g
           ON g.seq_region_id = sr.seq_region_id
-         AND g.seq_region_start <= CAST(SUBSTRING_INDEX(m.meta_value, '-', -1) AS UNSIGNED)
-         AND g.seq_region_end >= CAST(SUBSTRING_INDEX(SUBSTRING_INDEX(m.meta_value, ':', -1), '-', 1) AS UNSIGNED)
-       WHERE m.meta_key = 'genebuild.sample_location'
-         AND m.species_id = $species_id
-         AND g.gene_id IS NULL
+        AND g.seq_region_start <= CAST(SUBSTRING_INDEX(m.meta_value, '-', -1) AS UNSIGNED)
+        AND g.seq_region_end >= CAST(SUBSTRING_INDEX(SUBSTRING_INDEX(m.meta_value, ':', -1), '-', 1) AS UNSIGNED)
+      WHERE m.meta_key = 'genebuild.sample_location'
+        AND m.species_id = $species_id
+        AND cs.rank = 1
+        AND g.gene_id IS NULL
     /;
-
   is_rows_zero($self->dba, $sql_5, $desc_5, $diag_5);
 
 }

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1325,7 +1325,7 @@
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DensitySNPs"
    },
    "DisplayXrefExists" : {
-      "datacheck_type" : "advisory",
+      "datacheck_type" : "critical",
       "description" : "At least one gene name exists",
       "groups" : [
          "core",


### PR DESCRIPTION
Fix DisplayableSampleLocation false positive from multi-assembly seq_regions

The datacheck fails when multiple seq_regions share the same name across different assemblies (e.g., chromosome 4 in GRCm38, GRCm39, patches). The LEFT JOIN creates duplicate rows, and if any non-primary assembly lacks genes in the sample location coordinates, the IS NULL check incorrectly flags a failure.

Added coord_system join with cs.rank = 1 filter to restrict checks to primary assembly only.

Validated fix on mus_musculus_core_114_39 where three chromosome 4 seq_regions exist—only the primary (seq_region_id 125694) contains genes at the sample location coordinates.