### PR TITLE
Skip ControlledTables and DNAFragCore for InterPro family genomes

### DIFF
--- a/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/ControlledTablesCompara.pm
@@ -84,7 +84,54 @@ sub master_tables {
       if ($populated) {
         # Check that the table is a subset of the master database, and record the dbIDs
         my $id_column = $table eq 'species_set_header' ? 'species_set_id' : "${table}_id";
-        $ids{$table} = $self->consistent_data($helper, $master_helper, $table, [$id_column])
+
+        my $ipr_fam_gdb_query;
+        if ($table eq 'genome_db') {
+
+          $ipr_fam_gdb_query = qq/
+            SELECT
+              $id_column
+            FROM
+              method_link_species_set
+            JOIN
+              method_link USING (method_link_id)
+            JOIN
+              species_set USING (species_set_id)
+            JOIN
+              genome_db USING (genome_db_id)
+            GROUP BY
+              genome_db_id
+            HAVING
+              GROUP_CONCAT(method_link.type) = 'FAMILY';
+          /;
+
+        } elsif ($table eq 'method_link'
+                 || $table eq 'method_link_species_set'
+                 || $table eq 'species_set_header') {
+
+          $ipr_fam_gdb_query = qq/
+            SELECT
+              $id_column
+            FROM
+              method_link_species_set
+            JOIN
+              method_link USING (method_link_id)
+            JOIN
+              species_set_header USING (species_set_id)
+            WHERE
+              method_link.type = 'FAMILY';
+          /;
+        }
+
+        my $table_sql_filter;
+        if ($ipr_fam_gdb_query) {
+          my $ipr_fam_gdb_ids = $helper->execute_simple($ipr_fam_gdb_query);
+          if (scalar(@$ipr_fam_gdb_ids) > 0) {
+            $table_sql_filter = sprintf("WHERE $id_column NOT IN (%s)", join(',', @$ipr_fam_gdb_ids));
+          }
+        }
+
+        $ids{$table} = $self->consistent_data($helper, $master_helper, $table, [$id_column], $table_sql_filter);
       }
     }
 

--- a/lib/Bio/EnsEMBL/DataCheck/Checks/DNAFragCore.pm
+++ b/lib/Bio/EnsEMBL/DataCheck/Checks/DNAFragCore.pm
@@ -50,6 +50,27 @@ sub tests {
   my $desc = "Current genome_dbs exist";
   ok(scalar(@$genome_dbs), $desc);
 
+  my $ipr_fam_gdb_query = q/
+    SELECT
+      genome_db_id
+    FROM
+      method_link_species_set
+    JOIN
+      method_link USING (method_link_id)
+    JOIN
+      species_set USING (species_set_id)
+    JOIN
+      genome_db USING (genome_db_id)
+    GROUP BY
+      genome_db_id
+    HAVING
+      GROUP_CONCAT(method_link.type) = 'FAMILY';
+  /;
+
+  my $ipr_fam_gdb_ids = $self->dba->dbc->sql_helper->execute_simple($ipr_fam_gdb_query);
+  my %ipr_fam_gdb_id_set = map { $_ => 1 } @{$ipr_fam_gdb_ids};
+  @$genome_dbs = grep { !exists($ipr_fam_gdb_id_set{$_->dbID}) } @$genome_dbs;
+
   foreach my $genome_db (sort { $a->name cmp $b->name } @$genome_dbs) {
     my $gdb_name = $genome_db->name;
 


### PR DESCRIPTION
This draft pull request would:
- update datacheck `ControlledTablesCompara` to ignore genomes processed only in the InterPro family pipeline when checking the `genome_db`, `method_link`, `method_link_species_set` and `species_set_header` tables against the Compara master database;
- update datacheck `DNAFragCore` to ignore InterPro-family-only genomes when checking the consistency of the `dnafrag` table with core `seq_region` data.

These changes would eliminate a potential source of false alarms in Compara core-sync datachecks, which would make it easier to identify any issues that may occur.
