### PR TITLE
make display xref to advisory again until proper solution found

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExists.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DisplayXrefExists.pm
@@ -31,7 +31,7 @@ use constant {
   NAME           => 'DisplayXrefExists',
   DESCRIPTION    => 'At least one gene name exists',
   GROUPS         => ['core', 'xref', 'xref_gene_symbol_transformer', 'xref_name_projection'],
-  DATACHECK_TYPE => 'critical',
+  DATACHECK_TYPE => 'advisory',
   TABLES         => ['coord_system', 'gene', 'seq_region', 'transcript', 'xref'],
 };
 

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -1325,7 +1325,7 @@
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::DensitySNPs"
    },
    "DisplayXrefExists" : {
-      "datacheck_type" : "critical",
+      "datacheck_type" : "advisory",
       "description" : "At least one gene name exists",
       "groups" : [
          "core",


### PR DESCRIPTION
Display Xref checks were updated to be critical mistakenly now blocking handover. We wish to revert ahead of a proper fix to xref datachecks 