### PR TITLE
Strengthen species MLSS tag datachecks

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagSynteny.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/MLSSTagSynteny.pm
@@ -70,34 +70,63 @@ sub tests {
 
   cmp_tag($self->dba, 'SYNTENY', 'non_ref_coding_exon_length', '>', 0);
 
+  my $mlss_adap = $self->dba->get_MethodLinkSpeciesSetAdaptor;
 
-  my $mlsses = $self->dba->get_MethodLinkSpeciesSetAdaptor->fetch_all_by_method_link_type('SYNTENY');
+  my $mlsses = $mlss_adap->fetch_all_by_method_link_type('SYNTENY');
   foreach my $mlss (@{$mlsses}) {
 
-    if ($mlss->has_tag('reference_species') && $mlss->has_tag('non_reference_species')) {
-      my $non_ref_sp_name = $mlss->get_value_for_tag('non_reference_species');
-      my $ref_sp_name = $mlss->get_value_for_tag('reference_species');
+    if ($mlss->has_tag('reference_species') || $mlss->has_tag('non_reference_species')) {
 
-      if ($mlss->species_set->size > 1) {
+      if ($mlss->has_tag('pairwise_mlss_id')) {
+        my $pairwise_mlss_id = $mlss->get_value_for_tag('pairwise_mlss_id');
 
-        my $desc_1 = sprintf(
-          "synteny MLSS '%s' (mlss_id:%d) reference-species tag distinctness",
-          $mlss->name,
-          $mlss->dbID,
-        );
+        my $pairwise_mlss = $mlss_adap->fetch_by_dbID($pairwise_mlss_id);
 
-        isnt($non_ref_sp_name, $ref_sp_name, $desc_1);
+        my $desc_3 = sprintf("synteny MLSS '%s' (mlss_id:%d) pairwise_mlss_id referential integrity", $mlss->name, $mlss->dbID);
+        isa_ok($pairwise_mlss, 'Bio::EnsEMBL::Compara::MethodLinkSpeciesSet', $desc_3);
 
-      } else {
+        foreach my $tag ('reference_species', 'non_reference_species') {
+          my $synteny_tag_value = $mlss->get_value_for_tag($tag);
+          my $pairwise_tag_value = $pairwise_mlss->get_value_for_tag($tag);
+          if (defined $synteny_tag_value && $pairwise_tag_value) {
+            my $desc_4 = sprintf(
+              "'%s' tag consistency between synteny MLSS '%s' (mlss_id:%d) and pairwise MLSS '%s' (mlss_id:%d)",
+              $tag,
+              $mlss->name,
+              $mlss->dbID,
+              $pairwise_mlss->name,
+              $pairwise_mlss->dbID,
+            );
 
-        my $desc_2 = sprintf(
-          "synteny MLSS '%s' (mlss_id:%d) reference-species tag identity",
-          $mlss->name,
-          $mlss->dbID,
-        );
+            is($synteny_tag_value, $pairwise_tag_value, $desc_4);
+          }
+        }
+      }
 
-        is($non_ref_sp_name, $ref_sp_name, $desc_2);
+      if ($mlss->has_tag('reference_species') && $mlss->has_tag('non_reference_species')) {
+        my $non_ref_sp_name = $mlss->get_value_for_tag('non_reference_species');
+        my $ref_sp_name = $mlss->get_value_for_tag('reference_species');
 
+        if ($mlss->species_set->size > 1) {
+
+          my $desc_1 = sprintf(
+            "synteny MLSS '%s' (mlss_id:%d) reference-species tag distinctness",
+            $mlss->name,
+            $mlss->dbID,
+          );
+
+          isnt($non_ref_sp_name, $ref_sp_name, $desc_1);
+
+        } else {
+
+          my $desc_2 = sprintf(
+            "synteny MLSS '%s' (mlss_id:%d) reference-species tag identity",
+            $mlss->name,
+            $mlss->dbID,
+          );
+
+          is($non_ref_sp_name, $ref_sp_name, $desc_2);
+        }
       }
     }
   }

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesTagConsistency.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/SpeciesTagConsistency.pm
@@ -1,0 +1,100 @@
+=head1 LICENSE
+
+Copyright [2018-2025] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::DataCheck::Checks::SpeciesTagConsistency;
+
+use warnings;
+use strict;
+
+use Bio::EnsEMBL::ApiVersion qw(software_version);
+
+use Moose;
+use Test::More;
+
+extends 'Bio::EnsEMBL::DataCheck::DbCheck';
+
+use constant {
+  NAME           => 'SpeciesTagConsistency',
+  DESCRIPTION    => 'Consistency of reference and non-reference species tags across releases',
+  GROUPS         => ['compara'],
+  DATACHECK_TYPE => 'advisory',
+  DB_TYPES       => ['compara'],
+  TABLES         => ['method_link', 'method_link_species_set', 'method_link_species_set_tag'],
+  PER_DB         => 1
+};
+
+sub tests {
+  my ($self) = @_;
+  my $prev_dba = $self->get_old_dba;
+
+  my $curr_helper = $self->dba->dbc->sql_helper;
+  my $prev_helper = $prev_dba->dbc->sql_helper;
+
+  my $curr_release = software_version();
+
+  my $rerun_mlss_sql = qq/
+    SELECT method_link_species_set_id
+      FROM method_link_species_set_tag
+    WHERE
+      tag = 'rerun_in_$curr_release';
+  /;
+  my $rerun_mlss_ids = $curr_helper->execute_simple( -SQL => $rerun_mlss_sql );
+  my %rerun_mlss_id_set = map { $_ => 1 } @{$rerun_mlss_ids};
+
+  my $species_tag_sql = q/
+    SELECT method_link_species_set_id, tag, value
+      FROM method_link_species_set_tag
+    WHERE
+      tag IN ('reference_species', 'non_reference_species');
+  /;
+
+  my $prev_results = $prev_helper->execute( -SQL => $species_tag_sql );
+  my %prev_species_tags;
+  foreach my $row (@{$prev_results}) {
+    my ($mlss_id, $tag, $value) = @{$row};
+    $prev_species_tags{$mlss_id}{$tag} = $value;
+  }
+
+  my $curr_results = $curr_helper->execute( -SQL => $species_tag_sql );
+  my %curr_species_tags;
+  foreach my $row (@{$curr_results}) {
+    my ($mlss_id, $tag, $value) = @{$row};
+    $curr_species_tags{$mlss_id}{$tag} = $value;
+  }
+
+  my @reused_mlss_ids = grep { exists $prev_species_tags{$_} && ! exists $rerun_mlss_id_set{$_} } keys %curr_species_tags;
+
+  @reused_mlss_ids = sort { $a <=> $b } @reused_mlss_ids;
+
+  my $mlss_dba = $self->dba->get_MethodLinkSpeciesSetAdaptor();
+  foreach my $mlss_id (@reused_mlss_ids) {
+    my $mlss = $mlss_dba->fetch_by_dbID($mlss_id);
+    my $mlss_name = $mlss->name;
+    foreach my $tag ('reference_species', 'non_reference_species') {
+      if (exists $curr_species_tags{$mlss_id}{$tag} && exists $prev_species_tags{$mlss_id}{$tag}) {
+        my $prev_tag_value = $prev_species_tags{$mlss_id}{$tag};
+        my $curr_tag_value = $curr_species_tags{$mlss_id}{$tag};
+        my $desc_1 = sprintf("MLSS '%s' (mlss_id:%d) '%s' tag consistency", $mlss->name, $mlss_id, $tag);
+        is($curr_tag_value, $prev_tag_value, $desc_1);
+      }
+    }
+  }
+}
+
+1;
+

--- a/lib/Bio/EnsEMBL/DataCheck/index.json
+++ b/lib/Bio/EnsEMBL/DataCheck/index.json
@@ -2548,6 +2548,15 @@
       "name" : "SpeciesStrainGroup",
       "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SpeciesStrainGroup"
    },
+   "SpeciesTagConsistency" : {
+      "datacheck_type" : "advisory",
+      "description" : "Consistency of reference and non-reference species tags across releases",
+      "groups" : [
+         "compara"
+      ],
+      "name" : "SpeciesTagConsistency",
+      "package_name" : "Bio::EnsEMBL::DataCheck::Checks::SpeciesTagConsistency"
+   },
    "SpeciesTaxonomy" : {
       "datacheck_type" : "critical",
       "description" : "Taxonomic meta keys are consistent with taxonomy database",


### PR DESCRIPTION
This PR would:
- update `MLSSTagSynteny` to check that each synteny MLSS has `reference_species` and `non_reference_species` tags consistent with its corresponding pairwise alignment; and
- add a `SpeciesTagConsistency` advisory datacheck to flag MLSSes for which a `reference_species` or `non_reference_species` tag has changed relative to the previous release.

Both datachecks have already been used to identify synteny datasets with discrepant `reference_species` and `non_reference_species` tags in `ensembl_compara_116` and `ensembl_compara_plants_63_116` (`ENSCOMPARASW-9084`), and would help catch such discrepant tags in future.
